### PR TITLE
Enable Material options using maps

### DIFF
--- a/examples/bullet/pid_control.cpp
+++ b/examples/bullet/pid_control.cpp
@@ -1,6 +1,6 @@
 
-#include "threepp/extras/physics/BulletPhysics.hpp"
 #include "threepp/extras/imgui/imgui_context.hpp"
+#include "threepp/extras/physics/BulletPhysics.hpp"
 #include "threepp/threepp.hpp"
 
 #include "utility/PID.hpp"
@@ -35,8 +35,7 @@ std::shared_ptr<Mesh> createObject() {
     auto boxGeometry = BoxGeometry::create(0.1, 1, 0.1);
     boxGeometry->translate(0, boxGeometry->height / 2, 0);
 
-    auto material = MeshBasicMaterial::create();
-    material->color = 0x000000;
+    auto material = MeshBasicMaterial::create({{"color", 0x000000}});
 
     auto cylinder = Mesh::create(cylinderGeometry, material);
     auto box = Mesh::create(boxGeometry, material);

--- a/examples/geometries/box_geometry.cpp
+++ b/examples/geometries/box_geometry.cpp
@@ -5,12 +5,12 @@ using namespace threepp;
 
 namespace {
 
-    std::shared_ptr<LineSegments> createWireframe(const BufferGeometry& geometry) {
+    auto createWireframe(const BufferGeometry& geometry) {
 
-        auto line = LineSegments::create(WireframeGeometry::create(geometry));
-        line->material()->as<LineBasicMaterial>()->alphaTest = false;
-        line->material()->as<LineBasicMaterial>()->color = Color::black;
-        return line;
+        auto material = LineBasicMaterial::create({
+                {"color", Color::black}
+        });
+        return LineSegments::create(WireframeGeometry::create(geometry), material);
     }
 
     void updateGroupGeometry(Mesh& mesh, const BoxGeometry::Params& params) {
@@ -23,7 +23,7 @@ namespace {
     }
 
 
-    std::shared_ptr<Mesh> createMesh(const BoxGeometry::Params& params) {
+    auto createMesh(const BoxGeometry::Params& params) {
 
         auto geometry = BoxGeometry::create(params);
         auto material = MeshBasicMaterial::create();

--- a/examples/geometries/convex_geometry.cpp
+++ b/examples/geometries/convex_geometry.cpp
@@ -67,8 +67,7 @@ int main() {
         }
     }
 
-    auto points = Points::create(pointsGeometry);
-    points->material()->as<PointsMaterial>()->vertexColors = true;
+    auto points = Points::create(pointsGeometry, PointsMaterial::create({{"vertexColors", true}}));
     convex->add(points);
 
     auto lineMaterial = LineBasicMaterial::create();

--- a/examples/geometries/cylinder_geometry.cpp
+++ b/examples/geometries/cylinder_geometry.cpp
@@ -24,8 +24,7 @@ namespace {
     std::shared_ptr<Mesh> createMesh(const CylinderGeometry::Params& params) {
 
         auto geometry = CylinderGeometry::create(params);
-        auto material = MeshBasicMaterial::create();
-        material->side = DoubleSide;
+        auto material = MeshBasicMaterial::create({{"side", DoubleSide}});
 
         auto mesh = Mesh::create(geometry, material);
         mesh->add(createWireframe(*geometry));

--- a/examples/geometries/lathe_geometry.cpp
+++ b/examples/geometries/lathe_geometry.cpp
@@ -16,12 +16,10 @@ namespace {
 
     std::shared_ptr<Mesh> createLathe() {
         auto geometry = LatheGeometry::create(generateLathePoints());
-        auto material = MeshNormalMaterial::create();
-        material->side = DoubleSide;
+        auto material = MeshNormalMaterial::create({{"side", DoubleSide}});
         auto mesh = Mesh::create(geometry, material);
 
         auto line = LineSegments::create(WireframeGeometry::create(*geometry));
-        line->material()->as<LineBasicMaterial>()->alphaTest = false;
         mesh->add(line);
 
         return mesh;
@@ -34,7 +32,6 @@ namespace {
         auto mesh = Mesh::create(geometry, material);
 
         auto line = LineSegments::create(WireframeGeometry::create(*geometry));
-        line->material()->as<LineBasicMaterial>()->alphaTest = false;
         mesh->add(line);
 
         return mesh;

--- a/examples/geometries/plane_geometry.cpp
+++ b/examples/geometries/plane_geometry.cpp
@@ -5,12 +5,10 @@ using namespace threepp;
 
 namespace {
 
-    std::shared_ptr<LineSegments> createWireframe(const BufferGeometry& geometry) {
+    auto createWireframe(const BufferGeometry& geometry) {
 
-        auto line = LineSegments::create(WireframeGeometry::create(geometry));
-        line->material()->as<LineBasicMaterial>()->alphaTest = false;
-        line->material()->as<LineBasicMaterial>()->color = Color::black;
-        return line;
+        auto material = LineBasicMaterial::create({{"color", Color::black}});
+        return LineSegments::create(WireframeGeometry::create(geometry), material);
     }
 
     void updateGroupGeometry(Mesh& mesh, const PlaneGeometry::Params& params) {
@@ -22,8 +20,7 @@ namespace {
         mesh.add(createWireframe(*g));
     }
 
-
-    std::shared_ptr<Mesh> createMesh(const PlaneGeometry::Params& params) {
+    auto createMesh(const PlaneGeometry::Params& params) {
 
         auto geometry = PlaneGeometry::create(params);
         auto material = MeshBasicMaterial::create();

--- a/examples/geometries/shape_geometry.cpp
+++ b/examples/geometries/shape_geometry.cpp
@@ -28,9 +28,7 @@ int main() {
 
     auto geometry = ShapeGeometry::create(heartShape);
     geometry->center();
-    auto material = MeshBasicMaterial::create();
-    material->color = 0x00ff00;
-    material->side = DoubleSide;
+    auto material = MeshBasicMaterial::create({{"color", 0x00ff00}, {"side", DoubleSide}});
     auto mesh = Mesh::create(geometry, material);
     scene->add(mesh);
 

--- a/examples/geometries/sphere_geometry.cpp
+++ b/examples/geometries/sphere_geometry.cpp
@@ -24,8 +24,7 @@ namespace {
     std::shared_ptr<Mesh> createMesh(const SphereGeometry::Params& params) {
 
         auto geometry = SphereGeometry::create(params);
-        auto material = MeshBasicMaterial::create();
-        material->side = DoubleSide;
+        auto material = MeshBasicMaterial::create({{"side", DoubleSide}});
 
         auto mesh = Mesh::create(geometry, material);
         mesh->add(createWireframe(*geometry));

--- a/examples/geometries/tube_geometry.cpp
+++ b/examples/geometries/tube_geometry.cpp
@@ -7,13 +7,13 @@ using namespace threepp;
 
 namespace {
 
-    struct CustomSineCurve : public Curve3 {
+    struct CustomSineCurve: public Curve3 {
 
         float scale;
 
-        explicit CustomSineCurve(float scale) : scale(scale) {}
+        explicit CustomSineCurve(float scale): scale(scale) {}
 
-        void getPoint(float t, Vector3 &target) override {
+        void getPoint(float t, Vector3& target) override {
             float tx = t * 3 - 1.5f;
             float ty = std::sin(math::PI * 2 * t);
             float tz = 0;
@@ -38,16 +38,15 @@ int main() {
     auto curve = std::make_shared<CustomSineCurve>(10.f);
 
     const auto geometry = TubeGeometry::create(curve);
-    const auto material = MeshBasicMaterial::create();
-    material->color.setHex(0xff0000);
-    material->side = DoubleSide;
+    const auto material = MeshBasicMaterial::create({{"color", 0xff0000},
+                                                     {"side", DoubleSide}});
     auto mesh = Mesh::create(geometry, material);
     scene->add(mesh);
 
-    auto line = LineSegments::create(WireframeGeometry::create(*geometry));
-    line->material()->as<LineBasicMaterial>()->depthTest = false;
-    line->material()->as<LineBasicMaterial>()->opacity = 0.5;
-    line->material()->as<LineBasicMaterial>()->transparent = true;
+    auto lineMaterial = LineBasicMaterial::create({{"depthTest", false},
+                                                   {"opacity", 0.5f},
+                                                   {"transparent", true}});
+    auto line = LineSegments::create(WireframeGeometry::create(*geometry), lineMaterial);
     mesh->add(line);
 
     canvas.onWindowResize([&](WindowSize size) {
@@ -57,7 +56,6 @@ int main() {
     });
 
     canvas.animate([&](float dt) {
-
         mesh->rotation.y += 1 * dt;
 
         renderer.render(scene, camera);

--- a/examples/helpers/camera_helper.cpp
+++ b/examples/helpers/camera_helper.cpp
@@ -21,7 +21,7 @@ int main() {
     sphereMesh->position.z = -8;
     scene->add(sphereMesh);
 
-    auto sphereMaterialWireframe = MeshBasicMaterial::create();
+    auto sphereMaterialWireframe = MeshBasicMaterial::create({{"color", Color::black}, {"wireframe", true}});
     sphereMaterialWireframe->wireframe = true;
     sphereMaterialWireframe->color = Color::black;
     auto sphereMeshWireframe = Mesh::create(sphereGeometry, sphereMaterialWireframe);

--- a/examples/lights/hemi_light.cpp
+++ b/examples/lights/hemi_light.cpp
@@ -21,8 +21,7 @@ int main() {
 
     {
         const auto boxGeometry = BoxGeometry::create();
-        const auto boxMaterial = MeshPhongMaterial::create();
-        boxMaterial->color.setHex(0xff0000);
+        const auto boxMaterial = MeshPhongMaterial::create({{"color", 0xff0000}});
         auto box = Mesh::create(boxGeometry, boxMaterial);
         box->position.x = -1;
         group->add(box);
@@ -30,8 +29,7 @@ int main() {
 
     {
         const auto boxGeometry = BoxGeometry::create();
-        const auto boxMaterial = MeshPhongMaterial::create();
-        boxMaterial->color.setHex(0x00ff00);
+        const auto boxMaterial = MeshPhongMaterial::create({{"color", 0x00ff00}});
         auto box = Mesh::create(boxGeometry, boxMaterial);
         box->position.x = 1;
         group->add(box);
@@ -40,9 +38,7 @@ int main() {
     scene->add(group);
 
     const auto planeGeometry = PlaneGeometry::create(5, 5);
-    const auto planeMaterial = MeshPhongMaterial::create();
-    planeMaterial->color.setHex(Color::gray);
-    planeMaterial->side = DoubleSide;
+    const auto planeMaterial = MeshPhongMaterial::create({{"color", Color::gray}, {"side", DoubleSide}});
     auto plane = Mesh::create(planeGeometry, planeMaterial);
     plane->position.y = -1;
     plane->rotateX(math::degToRad(90));

--- a/examples/lights/spot_light.cpp
+++ b/examples/lights/spot_light.cpp
@@ -48,9 +48,7 @@ int main() {
     scene->add(mesh);
 
     const auto planeGeometry = PlaneGeometry::create(150, 150);
-    const auto planeMaterial = MeshPhongMaterial::create();
-    planeMaterial->color.setHex(Color::gray);
-    planeMaterial->side = DoubleSide;
+    const auto planeMaterial = MeshPhongMaterial::create({{"color", Color::gray}, {"side", DoubleSide}});
     auto plane = Mesh::create(planeGeometry, planeMaterial);
     plane->position.setY(-1);
     plane->rotateX(math::degToRad(-90));

--- a/examples/materials/meshlambert.cpp
+++ b/examples/materials/meshlambert.cpp
@@ -14,14 +14,14 @@ int main() {
 
     OrbitControls controls{camera, canvas};
 
-    auto light = AmbientLight::create(Color(0xffffff).multiplyScalar(0.5f));
+    auto light = HemisphereLight::create();
     scene->add(light);
 
     auto group = Group::create();
 
     {
         const auto boxGeometry = BoxGeometry::create();
-        const auto boxMaterial = MeshLambertMaterial::create();
+        const auto boxMaterial = MeshLambertMaterial::create({{"color", Color::red}});
         boxMaterial->color.setHex(0xff0000);
         auto box = Mesh::create(boxGeometry, boxMaterial);
         box->position.x = -1;
@@ -30,8 +30,7 @@ int main() {
 
     {
         const auto boxGeometry = BoxGeometry::create();
-        const auto boxMaterial = MeshLambertMaterial::create();
-        boxMaterial->color.setHex(0x00ff00);
+        const auto boxMaterial = MeshLambertMaterial::create({{"color", Color::green}});
         auto box = Mesh::create(boxGeometry, boxMaterial);
         box->position.x = 1;
         group->add(box);

--- a/examples/materials/meshphong.cpp
+++ b/examples/materials/meshphong.cpp
@@ -14,14 +14,14 @@ int main() {
 
     OrbitControls controls{camera, canvas};
 
-    auto light = AmbientLight::create(Color(0xffffff).multiplyScalar(0.5f));
+    auto light = HemisphereLight::create();
     scene->add(light);
 
     auto group = Group::create();
 
     {
         const auto boxGeometry = BoxGeometry::create();
-        const auto boxMaterial = MeshPhongMaterial::create();
+        const auto boxMaterial = MeshPhongMaterial::create({{"color", Color::red}});
         boxMaterial->color.setHex(0xff0000);
         auto box = Mesh::create(boxGeometry, boxMaterial);
         box->position.x = -1;
@@ -30,14 +30,18 @@ int main() {
 
     {
         const auto boxGeometry = BoxGeometry::create();
-        const auto boxMaterial = MeshPhongMaterial::create();
-        boxMaterial->color.setHex(0x00ff00);
+        const auto boxMaterial = MeshPhongMaterial::create({{"color", Color::green}});
         auto box = Mesh::create(boxGeometry, boxMaterial);
         box->position.x = 1;
         group->add(box);
     }
 
     scene->add(group);
+
+    auto group2 = group->clone(true);
+    group2->position.z = -2;
+    group2->rotateY(math::degToRad(180));
+    group->add(group2);
 
     canvas.onWindowResize([&](WindowSize size) {
         camera->aspect = size.getAspect();

--- a/examples/objects/decal.cpp
+++ b/examples/objects/decal.cpp
@@ -30,12 +30,12 @@ namespace {
         return decalMaterial;
     }
 
-    class MyMouseListener : public MouseListener {
+    class MyMouseListener: public MouseListener {
 
     public:
         Vector2 mouse{-Infinity<float>, -Infinity<float>};
 
-        explicit MyMouseListener(Canvas &canvas) : canvas(canvas) {}
+        explicit MyMouseListener(Canvas& canvas): canvas(canvas) {}
 
         bool mouseClick() {
             if (mouseDown) {
@@ -46,22 +46,22 @@ namespace {
             }
         }
 
-        void onMouseDown(int button, const Vector2 &pos) override {
-            if (button == 0) { // left mousebutton
+        void onMouseDown(int button, const Vector2& pos) override {
+            if (button == 0) {// left mousebutton
                 mouseDown = true;
             }
         }
 
-        void onMouseMove(const Vector2 &pos) override {
+        void onMouseMove(const Vector2& pos) override {
             updateMousePos(pos);
         }
 
     private:
-        Canvas &canvas;
+        Canvas& canvas;
         bool mouseDown = false;
 
         void updateMousePos(Vector2 pos) {
-            auto &size = canvas.getSize();
+            auto& size = canvas.getSize();
             mouse.x = (pos.x / static_cast<float>(size.width)) * 2 - 1;
             mouse.y = -(pos.y / static_cast<float>(size.height)) * 2 + 1;
         }
@@ -75,11 +75,11 @@ namespace {
         bool clear = false;
         bool mouseHover = false;
 
-        explicit MyGui(const Canvas &canvas) : imgui_context(canvas.window_ptr()) {}
+        explicit MyGui(const Canvas& canvas): imgui_context(canvas.window_ptr()) {}
 
         void onRender() override {
 
-            ImGui::SetNextWindowPos({0, 0}, 0, {0,0});
+            ImGui::SetNextWindowPos({0, 0}, 0, {0, 0});
             ImGui::SetNextWindowSize({100, 0}, 0);
 
             ImGui::Begin("Options");
@@ -88,7 +88,6 @@ namespace {
             mouseHover = ImGui::IsWindowHovered();
 
             ImGui::End();
-
         }
     };
 #endif
@@ -107,18 +106,19 @@ int main() {
 
     OrbitControls controls{camera, canvas};
 
-    TextureLoader texLoader;
+    TextureLoader tl;
     AssimpLoader loader;
     std::filesystem::path folder = "data/models/gltf/LeePerrySmith";
     auto model = loader.load(folder / "LeePerrySmith.glb");
     Mesh* mesh = nullptr;
-    model->traverseType<Mesh>([&](Mesh& _){
+    model->traverseType<Mesh>([&](Mesh& _) {
         mesh = &_;
-        auto mat = MeshPhongMaterial::create();
-        mat->map = texLoader.load(folder / "Map-COL.jpg", false);
-        mat->specularMap = texLoader.load(folder / "Map-SPEC.jpg", false);
-        mat->normalMap = texLoader.load(folder / "Infinite-Level_02_Tangent_SmoothUV.jpg", false);
-        mat->shininess = 25;
+        auto mat = MeshPhongMaterial::create({{
+                {"map", tl.load(folder / "Map-COL.jpg", false)},
+                {"specularMap", tl.load(folder / "Map-SPEC.jpg", false)},
+                {"normalMap", tl.load(folder / "Infinite-Level_02_Tangent_SmoothUV.jpg", false)},
+                {"shininess", 25.f},
+        }});
         mesh->setMaterial(mat);
     });
     scene->add(model);
@@ -168,7 +168,7 @@ int main() {
 
         if (!intersects.empty()) {
 
-            auto &i = intersects.front();
+            auto& i = intersects.front();
             Vector3 n = i.face->normal;
 
             mouseHelper.setPosition(i.point);
@@ -209,6 +209,5 @@ int main() {
         ui.render();
 
 #endif
-
     });
 }

--- a/examples/objects/lod.cpp
+++ b/examples/objects/lod.cpp
@@ -15,13 +15,11 @@ int main() {
 
     OrbitControls controls{camera, canvas};
 
-    auto material = MeshBasicMaterial::create();
-    material->wireframe = true;
-
     auto lod = LOD::create();
     scene->add(lod);
 
     float radius = 0.5;
+    auto material = MeshBasicMaterial::create({{"wireframe", true}});
     for (int z = 0; z <= 5; z++) {
         int detail = 6-z;
         auto obj = Mesh::create(IcosahedronGeometry::create(radius, detail), material);

--- a/examples/texture2d.cpp
+++ b/examples/texture2d.cpp
@@ -37,8 +37,7 @@ int main() {
     scene->add(box);
 
     const auto planeGeometry = PlaneGeometry::create(5, 5);
-    const auto planeMaterial = MeshBasicMaterial::create();
-    planeMaterial->side = DoubleSide;
+    const auto planeMaterial = MeshBasicMaterial::create({{"side", DoubleSide}});
     planeMaterial->map = loader.load("data/textures/brick_bump.jpg");
     auto plane = Mesh::create(planeGeometry, planeMaterial);
     plane->position.setZ(-1);

--- a/examples/texture2d.cpp
+++ b/examples/texture2d.cpp
@@ -16,11 +16,10 @@ int main() {
 
     OrbitControls controls{camera, canvas};
 
-    TextureLoader loader{};
+    TextureLoader loader;
 
     const auto sphereGeometry = SphereGeometry::create(0.5f, 16, 16);
-    const auto sphereMaterial = MeshBasicMaterial::create();
-    sphereMaterial->map = loader.load("data/textures/checker.png");
+    const auto sphereMaterial = MeshBasicMaterial::create({{"map", loader.load("data/textures/checker.png")}});
     auto sphere = Mesh::create(sphereGeometry, sphereMaterial);
     sphere->position.setX(1);
     scene->add(sphere);
@@ -37,8 +36,8 @@ int main() {
     scene->add(box);
 
     const auto planeGeometry = PlaneGeometry::create(5, 5);
-    const auto planeMaterial = MeshBasicMaterial::create({{"side", DoubleSide}});
-    planeMaterial->map = loader.load("data/textures/brick_bump.jpg");
+    const auto planeMaterial = MeshBasicMaterial::create({{"side", DoubleSide},
+                                                          {"map", loader.load("data/textures/brick_bump.jpg")}});
     auto plane = Mesh::create(planeGeometry, planeMaterial);
     plane->position.setZ(-1);
     scene->add(plane);

--- a/include/threepp/materials/LineBasicMaterial.hpp
+++ b/include/threepp/materials/LineBasicMaterial.hpp
@@ -12,31 +12,16 @@ namespace threepp {
                              public MaterialWithLineWidth {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "LineBasicMaterial";
-        }
+        std::shared_ptr<Material> clone() const override;
 
-        std::shared_ptr<Material> clone() const override {
-            auto m = create();
-            copyInto(m.get());
-
-            m->color.copy(color);
-
-            m->linewidth = linewidth;
-
-            return m;
-        }
-
-        static std::shared_ptr<LineBasicMaterial> create() {
-
-            return std::shared_ptr<LineBasicMaterial>(new LineBasicMaterial());
-        }
+        static std::shared_ptr<LineBasicMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        LineBasicMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithLineWidth(1) {}
+        LineBasicMaterial();
+
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/Material.hpp
+++ b/include/threepp/materials/Material.hpp
@@ -6,12 +6,14 @@
 #include "threepp/constants.hpp"
 #include "threepp/core/EventDispatcher.hpp"
 #include "threepp/core/Uniform.hpp"
-#include "threepp/math/MathUtils.hpp"
 #include "threepp/math/Plane.hpp"
 
 #include <optional>
+#include <variant>
 
 namespace threepp {
+
+    typedef std::variant<bool, int, float, Color, std::string> MaterialValue;
 
     class Material: public EventDispatcher, public std::enable_shared_from_this<Material> {
 
@@ -49,7 +51,7 @@ namespace threepp {
         int stencilZPass = KeepStencilOp;
         bool stencilWrite = false;
 
-        std::vector<Plane> clippingPlanes{};
+        std::vector<Plane> clippingPlanes;
         bool clipIntersection = false;
         bool clipShadows = false;
         bool clipping = false;
@@ -78,27 +80,19 @@ namespace threepp {
 
         Material(const Material&) = delete;
 
-        std::string uuid() const {
+        std::string uuid() const;
 
-            return uuid_;
-        }
+        void setValues(const std::unordered_map<std::string, MaterialValue>& values);
 
-        void dispose() {
-            if (!disposed_) {
-                disposed_ = true;
-                dispatchEvent("dispose", this);
-            }
-        }
+        void dispose();
 
-        void needsUpdate() {
-
-            this->version++;
-        }
+        void needsUpdate();
 
         [[nodiscard]] virtual std::string type() const = 0;
 
         template<class T>
         std::shared_ptr<T> as() {
+
             auto m = shared_from_this();
             return std::dynamic_pointer_cast<T>(m);
         }
@@ -111,86 +105,18 @@ namespace threepp {
 
         virtual std::shared_ptr<Material> clone() const { return nullptr; };
 
-        ~Material() override {
-            dispose();
-        }
+        ~Material() override;
 
     protected:
-        Material() = default;
+        Material();
 
-        void copyInto(Material* m) const {
+        void copyInto(Material* m) const;
 
-            m->name = name;
-
-            m->fog = fog;
-
-            m->blending = blending;
-            m->side = side;
-            m->vertexColors = vertexColors;
-
-            m->opacity = opacity;
-            m->transparent = transparent;
-
-            m->blendSrc = blendSrc;
-            m->blendDst = blendDst;
-            m->blendEquation = blendEquation;
-            m->blendSrcAlpha = blendSrcAlpha;
-            m->blendDstAlpha = blendDstAlpha;
-            m->blendEquationAlpha = blendEquationAlpha;
-
-            m->depthFunc = depthFunc;
-            m->depthTest = depthTest;
-            m->depthWrite = depthWrite;
-
-            m->stencilWriteMask = stencilWriteMask;
-            m->stencilFunc = stencilFunc;
-            m->stencilRef = stencilRef;
-            m->stencilFuncMask = stencilFuncMask;
-            m->stencilFail = stencilFail;
-            m->stencilZFail = stencilZFail;
-            m->stencilZPass = stencilZPass;
-            m->stencilWrite = stencilWrite;
-
-            const auto& srcPlanes = clippingPlanes;
-            std::vector<Plane> dstPlanes;
-
-            if (!srcPlanes.empty()) {
-
-                auto n = srcPlanes.size();
-                dstPlanes.resize(n);
-
-                for (unsigned i = 0; i != n; ++i) {
-
-                    dstPlanes[i] = srcPlanes[i];
-                }
-            }
-
-            m->clippingPlanes = dstPlanes;
-            m->clipIntersection = clipIntersection;
-            m->clipShadows = clipShadows;
-
-            m->shadowSide = shadowSide;
-
-            m->colorWrite = colorWrite;
-
-            m->polygonOffset = polygonOffset;
-            m->polygonOffsetFactor = polygonOffsetFactor;
-            m->polygonOffsetUnits = polygonOffsetUnits;
-
-            m->dithering = dithering;
-
-            m->alphaTest = alphaTest;
-            m->alphaToCoverage = alphaToCoverage;
-            m->premultipliedAlpha = premultipliedAlpha;
-
-            m->visible = visible;
-
-            m->toneMapped = toneMapped;
-        }
+        virtual bool setValue(const std::string& key, const MaterialValue& value);
 
     private:
         bool disposed_ = false;
-        std::string uuid_ = math::generateUUID();
+        std::string uuid_;
         inline static unsigned int materialId = 0;
     };
 

--- a/include/threepp/materials/Material.hpp
+++ b/include/threepp/materials/Material.hpp
@@ -13,7 +13,7 @@
 
 namespace threepp {
 
-    typedef std::variant<bool, int, float, Color, std::string> MaterialValue;
+    typedef std::variant<bool, int, float, Color, std::string, std::shared_ptr<Texture>> MaterialValue;
 
     class Material: public EventDispatcher, public std::enable_shared_from_this<Material> {
 

--- a/include/threepp/materials/MeshBasicMaterial.hpp
+++ b/include/threepp/materials/MeshBasicMaterial.hpp
@@ -27,53 +27,16 @@ namespace threepp {
           public MaterialWithCombine {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "MeshBasicMaterial";
-        }
+        std::shared_ptr<Material> clone() const override;
 
-        std::shared_ptr<Material> clone() const override {
-            auto m = create();
-            copyInto(m.get());
-
-            m->color.copy(color);
-
-            m->map = map;
-
-            m->lightMap = lightMap;
-            m->lightMapIntensity = lightMapIntensity;
-
-            m->aoMap = aoMap;
-            m->aoMapIntensity = aoMapIntensity;
-
-            m->specularMap = specularMap;
-
-            m->alphaMap = alphaMap;
-
-            m->envMap = envMap;
-            m->combine = combine;
-            m->reflectivity = reflectivity;
-            m->refractionRatio = refractionRatio;
-
-            m->wireframe = wireframe;
-            m->wireframeLinewidth = wireframeLinewidth;
-
-            return m;
-        }
-
-        static std::shared_ptr<MeshBasicMaterial> create() {
-
-            return std::shared_ptr<MeshBasicMaterial>(new MeshBasicMaterial());
-        }
+        static std::shared_ptr<MeshBasicMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        MeshBasicMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithAoMap(1),
-              MaterialWithLightMap(1),
-              MaterialWithCombine(MultiplyOperation),
-              MaterialWithReflectivity(1, 0.98f),
-              MaterialWithWireframe(false, 1) {}
+        MeshBasicMaterial();
+
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/MeshLambertMaterial.hpp
+++ b/include/threepp/materials/MeshLambertMaterial.hpp
@@ -23,58 +23,16 @@ namespace threepp {
           public MaterialWithCombine {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "MeshLambertMaterial";
-        }
+        [[nodiscard]] std::shared_ptr<Material> clone() const override;
 
-        [[nodiscard]] std::shared_ptr<Material> clone() const override {
-            auto m = create();
-            copyInto(m.get());
-
-            m->color.copy(color);
-
-            m->map = map;
-
-            m->lightMap = lightMap;
-            m->lightMapIntensity = lightMapIntensity;
-
-            m->aoMap = aoMap;
-            m->aoMapIntensity = aoMapIntensity;
-
-            m->emissive.copy(emissive);
-            m->emissiveMap = emissiveMap;
-            m->emissiveIntensity = emissiveIntensity;
-
-            m->specularMap = specularMap;
-
-            m->alphaMap = alphaMap;
-
-            m->envMap = envMap;
-            m->combine = combine;
-            m->reflectivity = reflectivity;
-            m->refractionRatio = refractionRatio;
-
-            m->wireframe = wireframe;
-            m->wireframeLinewidth = wireframeLinewidth;
-
-            return m;
-        }
-
-        static std::shared_ptr<MeshLambertMaterial> create() {
-
-            return std::shared_ptr<MeshLambertMaterial>(new MeshLambertMaterial());
-        }
+        static std::shared_ptr<MeshLambertMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        MeshLambertMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithWireframe(false, 1),
-              MaterialWithReflectivity(1, 0.98f),
-              MaterialWithLightMap(1),
-              MaterialWithEmissive(0x000000, 1),
-              MaterialWithAoMap(1),
-              MaterialWithCombine(MultiplyOperation) {}
+        MeshLambertMaterial();
+
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/MeshMatcapMaterial.hpp
+++ b/include/threepp/materials/MeshMatcapMaterial.hpp
@@ -19,7 +19,6 @@ namespace threepp {
                               public MaterialWithDefines {
 
     public:
-
         [[nodiscard]] std::string type() const override {
 
             return "MeshMatcapMaterial";

--- a/include/threepp/materials/MeshNormalMaterial.hpp
+++ b/include/threepp/materials/MeshNormalMaterial.hpp
@@ -16,46 +16,17 @@ namespace threepp {
                               public MaterialWithFlatShading {
 
     public:
-        static std::shared_ptr<MeshNormalMaterial> create() {
 
-            return std::shared_ptr<MeshNormalMaterial>(new MeshNormalMaterial());
-        }
+        [[nodiscard]] std::string type() const override;
 
-        std::shared_ptr<Material> clone() const override {
-            auto m = create();
-            copyInto(m.get());
+        static std::shared_ptr<MeshNormalMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
-            m->normalMap = normalMap;
-            m->normalMapType = normalMapType;
-            m->normalScale.copy(normalScale);
-
-            m->displacementMap = displacementMap;
-            m->displacementScale = displacementScale;
-            m->displacementBias = displacementBias;
-
-            m->wireframe = wireframe;
-            m->wireframeLinewidth = wireframeLinewidth;
-
-            m->flatShading = flatShading;
-
-            return m;
-        }
-
-
-        [[nodiscard]] std::string type() const override {
-
-            return "MeshNormalMaterial";
-        }
+        std::shared_ptr<Material> clone() const override;
 
     protected:
-        MeshNormalMaterial(): MaterialWithFlatShading(false),
-                              MaterialWithWireframe(false, 1),
-                              MaterialWithDisplacementMap(1, 0),
-                              MaterialWithNormalMap(TangentSpaceNormalMap, {1, 1}),
-                              MaterialWithBumpMap(1) {
+        MeshNormalMaterial();
 
-            this->fog = false;
-        }
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/MeshPhongMaterial.hpp
+++ b/include/threepp/materials/MeshPhongMaterial.hpp
@@ -28,79 +28,16 @@ namespace threepp {
           public MaterialWithFlatShading {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "MeshPhongMaterial";
-        }
+        [[nodiscard]] std::shared_ptr<Material> clone() const override;
 
-        [[nodiscard]] std::shared_ptr<Material> clone() const override {
-
-            auto m = create();
-            copyInto(m.get());
-
-            m->color.copy(color);
-            m->specular.copy(specular);
-            m->shininess = shininess;
-
-            m->map = map;
-
-            m->lightMap = lightMap;
-            m->lightMapIntensity = lightMapIntensity;
-
-            m->aoMap = aoMap;
-            m->aoMapIntensity = aoMapIntensity;
-
-            m->emissive.copy(emissive);
-            m->emissiveMap = emissiveMap;
-            m->emissiveIntensity = emissiveIntensity;
-
-            m->bumpMap = bumpMap;
-            m->bumpScale = bumpScale;
-
-            m->normalMap = normalMap;
-            m->normalMapType = normalMapType;
-            m->normalScale.copy(normalScale);
-
-            m->displacementMap = displacementMap;
-            m->displacementScale = displacementScale;
-            m->displacementBias = displacementBias;
-
-            m->specularMap = specularMap;
-
-            m->alphaMap = alphaMap;
-
-            m->envMap = envMap;
-            m->combine = combine;
-            m->reflectivity = reflectivity;
-            m->refractionRatio = refractionRatio;
-
-            m->wireframe = wireframe;
-            m->wireframeLinewidth = wireframeLinewidth;
-
-            m->flatShading = flatShading;
-
-            return m;
-        }
-
-        static std::shared_ptr<MeshPhongMaterial> create() {
-
-            return std::shared_ptr<MeshPhongMaterial>(new MeshPhongMaterial());
-        }
+        static std::shared_ptr<MeshPhongMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        MeshPhongMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithCombine(MultiplyOperation),
-              MaterialWithFlatShading(false),
-              MaterialWithSpecular(0x111111, 30),
-              MaterialWithLightMap(1),
-              MaterialWithAoMap(1),
-              MaterialWithEmissive(0x000000, 1),
-              MaterialWithBumpMap(1),
-              MaterialWithNormalMap(TangentSpaceNormalMap, {1, 1}),
-              MaterialWithDisplacementMap(1, 0),
-              MaterialWithReflectivity(1, 0.98f),
-              MaterialWithWireframe(false, 1) {}
+        explicit MeshPhongMaterial();
+
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/MeshStandardMaterial.hpp
+++ b/include/threepp/materials/MeshStandardMaterial.hpp
@@ -88,9 +88,12 @@ namespace threepp {
             return m;
         }
 
-        static std::shared_ptr<MeshStandardMaterial> create() {
+        static std::shared_ptr<MeshStandardMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {}) {
 
-            return std::shared_ptr<MeshStandardMaterial>(new MeshStandardMaterial());
+            auto m = std::shared_ptr<MeshStandardMaterial>(new MeshStandardMaterial());
+            m->setValues(values);
+
+            return m;
         }
 
     protected:
@@ -111,6 +114,32 @@ namespace threepp {
               MaterialWithFlatShading(false) {
 
             defines["STANDARD"] = "";
+        }
+
+        bool setValue(const std::string& key, const MaterialValue& value) override {
+
+            if (key == "color") {
+
+                if (std::holds_alternative<int>(value)) {
+                    color = std::get<int>(value);
+                } else {
+                    color.copy(std::get<Color>(value));
+                }
+
+                return true;
+
+            } else if (key == "wireframe") {
+
+                wireframe = std::get<bool>(value);
+                return true;
+
+            } else if (key == "flatShading") {
+
+                flatShading = std::get<bool>(value);
+                return true;
+            }
+
+            return false;
         }
     };
 

--- a/include/threepp/materials/MeshStandardMaterial.hpp
+++ b/include/threepp/materials/MeshStandardMaterial.hpp
@@ -28,119 +28,16 @@ namespace threepp {
                                 public MaterialWithDefines {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "MeshStandardMaterial";
-        }
+        [[nodiscard]] std::shared_ptr<Material> clone() const override;
 
-        [[nodiscard]] std::shared_ptr<Material> clone() const override {
-
-            auto m = create();
-            copyInto(m.get());
-
-            m->defines["STANDARD"] = "";
-
-            m->color.copy(color);
-            m->roughness = roughness;
-            m->metalness = metalness;
-
-            m->map = map;
-
-            m->lightMap = lightMap;
-            m->lightMapIntensity = lightMapIntensity;
-
-            m->aoMap = aoMap;
-            m->aoMapIntensity = aoMapIntensity;
-
-            m->emissive.copy(emissive);
-            m->emissiveMap = emissiveMap;
-            m->emissiveIntensity = emissiveIntensity;
-
-            m->bumpMap = bumpMap;
-            m->bumpScale = bumpScale;
-
-            m->normalMap = normalMap;
-            m->normalMapType = normalMapType;
-            m->normalScale.copy(normalScale);
-
-            m->displacementMap = displacementMap;
-            m->displacementScale = displacementScale;
-            m->displacementBias = displacementBias;
-
-            m->roughnessMap = roughnessMap;
-
-            m->metalnessMap = metalnessMap;
-
-            m->alphaMap = alphaMap;
-
-            m->envMap = envMap;
-            m->envMapIntensity = envMapIntensity;
-
-            m->refractionRatio = refractionRatio;
-
-            m->wireframe = wireframe;
-            m->wireframeLinewidth = wireframeLinewidth;
-
-            m->flatShading = flatShading;
-
-            m->vertexTangents = vertexTangents;
-
-            return m;
-        }
-
-        static std::shared_ptr<MeshStandardMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {}) {
-
-            auto m = std::shared_ptr<MeshStandardMaterial>(new MeshStandardMaterial());
-            m->setValues(values);
-
-            return m;
-        }
+        static std::shared_ptr<MeshStandardMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        MeshStandardMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithWireframe(false, 1),
-              MaterialWithRoughness(1),
-              MaterialWithMetalness(0),
-              MaterialWithLightMap(1),
-              MaterialWithAoMap(1),
-              MaterialWithEmissive(0x000000, 1),
-              MaterialWithBumpMap(1),
-              MaterialWithEnvMap(1.f),
-              MaterialWithDisplacementMap(1, 0),
-              MaterialWithReflectivityRatio(0.98),
-              MaterialWithNormalMap(TangentSpaceNormalMap, {1, 1}),
-              MaterialWithVertexTangents(false),
-              MaterialWithFlatShading(false) {
+        MeshStandardMaterial();
 
-            defines["STANDARD"] = "";
-        }
-
-        bool setValue(const std::string& key, const MaterialValue& value) override {
-
-            if (key == "color") {
-
-                if (std::holds_alternative<int>(value)) {
-                    color = std::get<int>(value);
-                } else {
-                    color.copy(std::get<Color>(value));
-                }
-
-                return true;
-
-            } else if (key == "wireframe") {
-
-                wireframe = std::get<bool>(value);
-                return true;
-
-            } else if (key == "flatShading") {
-
-                flatShading = std::get<bool>(value);
-                return true;
-            }
-
-            return false;
-        }
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/PointsMaterial.hpp
+++ b/include/threepp/materials/PointsMaterial.hpp
@@ -17,36 +17,16 @@ namespace threepp {
                           public MaterialWithSize {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "PointsMaterial";
-        }
+        std::shared_ptr<Material> clone() const override;
 
-        std::shared_ptr<Material> clone() const override {
-            auto m = create();
-            copyInto(m.get());
-
-            m->color.copy(color);
-
-            m->map = map;
-
-            m->alphaMap = alphaMap;
-
-            m->size = size;
-            m->sizeAttenuation = sizeAttenuation;
-
-            return m;
-        }
-
-        static std::shared_ptr<PointsMaterial> create() {
-
-            return std::shared_ptr<PointsMaterial>(new PointsMaterial());
-        }
+        static std::shared_ptr<PointsMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        PointsMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithSize(1, true) {}
+        PointsMaterial();
+
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/materials/SpriteMaterial.hpp
+++ b/include/threepp/materials/SpriteMaterial.hpp
@@ -17,39 +17,16 @@ namespace threepp {
                           public MaterialWithSize {
 
     public:
-        [[nodiscard]] std::string type() const override {
+        [[nodiscard]] std::string type() const override;
 
-            return "SpriteMaterial";
-        }
+        std::shared_ptr<Material> clone() const override;
 
-        std::shared_ptr<Material> clone() const override {
-            auto m = create();
-            copyInto(m.get());
-
-            m->color.copy(color);
-
-            m->map = map;
-
-            m->alphaMap = alphaMap;
-
-            m->rotation = rotation;
-
-            m->sizeAttenuation = sizeAttenuation;
-
-            return m;
-        }
-
-        static std::shared_ptr<SpriteMaterial> create() {
-
-            return std::shared_ptr<SpriteMaterial>(new SpriteMaterial());
-        }
+        static std::shared_ptr<SpriteMaterial> create(const std::unordered_map<std::string, MaterialValue>& values = {});
 
     protected:
-        SpriteMaterial()
-            : MaterialWithColor(0xffffff),
-              MaterialWithSize(0, true) {
-            transparent = true;
-        }
+        SpriteMaterial();
+
+        bool setValue(const std::string& key, const MaterialValue& value) override;
     };
 
 }// namespace threepp

--- a/include/threepp/math/Color.hpp
+++ b/include/threepp/math/Color.hpp
@@ -81,7 +81,7 @@ namespace threepp {
             return os;
         }
 
-        enum ColorName : std::uint32_t {
+        enum ColorName : int {
             aliceblue = 0xF0F8FF,
             antiquewhite = 0xFAEBD7,
             aqua = 0x00FFFF,

--- a/include/threepp/threepp.hpp
+++ b/include/threepp/threepp.hpp
@@ -15,6 +15,8 @@
 
 #include "threepp/materials/materials.hpp"
 
+#include "threepp/math/MathUtils.hpp"
+
 #include "threepp/helpers/helpers.hpp"
 
 #include "threepp/core/Object3D.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,6 +288,7 @@ set(sources
         "threepp/materials/MeshLambertMaterial.cpp"
         "threepp/materials/MeshNormalMaterial.cpp"
         "threepp/materials/MeshPhongMaterial.cpp"
+        "threepp/materials/MeshStandardMaterial.cpp"
         "threepp/materials/PointsMaterial.cpp"
         "threepp/materials/SpriteMaterial.cpp"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,6 +282,15 @@ set(sources
         "threepp/loaders/STLLoader.cpp"
         "threepp/loaders/TextureLoader.cpp"
 
+        "threepp/materials/LineBasicMaterial.cpp"
+        "threepp/materials/Material.cpp"
+        "threepp/materials/MeshBasicMaterial.cpp"
+        "threepp/materials/MeshLambertMaterial.cpp"
+        "threepp/materials/MeshNormalMaterial.cpp"
+        "threepp/materials/MeshPhongMaterial.cpp"
+        "threepp/materials/PointsMaterial.cpp"
+        "threepp/materials/SpriteMaterial.cpp"
+
         "threepp/math/Box2.cpp"
         "threepp/math/Box3.cpp"
         "threepp/math/Capsule.cpp"

--- a/src/threepp/materials/LineBasicMaterial.cpp
+++ b/src/threepp/materials/LineBasicMaterial.cpp
@@ -1,0 +1,50 @@
+
+#include "threepp/materials/LineBasicMaterial.hpp"
+
+using namespace threepp;
+
+LineBasicMaterial::LineBasicMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithLineWidth(1) {}
+
+
+std::string LineBasicMaterial::type() const {
+
+    return "LineBasicMaterial";
+}
+
+std::shared_ptr<Material> LineBasicMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->color.copy(color);
+
+    m->linewidth = linewidth;
+
+    return m;
+}
+
+std::shared_ptr<LineBasicMaterial> LineBasicMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<LineBasicMaterial>(new LineBasicMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+bool LineBasicMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/LineBasicMaterial.cpp
+++ b/src/threepp/materials/LineBasicMaterial.cpp
@@ -44,6 +44,10 @@ bool LineBasicMaterial::setValue(const std::string& key, const MaterialValue& va
         }
 
         return true;
+    } else if (key == "linewidth") {
+
+        linewidth = std::get<float>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/materials/Material.cpp
+++ b/src/threepp/materials/Material.cpp
@@ -1,0 +1,313 @@
+
+#include "threepp/materials/Material.hpp"
+
+#include "threepp/math/MathUtils.hpp"
+
+#include <iostream>
+#include <sstream>
+
+using namespace threepp;
+
+Material::Material()
+    : uuid_(math::generateUUID()) {}
+
+std::string Material::uuid() const {
+
+    return uuid_;
+}
+
+void Material::dispose() {
+    if (!disposed_) {
+        disposed_ = true;
+        dispatchEvent("dispose", this);
+    }
+}
+
+void Material::needsUpdate() {
+
+    this->version++;
+}
+
+void Material::copyInto(Material* m) const {
+
+    m->name = name;
+
+    m->fog = fog;
+
+    m->blending = blending;
+    m->side = side;
+    m->vertexColors = vertexColors;
+
+    m->opacity = opacity;
+    m->transparent = transparent;
+
+    m->blendSrc = blendSrc;
+    m->blendDst = blendDst;
+    m->blendEquation = blendEquation;
+    m->blendSrcAlpha = blendSrcAlpha;
+    m->blendDstAlpha = blendDstAlpha;
+    m->blendEquationAlpha = blendEquationAlpha;
+
+    m->depthFunc = depthFunc;
+    m->depthTest = depthTest;
+    m->depthWrite = depthWrite;
+
+    m->stencilWriteMask = stencilWriteMask;
+    m->stencilFunc = stencilFunc;
+    m->stencilRef = stencilRef;
+    m->stencilFuncMask = stencilFuncMask;
+    m->stencilFail = stencilFail;
+    m->stencilZFail = stencilZFail;
+    m->stencilZPass = stencilZPass;
+    m->stencilWrite = stencilWrite;
+
+    const auto& srcPlanes = clippingPlanes;
+    std::vector<Plane> dstPlanes;
+
+    if (!srcPlanes.empty()) {
+
+        auto n = srcPlanes.size();
+        dstPlanes.resize(n);
+
+        for (unsigned i = 0; i != n; ++i) {
+
+            dstPlanes[i] = srcPlanes[i];
+        }
+    }
+
+    m->clippingPlanes = dstPlanes;
+    m->clipIntersection = clipIntersection;
+    m->clipShadows = clipShadows;
+
+    m->shadowSide = shadowSide;
+
+    m->colorWrite = colorWrite;
+
+    m->polygonOffset = polygonOffset;
+    m->polygonOffsetFactor = polygonOffsetFactor;
+    m->polygonOffsetUnits = polygonOffsetUnits;
+
+    m->dithering = dithering;
+
+    m->alphaTest = alphaTest;
+    m->alphaToCoverage = alphaToCoverage;
+    m->premultipliedAlpha = premultipliedAlpha;
+
+    m->visible = visible;
+
+    m->toneMapped = toneMapped;
+}
+
+Material::~Material() {
+
+    dispose();
+}
+
+void Material::setValues(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    if (values.empty()) return;
+
+    std::vector<std::string> unused;
+
+    for (const auto& [key, value] : values) {
+
+        bool used = false;
+
+        if (key == "fog") {
+
+            fog = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "blending") {
+
+            blending = std::get<int>(value);
+            used = true;
+
+        } else if (key == "side") {
+
+            side = std::get<int>(value);
+            used = true;
+
+        } else if (key == "vertexColors") {
+
+            vertexColors = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "opacity") {
+
+            opacity = std::get<float>(value);
+            used = true;
+
+        } else if (key == "transparent") {
+
+            transparent = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "blendSrc") {
+
+            blendSrc = std::get<int>(value);
+            used = true;
+
+        } else if (key == "blendDst") {
+
+            blendDst = std::get<int>(value);
+            used = true;
+
+        } else if (key == "blendEquation") {
+
+            blendEquation = std::get<int>(value);
+            used = true;
+
+        } else if (key == "blendSrcAlpha") {
+
+            blendSrcAlpha = std::get<int>(value);
+            used = true;
+
+        } else if (key == "blendDstAlpha") {
+
+            blendDstAlpha = std::get<int>(value);
+
+        } else if (key == "blendEquationAlpha") {
+
+            blendEquationAlpha = std::get<int>(value);
+            used = true;
+
+        } else if (key == "depthFunc") {
+
+            depthFunc = std::get<int>(value);
+            used = true;
+
+        } else if (key == "depthTest") {
+
+            depthTest = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "depthWrite") {
+
+            depthWrite = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "stencilWriteMask") {
+
+            stencilWriteMask = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilFunc") {
+
+            stencilFunc = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilRef") {
+
+            stencilRef = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilFuncMask") {
+
+            stencilFuncMask = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilFail") {
+
+            stencilFail = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilZFail") {
+
+            stencilZFail = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilZPass") {
+
+            stencilZPass = std::get<int>(value);
+            used = true;
+
+        } else if (key == "stencilWrite") {
+
+            stencilWrite = std::get<int>(value);
+            used = true;
+
+        } else if (key == "shadowSide") {
+
+            shadowSide = std::get<int>(value);
+            used = true;
+
+        } else if (key == "colorWrite") {
+
+            colorWrite = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "polygonOffset") {
+
+            polygonOffset = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "polygonOffsetFactor") {
+
+            polygonOffsetFactor = std::get<float>(value);
+            used = true;
+
+        } else if (key == "polygonOffsetUnits") {
+
+            polygonOffsetUnits = std::get<float>(value);
+            used = true;
+
+        } else if (key == "dithering") {
+
+            dithering = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "alphaTest") {
+
+            alphaTest = std::get<float>(value);
+            used = true;
+
+        } else if (key == "alphaToCoverage") {
+
+            alphaToCoverage = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "premultipliedAlpha") {
+
+            premultipliedAlpha = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "visible") {
+
+            visible = std::get<bool>(value);
+            used = true;
+
+        } else if (key == "toneMapped") {
+
+            toneMapped = std::get<bool>(value);
+            used = true;
+
+        } else {
+
+            used = setValue(key, value);
+        }
+
+        if (!used) {
+            unused.emplace_back(key);
+        }
+    }
+
+    if (!unused.empty()) {
+        std::stringstream ss;
+        ss << "[";
+        for (unsigned i = 0; i < unused.size(); i++) {
+            ss << unused[i];
+            if (i < unused.size() - 1) {
+                ss << ",";
+            }
+        }
+        ss << "]";
+
+        std::cerr << "Unused material values: " << ss.str() << std::endl;
+    }
+}
+
+bool Material::setValue(const std::string& key, const MaterialValue& value) {
+
+    return false;
+}

--- a/src/threepp/materials/MeshBasicMaterial.cpp
+++ b/src/threepp/materials/MeshBasicMaterial.cpp
@@ -1,0 +1,77 @@
+
+#include "threepp/materials/MeshBasicMaterial.hpp"
+
+using namespace threepp;
+
+MeshBasicMaterial::MeshBasicMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithAoMap(1),
+      MaterialWithLightMap(1),
+      MaterialWithCombine(MultiplyOperation),
+      MaterialWithReflectivity(1, 0.98f),
+      MaterialWithWireframe(false, 1) {}
+
+
+std::string MeshBasicMaterial::type() const {
+
+    return "MeshBasicMaterial";
+}
+
+std::shared_ptr<Material> MeshBasicMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->color.copy(color);
+
+    m->map = map;
+
+    m->lightMap = lightMap;
+    m->lightMapIntensity = lightMapIntensity;
+
+    m->aoMap = aoMap;
+    m->aoMapIntensity = aoMapIntensity;
+
+    m->specularMap = specularMap;
+
+    m->alphaMap = alphaMap;
+
+    m->envMap = envMap;
+    m->combine = combine;
+    m->reflectivity = reflectivity;
+    m->refractionRatio = refractionRatio;
+
+    m->wireframe = wireframe;
+    m->wireframeLinewidth = wireframeLinewidth;
+
+    return m;
+}
+
+std::shared_ptr<MeshBasicMaterial> MeshBasicMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<MeshBasicMaterial>(new MeshBasicMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+bool MeshBasicMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+
+    } else if (key == "wireframe") {
+
+        wireframe = std::get<bool>(value);
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/MeshBasicMaterial.cpp
+++ b/src/threepp/materials/MeshBasicMaterial.cpp
@@ -97,9 +97,39 @@ bool MeshBasicMaterial::setValue(const std::string& key, const MaterialValue& va
         aoMap = std::get<std::shared_ptr<Texture>>(value);
         return true;
 
+    } else if (key == "aoMapIntensity") {
+
+        aoMapIntensity = std::get<float>(value);
+        return true;
+
     } else if (key == "lightMap") {
 
         lightMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "lightMapIntensity") {
+
+        lightMapIntensity = std::get<float>(value);
+        return true;
+
+    } else if (key == "envMap") {
+
+        envMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "combine") {
+
+        combine = std::get<int>(value);
+        return true;
+
+    } else if (key == "reflectivity") {
+
+        reflectivity = std::get<float>(value);
+        return true;
+
+    } else if (key == "refractionRatio") {
+
+        refractionRatio = std::get<float>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshBasicMaterial.cpp
+++ b/src/threepp/materials/MeshBasicMaterial.cpp
@@ -71,6 +71,15 @@ bool MeshBasicMaterial::setValue(const std::string& key, const MaterialValue& va
 
         wireframe = std::get<bool>(value);
         return true;
+
+    } else if (key == "map") {
+
+        map = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+    } else if (key == "alphaMap") {
+
+        alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/materials/MeshBasicMaterial.cpp
+++ b/src/threepp/materials/MeshBasicMaterial.cpp
@@ -72,13 +72,34 @@ bool MeshBasicMaterial::setValue(const std::string& key, const MaterialValue& va
         wireframe = std::get<bool>(value);
         return true;
 
+    } else if (key == "wireframeLinewidth") {
+
+        wireframeLinewidth = std::get<float>(value);
+        return true;
+
     } else if (key == "map") {
 
         map = std::get<std::shared_ptr<Texture>>(value);
         return true;
+
     } else if (key == "alphaMap") {
 
         alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "specularMap") {
+
+        specularMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "aoMap") {
+
+        aoMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "lightMap") {
+
+        lightMap = std::get<std::shared_ptr<Texture>>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshLambertMaterial.cpp
+++ b/src/threepp/materials/MeshLambertMaterial.cpp
@@ -71,6 +71,16 @@ bool MeshLambertMaterial::setValue(const std::string& key, const MaterialValue& 
         }
 
         return true;
+
+    } else if (key == "map") {
+
+        map = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "alphaMap") {
+
+        alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/materials/MeshLambertMaterial.cpp
+++ b/src/threepp/materials/MeshLambertMaterial.cpp
@@ -72,14 +72,59 @@ bool MeshLambertMaterial::setValue(const std::string& key, const MaterialValue& 
 
         return true;
 
+    } else if (key == "emissive") {
+
+        if (std::holds_alternative<int>(value)) {
+            emissive = std::get<int>(value);
+        } else {
+            emissive.copy(std::get<Color>(value));
+        }
+
+        return true;
+
     } else if (key == "map") {
 
         map = std::get<std::shared_ptr<Texture>>(value);
         return true;
 
+    } else if (key == "aoMap") {
+
+        aoMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "aoMapIntensity") {
+
+        aoMapIntensity = std::get<float>(value);
+        return true;
+
     } else if (key == "alphaMap") {
 
         alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "specularMap") {
+
+        specularMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "lightMap") {
+
+        lightMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "lightMapIntensity") {
+
+        lightMapIntensity = std::get<float>(value);
+        return true;
+
+    } else if (key == "wireframe") {
+
+        wireframe = std::get<bool>(value);
+        return true;
+
+    } else if (key == "wireframeLinewidth") {
+
+        wireframeLinewidth = std::get<float>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshLambertMaterial.cpp
+++ b/src/threepp/materials/MeshLambertMaterial.cpp
@@ -126,6 +126,26 @@ bool MeshLambertMaterial::setValue(const std::string& key, const MaterialValue& 
 
         wireframeLinewidth = std::get<float>(value);
         return true;
+
+    } else if (key == "envMap") {
+
+        envMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "combine") {
+
+        combine = std::get<int>(value);
+        return true;
+
+    } else if (key == "reflectivity") {
+
+        reflectivity = std::get<float>(value);
+        return true;
+
+    } else if (key == "refractionRatio") {
+
+        refractionRatio = std::get<float>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/materials/MeshLambertMaterial.cpp
+++ b/src/threepp/materials/MeshLambertMaterial.cpp
@@ -1,0 +1,77 @@
+
+#include "threepp/materials/MeshLambertMaterial.hpp"
+
+using namespace threepp;
+
+MeshLambertMaterial::MeshLambertMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithWireframe(false, 1),
+      MaterialWithReflectivity(1, 0.98f),
+      MaterialWithLightMap(1),
+      MaterialWithEmissive(0x000000, 1),
+      MaterialWithAoMap(1),
+      MaterialWithCombine(MultiplyOperation) {}
+
+
+std::string MeshLambertMaterial::type() const {
+
+    return "MeshLambertMaterial";
+}
+
+std::shared_ptr<Material> MeshLambertMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->color.copy(color);
+
+    m->map = map;
+
+    m->lightMap = lightMap;
+    m->lightMapIntensity = lightMapIntensity;
+
+    m->aoMap = aoMap;
+    m->aoMapIntensity = aoMapIntensity;
+
+    m->emissive.copy(emissive);
+    m->emissiveMap = emissiveMap;
+    m->emissiveIntensity = emissiveIntensity;
+
+    m->specularMap = specularMap;
+
+    m->alphaMap = alphaMap;
+
+    m->envMap = envMap;
+    m->combine = combine;
+    m->reflectivity = reflectivity;
+    m->refractionRatio = refractionRatio;
+
+    m->wireframe = wireframe;
+    m->wireframeLinewidth = wireframeLinewidth;
+
+    return m;
+}
+
+std::shared_ptr<MeshLambertMaterial> MeshLambertMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<MeshLambertMaterial>(new MeshLambertMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+bool MeshLambertMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/MeshNormalMaterial.cpp
+++ b/src/threepp/materials/MeshNormalMaterial.cpp
@@ -60,6 +60,10 @@ bool MeshNormalMaterial::setValue(const std::string& key, const MaterialValue& v
         flatShading = std::get<bool>(value);
 
         return true;
+    } else if (key == "normalMap") {
+
+        normalMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/materials/MeshNormalMaterial.cpp
+++ b/src/threepp/materials/MeshNormalMaterial.cpp
@@ -53,16 +53,36 @@ bool MeshNormalMaterial::setValue(const std::string& key, const MaterialValue& v
     if (key == "wireframe") {
 
         wireframe = std::get<bool>(value);
-
         return true;
+
+    } else if (key == "wireframeLinewidth") {
+
+        wireframeLinewidth = std::get<float>(value);
+        return true;
+
     } else if (key == "flatShading") {
 
         flatShading = std::get<bool>(value);
-
         return true;
+
     } else if (key == "normalMap") {
 
         normalMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "displacementMap") {
+
+        displacementMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "displacementBias") {
+
+        displacementBias = std::get<float>(value);
+        return true;
+
+    } else if (key == "displacementScale") {
+
+        displacementScale = std::get<float>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshNormalMaterial.cpp
+++ b/src/threepp/materials/MeshNormalMaterial.cpp
@@ -1,0 +1,66 @@
+
+#include "threepp/materials/MeshNormalMaterial.hpp"
+
+using namespace threepp;
+
+MeshNormalMaterial::MeshNormalMaterial()
+    : MaterialWithFlatShading(false),
+      MaterialWithWireframe(false, 1),
+      MaterialWithDisplacementMap(1, 0),
+      MaterialWithNormalMap(TangentSpaceNormalMap, {1, 1}),
+      MaterialWithBumpMap(1) {
+
+    this->fog = false;
+}
+
+
+std::string MeshNormalMaterial::type() const {
+
+    return "MeshNormalMaterial";
+}
+
+std::shared_ptr<MeshNormalMaterial> MeshNormalMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<MeshNormalMaterial>(new MeshNormalMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+std::shared_ptr<Material> MeshNormalMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->normalMap = normalMap;
+    m->normalMapType = normalMapType;
+    m->normalScale.copy(normalScale);
+
+    m->displacementMap = displacementMap;
+    m->displacementScale = displacementScale;
+    m->displacementBias = displacementBias;
+
+    m->wireframe = wireframe;
+    m->wireframeLinewidth = wireframeLinewidth;
+
+    m->flatShading = flatShading;
+
+    return m;
+}
+
+bool MeshNormalMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "wireframe") {
+
+        wireframe = std::get<bool>(value);
+
+        return true;
+    } else if (key == "flatShading") {
+
+        flatShading = std::get<bool>(value);
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/MeshNormalMaterial.cpp
+++ b/src/threepp/materials/MeshNormalMaterial.cpp
@@ -70,6 +70,11 @@ bool MeshNormalMaterial::setValue(const std::string& key, const MaterialValue& v
         normalMap = std::get<std::shared_ptr<Texture>>(value);
         return true;
 
+    } else if (key == "normalMapType") {
+
+        normalMapType = std::get<int>(value);
+        return true;
+
     } else if (key == "displacementMap") {
 
         displacementMap = std::get<std::shared_ptr<Texture>>(value);

--- a/src/threepp/materials/MeshPhongMaterial.cpp
+++ b/src/threepp/materials/MeshPhongMaterial.cpp
@@ -97,6 +97,11 @@ bool MeshPhongMaterial::setValue(const std::string& key, const MaterialValue& va
         wireframe = std::get<bool>(value);
         return true;
 
+    } else if (key == "wireframeLinewidth") {
+
+        wireframeLinewidth = std::get<float>(value);
+        return true;
+
     } else if (key == "flatShading") {
 
         flatShading = std::get<bool>(value);
@@ -120,6 +125,31 @@ bool MeshPhongMaterial::setValue(const std::string& key, const MaterialValue& va
     } else if (key == "alphaMap") {
 
         alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "specularMap") {
+
+        specularMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "displacementMap") {
+
+        displacementMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "displacementBias") {
+
+        displacementBias = std::get<float>(value);
+        return true;
+
+    } else if (key == "displacementScale") {
+
+        displacementScale = std::get<float>(value);
+        return true;
+
+    } else if (key == "shininess") {
+
+        shininess = std::get<float>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshPhongMaterial.cpp
+++ b/src/threepp/materials/MeshPhongMaterial.cpp
@@ -100,7 +100,26 @@ bool MeshPhongMaterial::setValue(const std::string& key, const MaterialValue& va
     } else if (key == "flatShading") {
 
         flatShading = std::get<bool>(value);
+        return true;
 
+    } else if (key == "map") {
+
+        map = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "bumpMap") {
+
+        bumpMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "normalMap") {
+
+        normalMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "alphaMap") {
+
+        alphaMap = std::get<std::shared_ptr<Texture>>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshPhongMaterial.cpp
+++ b/src/threepp/materials/MeshPhongMaterial.cpp
@@ -1,0 +1,108 @@
+
+#include "threepp/materials/MeshPhongMaterial.hpp"
+
+using namespace threepp;
+
+MeshPhongMaterial::MeshPhongMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithCombine(MultiplyOperation),
+      MaterialWithFlatShading(false),
+      MaterialWithSpecular(0x111111, 30),
+      MaterialWithLightMap(1),
+      MaterialWithAoMap(1),
+      MaterialWithEmissive(0x000000, 1),
+      MaterialWithBumpMap(1),
+      MaterialWithNormalMap(TangentSpaceNormalMap, {1, 1}),
+      MaterialWithDisplacementMap(1, 0),
+      MaterialWithReflectivity(1, 0.98f),
+      MaterialWithWireframe(false, 1) {}
+
+
+std::string MeshPhongMaterial::type() const {
+
+    return "MeshPhongMaterial";
+}
+
+std::shared_ptr<Material> MeshPhongMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->color.copy(color);
+    m->specular.copy(specular);
+    m->shininess = shininess;
+
+    m->map = map;
+
+    m->lightMap = lightMap;
+    m->lightMapIntensity = lightMapIntensity;
+
+    m->aoMap = aoMap;
+    m->aoMapIntensity = aoMapIntensity;
+
+    m->emissive.copy(emissive);
+    m->emissiveMap = emissiveMap;
+    m->emissiveIntensity = emissiveIntensity;
+
+    m->bumpMap = bumpMap;
+    m->bumpScale = bumpScale;
+
+    m->normalMap = normalMap;
+    m->normalMapType = normalMapType;
+    m->normalScale.copy(normalScale);
+
+    m->displacementMap = displacementMap;
+    m->displacementScale = displacementScale;
+    m->displacementBias = displacementBias;
+
+    m->specularMap = specularMap;
+
+    m->alphaMap = alphaMap;
+
+    m->envMap = envMap;
+    m->combine = combine;
+    m->reflectivity = reflectivity;
+    m->refractionRatio = refractionRatio;
+
+    m->wireframe = wireframe;
+    m->wireframeLinewidth = wireframeLinewidth;
+
+    m->flatShading = flatShading;
+
+    return m;
+}
+
+std::shared_ptr<MeshPhongMaterial> MeshPhongMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<MeshPhongMaterial>(new MeshPhongMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+bool MeshPhongMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+
+    } else if (key == "wireframe") {
+
+        wireframe = std::get<bool>(value);
+        return true;
+
+    } else if (key == "flatShading") {
+
+        flatShading = std::get<bool>(value);
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/MeshPhongMaterial.cpp
+++ b/src/threepp/materials/MeshPhongMaterial.cpp
@@ -112,14 +112,44 @@ bool MeshPhongMaterial::setValue(const std::string& key, const MaterialValue& va
         map = std::get<std::shared_ptr<Texture>>(value);
         return true;
 
+    } else if (key == "aoMap") {
+
+        aoMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "aoMapIntensity") {
+
+        aoMapIntensity = std::get<float>(value);
+        return true;
+
     } else if (key == "bumpMap") {
 
         bumpMap = std::get<std::shared_ptr<Texture>>(value);
         return true;
 
+    } else if (key == "bumpScale") {
+
+        bumpScale = std::get<float>(value);
+        return true;
+
+    } else if (key == "lightMap") {
+
+        lightMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "lightMapIntensity") {
+
+        lightMapIntensity = std::get<float>(value);
+        return true;
+
     } else if (key == "normalMap") {
 
         normalMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "normalMapType") {
+
+        normalMapType = std::get<int>(value);
         return true;
 
     } else if (key == "alphaMap") {
@@ -150,6 +180,26 @@ bool MeshPhongMaterial::setValue(const std::string& key, const MaterialValue& va
     } else if (key == "shininess") {
 
         shininess = std::get<float>(value);
+        return true;
+
+    } else if (key == "envMap") {
+
+        envMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "combine") {
+
+        combine = std::get<int>(value);
+        return true;
+
+    } else if (key == "reflectivity") {
+
+        reflectivity = std::get<float>(value);
+        return true;
+
+    } else if (key == "refractionRatio") {
+
+        refractionRatio = std::get<float>(value);
         return true;
     }
 

--- a/src/threepp/materials/MeshStandardMaterial.cpp
+++ b/src/threepp/materials/MeshStandardMaterial.cpp
@@ -1,0 +1,244 @@
+
+#include "threepp/materials/MeshStandardMaterial.hpp"
+
+using namespace threepp;
+
+
+MeshStandardMaterial::MeshStandardMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithWireframe(false, 1),
+      MaterialWithRoughness(1),
+      MaterialWithMetalness(0),
+      MaterialWithLightMap(1),
+      MaterialWithAoMap(1),
+      MaterialWithEmissive(0x000000, 1),
+      MaterialWithBumpMap(1),
+      MaterialWithEnvMap(1.f),
+      MaterialWithDisplacementMap(1, 0),
+      MaterialWithReflectivityRatio(0.98),
+      MaterialWithNormalMap(TangentSpaceNormalMap, {1, 1}),
+      MaterialWithVertexTangents(false),
+      MaterialWithFlatShading(false) {
+
+    defines["STANDARD"] = "";
+}
+
+
+std::string MeshStandardMaterial::type() const {
+
+    return "MeshStandardMaterial";
+}
+
+std::shared_ptr<MeshStandardMaterial> MeshStandardMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<MeshStandardMaterial>(new MeshStandardMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+std::shared_ptr<Material> MeshStandardMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->defines["STANDARD"] = "";
+
+    m->color.copy(color);
+    m->roughness = roughness;
+    m->metalness = metalness;
+
+    m->map = map;
+
+    m->lightMap = lightMap;
+    m->lightMapIntensity = lightMapIntensity;
+
+    m->aoMap = aoMap;
+    m->aoMapIntensity = aoMapIntensity;
+
+    m->emissive.copy(emissive);
+    m->emissiveMap = emissiveMap;
+    m->emissiveIntensity = emissiveIntensity;
+
+    m->bumpMap = bumpMap;
+    m->bumpScale = bumpScale;
+
+    m->normalMap = normalMap;
+    m->normalMapType = normalMapType;
+    m->normalScale.copy(normalScale);
+
+    m->displacementMap = displacementMap;
+    m->displacementScale = displacementScale;
+    m->displacementBias = displacementBias;
+
+    m->roughnessMap = roughnessMap;
+
+    m->metalnessMap = metalnessMap;
+
+    m->alphaMap = alphaMap;
+
+    m->envMap = envMap;
+    m->envMapIntensity = envMapIntensity;
+
+    m->refractionRatio = refractionRatio;
+
+    m->wireframe = wireframe;
+    m->wireframeLinewidth = wireframeLinewidth;
+
+    m->flatShading = flatShading;
+
+    m->vertexTangents = vertexTangents;
+
+    return m;
+}
+
+bool MeshStandardMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+
+    } else if (key == "emissive") {
+
+        if (std::holds_alternative<int>(value)) {
+            emissive = std::get<int>(value);
+        } else {
+            emissive.copy(std::get<Color>(value));
+        }
+
+        return true;
+
+    } else if (key == "emissiveIntensity") {
+
+        emissiveIntensity = std::get<float>(value);
+        return true;
+
+    } else if (key == "emissiveMap") {
+
+        emissiveMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "bumpMap") {
+
+        bumpMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "bumpScale") {
+
+        bumpScale = std::get<float>(value);
+        return true;
+
+    } else if (key == "lightMap") {
+
+        lightMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "lightMapIntensity") {
+
+        lightMapIntensity = std::get<float>(value);
+        return true;
+
+    } else if (key == "aoMap") {
+
+        aoMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "aoMapIntensity") {
+
+        aoMapIntensity = std::get<float>(value);
+        return true;
+
+    } else if (key == "normalMap") {
+
+        normalMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "normalMapType") {
+
+        normalMapType = std::get<int>(value);
+        return true;
+
+    } else if (key == "displacementMap") {
+
+        displacementMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "displacementScale") {
+
+        displacementScale = std::get<float>(value);
+        return true;
+
+    } else if (key == "displacementBias") {
+
+        displacementBias = std::get<float>(value);
+        return true;
+
+    } else if (key == "alphaMap") {
+
+        alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "roughnessMap") {
+
+        roughnessMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "roughness") {
+
+        roughness = std::get<float>(value);
+        return true;
+
+    } else if (key == "metalnessMap") {
+
+        metalnessMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "metalness") {
+
+        metalness = std::get<float>(value);
+        return true;
+
+    } else if (key == "envMap") {
+
+        envMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "envMapIntensity") {
+
+        envMapIntensity = std::get<float>(value);
+        return true;
+
+    } else if (key == "refractionRatio") {
+
+        refractionRatio = std::get<float>(value);
+        return true;
+
+    } else if (key == "wireframe") {
+
+        wireframe = std::get<bool>(value);
+        return true;
+
+    } else if (key == "wireframeLinewidth") {
+
+        wireframeLinewidth = std::get<float>(value);
+        return true;
+
+    } else if (key == "flatShading") {
+
+        flatShading = std::get<bool>(value);
+        return true;
+
+    } else if (key == "refractionRatio") {
+
+        vertexTangents = std::get<bool>(value);
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/PointsMaterial.cpp
+++ b/src/threepp/materials/PointsMaterial.cpp
@@ -63,6 +63,7 @@ bool PointsMaterial::setValue(const std::string& key, const MaterialValue& value
 
         map = std::get<std::shared_ptr<Texture>>(value);
         return true;
+
     } else if (key == "alphaMap") {
 
         alphaMap = std::get<std::shared_ptr<Texture>>(value);

--- a/src/threepp/materials/PointsMaterial.cpp
+++ b/src/threepp/materials/PointsMaterial.cpp
@@ -1,0 +1,59 @@
+
+#include "threepp/materials/PointsMaterial.hpp"
+
+using namespace threepp;
+
+PointsMaterial::PointsMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithSize(1, true) {}
+
+
+std::string PointsMaterial::type() const {
+
+    return "PointsMaterial";
+}
+
+std::shared_ptr<Material> PointsMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->color.copy(color);
+
+    m->map = map;
+
+    m->alphaMap = alphaMap;
+
+    m->size = size;
+    m->sizeAttenuation = sizeAttenuation;
+
+    return m;
+}
+
+std::shared_ptr<PointsMaterial> PointsMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<PointsMaterial>(new PointsMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+bool PointsMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+    } else if (key == "size") {
+
+        size = std::get<float>(value);
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/PointsMaterial.cpp
+++ b/src/threepp/materials/PointsMaterial.cpp
@@ -53,6 +53,20 @@ bool PointsMaterial::setValue(const std::string& key, const MaterialValue& value
 
         size = std::get<float>(value);
         return true;
+
+    } else if (key == "sizeAttenuation") {
+
+        sizeAttenuation = std::get<bool>(value);
+        return true;
+
+    } else if (key == "map") {
+
+        map = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+    } else if (key == "alphaMap") {
+
+        alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/materials/SpriteMaterial.cpp
+++ b/src/threepp/materials/SpriteMaterial.cpp
@@ -1,0 +1,57 @@
+
+#include "threepp/materials/SpriteMaterial.hpp"
+
+using namespace threepp;
+
+SpriteMaterial::SpriteMaterial()
+    : MaterialWithColor(0xffffff),
+      MaterialWithSize(0, true) {
+    transparent = true;
+}
+
+std::string SpriteMaterial::type() const {
+
+    return "SpriteMaterial";
+}
+
+std::shared_ptr<Material> SpriteMaterial::clone() const {
+
+    auto m = create();
+    copyInto(m.get());
+
+    m->color.copy(color);
+
+    m->map = map;
+
+    m->alphaMap = alphaMap;
+
+    m->rotation = rotation;
+
+    m->sizeAttenuation = sizeAttenuation;
+
+    return m;
+}
+
+std::shared_ptr<SpriteMaterial> SpriteMaterial::create(const std::unordered_map<std::string, MaterialValue>& values) {
+
+    auto m = std::shared_ptr<SpriteMaterial>(new SpriteMaterial());
+    m->setValues(values);
+
+    return m;
+}
+
+bool SpriteMaterial::setValue(const std::string& key, const MaterialValue& value) {
+
+    if (key == "color") {
+
+        if (std::holds_alternative<int>(value)) {
+            color = std::get<int>(value);
+        } else {
+            color.copy(std::get<Color>(value));
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/threepp/materials/SpriteMaterial.cpp
+++ b/src/threepp/materials/SpriteMaterial.cpp
@@ -51,6 +51,25 @@ bool SpriteMaterial::setValue(const std::string& key, const MaterialValue& value
         }
 
         return true;
+    } else if (key == "map") {
+
+        map = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "alphaMap") {
+
+        alphaMap = std::get<std::shared_ptr<Texture>>(value);
+        return true;
+
+    } else if (key == "rotation") {
+
+        rotation = std::get<float>(value);
+        return true;
+
+    } else if (key == "sizeAttenuation") {
+
+        rotation = std::get<bool>(value);
+        return true;
     }
 
     return false;

--- a/src/threepp/objects/Reflector.cpp
+++ b/src/threepp/objects/Reflector.cpp
@@ -3,6 +3,7 @@
 
 #include "threepp/cameras/PerspectiveCamera.hpp"
 #include "threepp/materials/ShaderMaterial.hpp"
+#include "threepp/math/MathUtils.hpp"
 #include "threepp/objects/Reflector.hpp"
 #include "threepp/renderers/GLRenderTarget.hpp"
 #include "threepp/renderers/GLRenderer.hpp"

--- a/src/threepp/objects/Water.cpp
+++ b/src/threepp/objects/Water.cpp
@@ -4,6 +4,7 @@
 #include "threepp/cameras/PerspectiveCamera.hpp"
 #include "threepp/core/Shader.hpp"
 #include "threepp/materials/ShaderMaterial.hpp"
+#include "threepp/math/MathUtils.hpp"
 #include "threepp/renderers/GLRenderTarget.hpp"
 #include "threepp/renderers/GLRenderer.hpp"
 #include "threepp/renderers/shaders/UniformsLib.hpp"


### PR DESCRIPTION
This PR enables setting material options in a way more in line with three.js

```cpp
auto lineMaterial = LineBasicMaterial::create({{"depthTest", false},
                                                   {"opacity", 0.5f},
                                                   {"transparent", true}});
```