### PR TITLE
Change renderer.render(...) signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ int main() {
         float dt = clock.getDelta();
         group->rotation.y += 1.f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }
 

--- a/examples/bullet/bullet_demo.cpp
+++ b/examples/bullet/bullet_demo.cpp
@@ -162,7 +162,7 @@ int main() {
         float dt = clock.getDelta();
         bullet.step(dt);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         std::stringstream ss;
         ss << renderer.info();

--- a/examples/bullet/instanced_physics.cpp
+++ b/examples/bullet/instanced_physics.cpp
@@ -166,7 +166,7 @@ int main() {
         float dt = clock.getDelta();
         bullet.step(dt);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         std::stringstream ss;
         ss << renderer.info();

--- a/examples/bullet/pid_control.cpp
+++ b/examples/bullet/pid_control.cpp
@@ -162,7 +162,7 @@ int main() {
 
         target->rotation.z = opt.targetAngle * math::DEG2RAD;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
         ui.render();
 
 #ifdef HAS_MATPLOTLIB

--- a/examples/demo.cpp
+++ b/examples/demo.cpp
@@ -140,7 +140,7 @@ int main() {
         box->rotation.y += 0.5f * dt;
         handle.setText("Delta=" + std::to_string(dt));
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
 #ifdef HAS_IMGUI
         ui.render();

--- a/examples/extras/core/fonts.cpp
+++ b/examples/extras/core/fonts.cpp
@@ -71,6 +71,6 @@ int main() {
 
     canvas.animate([&]() {
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/extras/curves/catmull_room_curve3.cpp
+++ b/examples/extras/curves/catmull_room_curve3.cpp
@@ -52,6 +52,6 @@ int main() {
 
     canvas.animate([&]() {
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/extras/curves/cubic_bezier_curve.cpp
+++ b/examples/extras/curves/cubic_bezier_curve.cpp
@@ -80,6 +80,6 @@ int main() {
 
     canvas.animate([&]() {
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/geometries/box_geometry.cpp
+++ b/examples/geometries/box_geometry.cpp
@@ -82,7 +82,7 @@ int main() {
         mesh->rotation.y += 0.8f * dt;
         mesh->rotation.x += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         ui.render();
 

--- a/examples/geometries/convex_geometry.cpp
+++ b/examples/geometries/convex_geometry.cpp
@@ -86,6 +86,6 @@ int main() {
 
         convex->rotation.y += 0.2f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/geometries/cylinder_geometry.cpp
+++ b/examples/geometries/cylinder_geometry.cpp
@@ -87,7 +87,7 @@ int main() {
         mesh->rotation.y += 0.8f * dt;
         mesh->rotation.x += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         ui.render();
 

--- a/examples/geometries/geometries.cpp
+++ b/examples/geometries/geometries.cpp
@@ -174,6 +174,6 @@ int main() {
             m->rotation.y += 1 * dt;
         }
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/geometries/lathe_geometry.cpp
+++ b/examples/geometries/lathe_geometry.cpp
@@ -77,6 +77,6 @@ int main() {
         capsule->rotation.y += 0.8f * dt;
         capsule->rotation.x += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/geometries/plane_geometry.cpp
+++ b/examples/geometries/plane_geometry.cpp
@@ -79,7 +79,7 @@ int main() {
         mesh->rotation.y += 0.8f * dt;
         mesh->rotation.x += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         ui.render();
 

--- a/examples/geometries/shape_geometry.cpp
+++ b/examples/geometries/shape_geometry.cpp
@@ -140,6 +140,6 @@ int main() {
 
         group->rotation.y += 0.8f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/geometries/sphere_geometry.cpp
+++ b/examples/geometries/sphere_geometry.cpp
@@ -85,7 +85,7 @@ int main() {
         mesh->rotation.y += 0.8f * dt;
         mesh->rotation.x += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         ui.render();
 

--- a/examples/geometries/tube_geometry.cpp
+++ b/examples/geometries/tube_geometry.cpp
@@ -59,6 +59,6 @@ int main() {
     canvas.animate([&]() {
         mesh->rotation.y += 1 * clock.getDelta();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/helpers/camera_helper.cpp
+++ b/examples/helpers/camera_helper.cpp
@@ -64,12 +64,12 @@ int main() {
         helper->visible = false;
 
         renderer.setViewport({size.width / 2, 0, size.width / 2, size.height});
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         helper->visible = true;
 
         renderer.setViewport({0, 0, size.width / 2, size.height});
-        renderer.render(scene, camera2);
+        renderer.render(*scene, *camera2);
 
         camera->position.z = 4 * std::sin(math::TWO_PI * 0.1f * clock.getElapsedTime());
     });

--- a/examples/helpers/helpers.cpp
+++ b/examples/helpers/helpers.cpp
@@ -68,6 +68,6 @@ int main() {
 
         boxHelper->update();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/lights/directional.cpp
+++ b/examples/lights/directional.cpp
@@ -107,6 +107,6 @@ int main() {
         light->updateMatrixWorld();
         helper->update();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/lights/hemi_light.cpp
+++ b/examples/lights/hemi_light.cpp
@@ -66,6 +66,6 @@ int main() {
 
         group->rotation.y += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/lights/point_light.cpp
+++ b/examples/lights/point_light.cpp
@@ -96,6 +96,6 @@ int main() {
         light2->position.x = 5 * std::sin(t);
         light2->position.z = 1 * std::sin(t);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/lights/spot_light.cpp
+++ b/examples/lights/spot_light.cpp
@@ -90,6 +90,6 @@ int main() {
 
         helper->update();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/loaders/assimp_loader.cpp
+++ b/examples/loaders/assimp_loader.cpp
@@ -91,6 +91,6 @@ int main() {
             child->rotation.y += 1 * dt;
         }
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/loaders/obj_loader.cpp
+++ b/examples/loaders/obj_loader.cpp
@@ -58,6 +58,6 @@ int main() {
         obj1->rotation.y += 1 * dt;
         obj2->rotation.y += 1 * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/loaders/stl_loader.cpp
+++ b/examples/loaders/stl_loader.cpp
@@ -46,6 +46,6 @@ int main() {
 
         mesh->rotation.z += 1 * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/loaders/svg_loader.cpp
+++ b/examples/loaders/svg_loader.cpp
@@ -184,7 +184,8 @@ int main() {
 
     Clock clock;
     canvas.animate([&]() {
-        renderer.render(scene, camera);
+
+        renderer.render(*scene, *camera);
 
 #ifdef HAS_IMGUI
 

--- a/examples/misc/raycast.cpp
+++ b/examples/misc/raycast.cpp
@@ -81,6 +81,6 @@ int main() {
             sphere->visible = true;
         }
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/objects/decal.cpp
+++ b/examples/objects/decal.cpp
@@ -202,7 +202,7 @@ int main() {
             }
         }
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
 #ifdef HAS_IMGUI
 

--- a/examples/objects/instancing.cpp
+++ b/examples/objects/instancing.cpp
@@ -107,6 +107,6 @@ int main() {
         counter.update(clock.getElapsedTime());
         handle.setText("FPS: " + std::to_string(counter.fps));
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/objects/lod.cpp
+++ b/examples/objects/lod.cpp
@@ -39,6 +39,6 @@ int main() {
 
         handle.setText("LOD level: " + std::to_string(lod->getCurrentLevel()));
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/objects/points.cpp
+++ b/examples/objects/points.cpp
@@ -58,6 +58,6 @@ int main() {
         points->rotation.x = t * 0.25f;
         points->rotation.y = t * 0.5f;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/objects/sprite.cpp
+++ b/examples/objects/sprite.cpp
@@ -62,6 +62,6 @@ int main() {
             helper->visible = true;
         }
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/objects/water.cpp
+++ b/examples/objects/water.cpp
@@ -87,6 +87,6 @@ int main() {
 
         water->material()->as<ShaderMaterial>()->uniforms->at("time").setValue(t);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/projects/Crane3R/main.cpp
+++ b/examples/projects/Crane3R/main.cpp
@@ -135,7 +135,7 @@ int main() {
 
         float dt = clock.getDelta();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         if (crane) {
 

--- a/examples/projects/Youbot/youbot.cpp
+++ b/examples/projects/Youbot/youbot.cpp
@@ -56,7 +56,7 @@ int main() {
 
         float dt = clock.getDelta();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         if (youbot) youbot->update(dt);
     });

--- a/examples/projects/Youbot/youbot_kine.cpp
+++ b/examples/projects/Youbot/youbot_kine.cpp
@@ -142,7 +142,7 @@ int main() {
 
         float dt = clock.getDelta();
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         if (youbot) {
 

--- a/examples/projects/snake/SnakeScene.hpp
+++ b/examples/projects/snake/SnakeScene.hpp
@@ -9,10 +9,10 @@
 using namespace threepp;
 
 
-class SnakeScene : public Scene, public KeyListener {
+class SnakeScene: public Scene, public KeyListener {
 
 public:
-    explicit SnakeScene(SnakeGame &game) : game_(game) {
+    explicit SnakeScene(SnakeGame& game): game_(game) {
 
         int size = game.gridSize();
         auto grid = GridHelper::create(size, size, 0x444444, 0x444444);
@@ -66,9 +66,9 @@ public:
         auto foodPos = game_.foodPos();
         food_->position.set(foodPos.x, foodPos.y, 0);
 
-        auto &positions = game_.snake().positions();
+        auto& positions = game_.snake().positions();
         for (unsigned i = 0; i < positions.size(); ++i) {
-            auto &pos = positions.at(i);
+            auto& pos = positions.at(i);
             if (positions.size() != snake_.size()) {
                 snake_.emplace_back(Mesh::create(boxGeometry_, snakeMaterial_));
                 add(snake_.back());
@@ -93,12 +93,12 @@ public:
         snakeMaterial_->color = Color::white;
     }
 
-    [[nodiscard]] OrthographicCamera &camera() const {
+    [[nodiscard]] OrthographicCamera& camera() const {
         return *camera_;
     }
 
 private:
-    SnakeGame &game_;
+    SnakeGame& game_;
     std::shared_ptr<Mesh> food_;
     std::shared_ptr<OrthographicCamera> camera_;
 

--- a/examples/projects/snake/main.cpp
+++ b/examples/projects/snake/main.cpp
@@ -30,6 +30,6 @@ int main() {
             scene->update();
 
         }
-        renderer.render(scene.get(), &scene->camera());
+        renderer.render(*scene, scene->camera());
     });
 }

--- a/examples/shaders/raw_shader.cpp
+++ b/examples/shaders/raw_shader.cpp
@@ -102,6 +102,6 @@ int main() {
         mesh->rotation.y = t * 0.5f;
         material->uniforms->at("time").setValue(t * 5);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/shaders/seascape_demo.cpp
+++ b/examples/shaders/seascape_demo.cpp
@@ -47,7 +47,7 @@ int main() {
         mesh->rotation.y = t;
         material->uniforms->at("iTime").setValue(t);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }
 

--- a/examples/textures/data_texture.cpp
+++ b/examples/textures/data_texture.cpp
@@ -93,7 +93,7 @@ int main() {
         sphere->rotation.x += 0.5f * dt;
 
         renderer.clear();
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
 
         vector.x = (size.width / 2) - (textureSize / 2);
         vector.y = (size.height / 2) - (textureSize / 2);
@@ -101,6 +101,6 @@ int main() {
         renderer.copyFramebufferToTexture(vector, *texture);
 
         renderer.clearDepth();
-        renderer.render(orthoScene, orthoCamera);
+        renderer.render(*orthoScene, *orthoCamera);
     });
 }

--- a/examples/textures/texture2d.cpp
+++ b/examples/textures/texture2d.cpp
@@ -72,6 +72,6 @@ int main() {
         box->rotation.y += 0.5f * dt;
         sphere->rotation.x += 0.5f * dt;
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }

--- a/examples/textures/texture3d.cpp
+++ b/examples/textures/texture3d.cpp
@@ -105,7 +105,7 @@ int main() {
         int step = std::floor(50 * std::sin(math::TWO_PI * 0.1f * t) + 50);
         material->uniforms->at("steps").value<int>() = std::max(1, step);
 
-        renderer.render(scene, camera);
+        renderer.render(*scene, *camera);
     });
 }
 

--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -131,9 +131,7 @@ namespace threepp {
 
         void dispose();
 
-        void render(Scene* scene, Camera* camera);
-
-        void render(const std::shared_ptr<Scene>& scene, const std::shared_ptr<Camera>& camera);
+        void render(Scene& scene, Camera& camera);
 
         void renderBufferDirect(Camera* camera, Scene* scene, BufferGeometry* geometry, Material* material, Object3D* object, std::optional<GeometryGroup> group);
 

--- a/src/threepp/objects/Reflector.cpp
+++ b/src/threepp/objects/Reflector.cpp
@@ -153,7 +153,7 @@ struct Reflector::Impl {
             _renderer->state().depthBuffer.setMask(true);// make sure the depth buffer is writable so it can be properly cleared, see #18897
 
             if (!_renderer->autoClear) _renderer->clear();
-            _renderer->render(scene, virtualCamera.get());
+            _renderer->render(*scene, *virtualCamera);
             _renderer->shadowMap().autoUpdate = currentShadowAutoUpdate;
             _renderer->setRenderTarget(currentRenderTarget);// Restore viewport
 

--- a/src/threepp/objects/Water.cpp
+++ b/src/threepp/objects/Water.cpp
@@ -241,7 +241,7 @@ struct Water::Impl {
             _renderer->state().depthBuffer.setMask(true);// make sure the depth buffer is writable so it can be properly cleared, see #18897
 
             if (!_renderer->autoClear) _renderer->clear();
-            _renderer->render(scene, mirrorCamera.get());
+            _renderer->render(*scene, *mirrorCamera);
             water_.visible = true;
             _renderer->shadowMap().autoUpdate = currentShadowAutoUpdate;
             _renderer->setRenderTarget(currentRenderTarget);// Restore viewport

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -1244,14 +1244,9 @@ void GLRenderer::dispose() {
     pimpl_->dispose();
 }
 
-void GLRenderer::render(Scene* scene, Camera* camera) {
+void GLRenderer::render(Scene& scene, Camera& camera) {
 
-    pimpl_->render(scene, camera);
-}
-
-void threepp::GLRenderer::render(const std::shared_ptr<Scene>& scene, const std::shared_ptr<Camera>& camera) {
-
-    render(scene.get(), camera.get());
+    pimpl_->render(&scene, &camera);
 }
 
 void GLRenderer::renderBufferDirect(Camera* camera, Scene* scene, BufferGeometry* geometry, Material* material, Object3D* object, std::optional<GeometryGroup> group) {


### PR DESCRIPTION
Breaking change.

Replaces raw and smart pointer function signatures for renderer.render. Use reference.