### PR TITLE
Decouple GLRenderer from Canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ auto createBox(const Vector3& pos, const Color& color) {
 int main() {
 
     Canvas canvas("Demo");
-    GLRenderer renderer{canvas};
+    GLRenderer renderer{canvas.size()};
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 100);
     camera->position.z = 5;
     
     OrbitControls controls{*camera, canvas};
@@ -119,7 +119,7 @@ int main() {
     scene->add(plane);
 
     canvas.onWindowResize([&](WindowSize size) {
-        camera->aspect = size.getAspect();
+        camera->aspect = size.aspect();
         camera->updateProjectionMatrix();
         renderer.setSize(size);
     });

--- a/examples/bullet/bullet_demo.cpp
+++ b/examples/bullet/bullet_demo.cpp
@@ -82,12 +82,12 @@ int main() {
     Canvas canvas(Canvas::Parameters().antialiasing(4));
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.set(-10, 10, 10);
 
     OrbitControls controls{*camera, canvas};
 
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     scene->add(HemisphereLight::create());

--- a/examples/bullet/instanced_physics.cpp
+++ b/examples/bullet/instanced_physics.cpp
@@ -78,13 +78,13 @@ namespace {
 int main() {
 
     Canvas canvas(Canvas::Parameters().antialiasing(4));
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.shadowMap().enabled = true;
     renderer.shadowMap().type = ShadowMap::PFCSoft;
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.set(-20, 10, 20);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/bullet/pid_control.cpp
+++ b/examples/bullet/pid_control.cpp
@@ -91,7 +91,7 @@ namespace {
 int main() {
 
     Canvas canvas;
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();

--- a/examples/demo.cpp
+++ b/examples/demo.cpp
@@ -102,10 +102,10 @@ int main() {
     Canvas canvas("threepp demo");
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 5;
 
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto box = createBox();
@@ -120,14 +120,14 @@ int main() {
 
     renderer.enableTextRendering();
     auto& handle = renderer.textHandle();
-    handle.setPosition(canvas.getSize().width - 130, 0);
+    handle.setPosition(canvas.size().width - 130, 0);
     handle.color = Color::red;
 
     canvas.onWindowResize([&](WindowSize size) {
         camera->aspect = size.getAspect();
         camera->updateProjectionMatrix();
         renderer.setSize(size);
-        handle.setPosition(canvas.getSize().width - 130, 0);
+        handle.setPosition(canvas.size().width - 130, 0);
     });
 
 #ifdef HAS_IMGUI

--- a/examples/extras/core/fonts.cpp
+++ b/examples/extras/core/fonts.cpp
@@ -10,13 +10,13 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("Fonts", {{"aa", 8}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.shadowMap().enabled = true;
     renderer.shadowMap().type = ShadowMap::PFCSoft;
 
     auto scene = Scene::create();
     scene->background = Color::black;
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 10000);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 10000);
     camera->position.set(0, 5, 40);
 
     auto light = DirectionalLight::create();

--- a/examples/extras/curves/catmull_room_curve3.cpp
+++ b/examples/extras/curves/catmull_room_curve3.cpp
@@ -7,11 +7,11 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("CatmullRoomCurve", {{"aa", 8}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.set(5, 10, 20);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/extras/curves/cubic_bezier_curve.cpp
+++ b/examples/extras/curves/cubic_bezier_curve.cpp
@@ -8,11 +8,11 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("CubicBezierCurve", {{"aa", 8}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.set(0, 5, 20);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/geometries/box_geometry.cpp
+++ b/examples/geometries/box_geometry.cpp
@@ -36,11 +36,11 @@ namespace {
 int main() {
 
     Canvas canvas("BoxGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::blue;
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.z = 5;
 
     BoxGeometry::Params params{};

--- a/examples/geometries/convex_geometry.cpp
+++ b/examples/geometries/convex_geometry.cpp
@@ -30,11 +30,11 @@ namespace {
 int main() {
 
     Canvas canvas("ConvexGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::blue;
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 1000);
     camera->position.set(0, 5, 30);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/geometries/cylinder_geometry.cpp
+++ b/examples/geometries/cylinder_geometry.cpp
@@ -37,11 +37,11 @@ namespace {
 int main() {
 
     Canvas canvas("CylinderGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::blue;
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.z = 5;
 
     CylinderGeometry::Params params{};

--- a/examples/geometries/geometries.cpp
+++ b/examples/geometries/geometries.cpp
@@ -110,10 +110,10 @@ namespace {
 int main() {
 
     Canvas canvas("Geometries", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.z = 8;
 
     TextureLoader tl;

--- a/examples/geometries/lathe_geometry.cpp
+++ b/examples/geometries/lathe_geometry.cpp
@@ -42,11 +42,11 @@ namespace {
 int main() {
 
     Canvas canvas("LatheGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::gray;
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 5;
 
     OrbitControls controls{*camera, canvas};

--- a/examples/geometries/plane_geometry.cpp
+++ b/examples/geometries/plane_geometry.cpp
@@ -37,11 +37,11 @@ namespace {
 int main() {
 
     Canvas canvas("PlaneGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::blue;
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.z = 5;
 
     PlaneGeometry::Params params{};

--- a/examples/geometries/shape_geometry.cpp
+++ b/examples/geometries/shape_geometry.cpp
@@ -94,11 +94,11 @@ std::shared_ptr<Mesh> createMesh(const Shape& shape, float scale = 1) {
 int main() {
 
     Canvas canvas("ShapeGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::blue;
-    auto camera = PerspectiveCamera::create(65, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(65, canvas.aspect(), 0.1f, 1000);
     camera->position.set(0, 0, 60);
 
     auto light1 = DirectionalLight::create(0xffffff, 0.7f);

--- a/examples/geometries/sphere_geometry.cpp
+++ b/examples/geometries/sphere_geometry.cpp
@@ -37,11 +37,11 @@ namespace {
 int main() {
 
     Canvas canvas("SphereGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = Color::blue;
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.z = 5;
 
     SphereGeometry::Params params{};

--- a/examples/geometries/tube_geometry.cpp
+++ b/examples/geometries/tube_geometry.cpp
@@ -27,10 +27,10 @@ namespace {
 int main() {
 
     Canvas canvas("TubeGeometry", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 20;
 
     OrbitControls controls{*camera, canvas};

--- a/examples/helpers/camera_helper.cpp
+++ b/examples/helpers/camera_helper.cpp
@@ -28,16 +28,16 @@ namespace {
 int main() {
 
     Canvas canvas{"Camera helper"};
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.autoClear = false;
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, 0.5f * canvas.getAspect(), 1, 10);
+    auto camera = PerspectiveCamera::create(60, 0.5f * canvas.aspect(), 1, 10);
 
     auto sphere = createSphere();
     scene->add(sphere);
 
-    auto camera2 = PerspectiveCamera::create(50, 0.5f * canvas.getAspect(), 1, 1000);
+    auto camera2 = PerspectiveCamera::create(50, 0.5f * canvas.aspect(), 1, 1000);
     camera2->position.x = 30;
 
     OrbitControls controls{*camera2, canvas};
@@ -57,7 +57,7 @@ int main() {
 
     Clock clock;
     canvas.animate([&]() {
-        auto size = canvas.getSize();
+        auto size = canvas.size();
 
         renderer.clear();
 

--- a/examples/helpers/helpers.cpp
+++ b/examples/helpers/helpers.cpp
@@ -11,10 +11,10 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("Helpers");
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 2;
     camera->position.y = 1;
 

--- a/examples/lights/directional.cpp
+++ b/examples/lights/directional.cpp
@@ -58,13 +58,13 @@ namespace {
 int main() {
 
     Canvas canvas("DirectionalLight", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.shadowMap().enabled = true;
     renderer.shadowMap().type = ShadowMap::PFCSoft;
     renderer.toneMapping = ToneMapping::ACESFilmic;
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.set(-5, 2, -5);
 
     auto light = DirectionalLight::create();

--- a/examples/lights/hemi_light.cpp
+++ b/examples/lights/hemi_light.cpp
@@ -30,10 +30,10 @@ namespace {
 int main() {
 
     Canvas canvas("HemisphereLight", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 100);
     camera->position.set(5, 2, 5);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/lights/point_light.cpp
+++ b/examples/lights/point_light.cpp
@@ -41,11 +41,11 @@ namespace {
 int main() {
 
     Canvas canvas("PointLight", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.shadowMap().enabled = true;
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 100);
     camera->position.set(5, 3, 5);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/lights/spot_light.cpp
+++ b/examples/lights/spot_light.cpp
@@ -40,11 +40,11 @@ namespace {
 int main() {
 
     Canvas canvas("SpotLight", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.shadowMap().enabled = true;
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 100);
     camera->position.set(0, 10, 25);
 
     OrbitControls controls{*camera, canvas};

--- a/examples/loaders/assimp_loader.cpp
+++ b/examples/loaders/assimp_loader.cpp
@@ -45,11 +45,11 @@ namespace {
 int main() {
 
     Canvas canvas{Canvas::Parameters().antialiasing(4)};
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.set(0, 100, 175);
 
     float sep = 40;

--- a/examples/loaders/obj_loader.cpp
+++ b/examples/loaders/obj_loader.cpp
@@ -20,10 +20,10 @@ void createAndAddLights(Scene& scene) {
 int main() {
 
     Canvas canvas{Canvas::Parameters().antialiasing(8)};
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.set(0, 100, 150);
 
     OBJLoader loader;

--- a/examples/loaders/stl_loader.cpp
+++ b/examples/loaders/stl_loader.cpp
@@ -6,11 +6,11 @@ using namespace threepp;
 int main() {
 
     Canvas canvas{Canvas::Parameters().antialiasing(4)};
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 100);
     camera->position.z = 1;
 
     OrbitControls controls{*camera, canvas};

--- a/examples/loaders/svg_loader.cpp
+++ b/examples/loaders/svg_loader.cpp
@@ -138,10 +138,10 @@ int main() {
     Canvas canvas("SVGLoader", {{"antialiasing", 4}});
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 100;
 
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto gridHelper = GridHelper::create(160, 10);

--- a/examples/misc/raycast.cpp
+++ b/examples/misc/raycast.cpp
@@ -8,11 +8,11 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("Raycast");
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->layers.enableAll();
     camera->position.z = 5;
 
@@ -56,7 +56,7 @@ int main() {
         // calculate mouse position in normalized device coordinates
         // (-1 to +1) for both components
 
-        auto size = canvas.getSize();
+        auto size = canvas.size();
         mouse.x = (pos.x / static_cast<float>(size.width)) * 2 - 1;
         mouse.y = -(pos.y / static_cast<float>(size.height)) * 2 + 1;
     });

--- a/examples/objects/decal.cpp
+++ b/examples/objects/decal.cpp
@@ -61,7 +61,7 @@ namespace {
         bool mouseDown = false;
 
         void updateMousePos(Vector2 pos) {
-            auto& size = canvas.getSize();
+            auto& size = canvas.size();
             mouse.x = (pos.x / static_cast<float>(size.width)) * 2 - 1;
             mouse.y = -(pos.y / static_cast<float>(size.height)) * 2 + 1;
         }
@@ -108,10 +108,10 @@ namespace {
 int main() {
 
     Canvas canvas{"Decals", {{"aa", 8}}};
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 100);
     camera->position.set(0, 1, 10);
 
     addLights(*scene);

--- a/examples/objects/instancing.cpp
+++ b/examples/objects/instancing.cpp
@@ -31,14 +31,14 @@ namespace {
 int main() {
 
     Canvas canvas("Instancing", {{"aa", 4}, {"vsync", false}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     int amount = 10;
     int count = static_cast<int>(std::pow(amount, 3));
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 10000);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 10000);
     camera->position.set(amount, amount, amount);
 
     OrbitControls controls{*camera, canvas};
@@ -76,7 +76,7 @@ int main() {
 
     Vector2 mouse{-Infinity<float>, -Infinity<float>};
     MouseMoveListener l([&](auto& pos) {
-        auto size = canvas.getSize();
+        auto size = canvas.size();
         mouse.x = (pos.x / static_cast<float>(size.width)) * 2 - 1;
         mouse.y = -(pos.y / static_cast<float>(size.height)) * 2 + 1;
     });

--- a/examples/objects/lod.cpp
+++ b/examples/objects/lod.cpp
@@ -7,10 +7,10 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("LOD");
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 10);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 10);
     camera->position.z = -5;
 
     OrbitControls controls{*camera, canvas};

--- a/examples/objects/points.cpp
+++ b/examples/objects/points.cpp
@@ -6,12 +6,12 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("Points", {{"aa", 8}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = Scene::create();
     scene->background = 0x050505;
     scene->fog = Fog(0x050505, 2000, 3500);
-    auto camera = PerspectiveCamera::create(27, canvas.getAspect(), 5, 3500);
+    auto camera = PerspectiveCamera::create(27, canvas.aspect(), 5, 3500);
     camera->position.z = 2750;
 
     canvas.onWindowResize([&](WindowSize size) {

--- a/examples/objects/sprite.cpp
+++ b/examples/objects/sprite.cpp
@@ -6,11 +6,11 @@ using namespace threepp;
 int main() {
 
     Canvas canvas{"Sprite", {{"aa", 4}, {"favicon", "data/textures/three.png"}}};
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 8;
 
     OrbitControls controls{*camera, canvas};
@@ -42,7 +42,7 @@ int main() {
 
     Vector2 mouse{-Infinity<float>, -Infinity<float>};
     MouseMoveListener l([&](auto &pos) {
-        auto size = canvas.getSize();
+        auto size = canvas.size();
         mouse.x = (pos.x / static_cast<float>(size.width)) * 2 - 1;
         mouse.y = -(pos.y / static_cast<float>(size.height)) * 2 + 1;
     });

--- a/examples/objects/water.cpp
+++ b/examples/objects/water.cpp
@@ -13,7 +13,7 @@ int main() {
     Canvas canvas("Water", {{"aa", 4}});
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(55, canvas.getAspect(), 1, 2000);
+    auto camera = PerspectiveCamera::create(55, canvas.aspect(), 1, 2000);
     camera->position.set(-300, 120, -150);
 
     OrbitControls controls{*camera, canvas};
@@ -27,7 +27,7 @@ int main() {
     light->position.set(100, 10, 100);
     scene->add(light);
 
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.checkShaderErrors = true;
     renderer.toneMapping = ToneMapping::ACESFilmic;
 

--- a/examples/projects/Crane3R/main.cpp
+++ b/examples/projects/Crane3R/main.cpp
@@ -68,10 +68,10 @@ struct MyUI: ImguiContext {
 int main() {
 
     Canvas canvas{"Crane3R", {{"size", WindowSize{1280, 720}}, {"antialiasing", 8}}};
-    GLRenderer renderer{canvas};
+    GLRenderer renderer{canvas.size()};
     renderer.setClearColor(Color::aliceblue);
 
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.01, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.01, 100);
     camera->position.set(-15, 8, 15);
 
     OrbitControls controls(*camera, canvas);

--- a/examples/projects/Youbot/youbot.cpp
+++ b/examples/projects/Youbot/youbot.cpp
@@ -11,12 +11,12 @@ using namespace threepp;
 int main() {
 
     Canvas canvas{Canvas::Parameters().size({1280, 720}).antialiasing(8)};
-    GLRenderer renderer{canvas};
+    GLRenderer renderer{canvas.size()};
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
 
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.01, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.01, 100);
     camera->position.set(-15, 8, 15);
 
     OrbitControls controls(*camera, canvas);

--- a/examples/projects/Youbot/youbot_kine.cpp
+++ b/examples/projects/Youbot/youbot_kine.cpp
@@ -65,12 +65,12 @@ struct MyUI: ImguiContext {
 int main() {
 
     Canvas canvas{Canvas::Parameters().size({1280, 720}).antialiasing(8)};
-    GLRenderer renderer{canvas};
+    GLRenderer renderer{canvas.size()};
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
 
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.01, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.01, 100);
     camera->position.set(-15, 8, 15);
 
     OrbitControls controls(*camera, canvas);

--- a/examples/projects/snake/main.cpp
+++ b/examples/projects/snake/main.cpp
@@ -6,7 +6,7 @@ int main() {
     SnakeGame game(10);
 
     Canvas canvas("Snake");
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
 
     auto scene = std::make_shared<SnakeScene>(game);
     canvas.addKeyListener(scene.get());

--- a/examples/shaders/raw_shader.cpp
+++ b/examples/shaders/raw_shader.cpp
@@ -50,11 +50,11 @@ int main() {
 
     Canvas canvas("Raw Shader demo", {{"antialiasing", 4}});
 
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.checkShaderErrors = true;
     auto scene = Scene::create();
 
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 1, 10);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 1, 10);
     camera->position.z = 2;
 
     int triangles = 1000;

--- a/examples/shaders/seascape_demo.cpp
+++ b/examples/shaders/seascape_demo.cpp
@@ -14,16 +14,16 @@ int main() {
 
     Canvas canvas("Seascape demo", {{"antialiasing", 4}});
 
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.checkShaderErrors = true;
     auto scene = Scene::create();
 
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 1, 1000000);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 1, 1000000);
     camera->position.y = 100;
 
     auto geometry = BoxGeometry::create(1000, 1000, 1000);
 
-    auto size = canvas.getSize();
+    auto size = canvas.size();
     auto material = RawShaderMaterial::create();
     (*material->uniforms)["iTime"] = Uniform();
     (*material->uniforms)["iResolution"] = Uniform(Vector2(size.width, size.height));

--- a/examples/textures/data_texture.cpp
+++ b/examples/textures/data_texture.cpp
@@ -22,16 +22,16 @@ namespace {
 int main() {
 
     Canvas canvas("Data texture", {{"aa", 4}});
-    GLRenderer renderer{canvas};
+    GLRenderer renderer{canvas.size()};
     renderer.autoClear = false;
     renderer.setClearColor(Color::aliceblue);
 
-    const auto& size = canvas.getSize();
+    const auto& size = canvas.size();
 
     auto scene = Scene::create();
     auto orthoScene = Scene::create();
 
-    auto camera = PerspectiveCamera::create(70, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(70, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 10;
 
     auto orthoCamera = OrthographicCamera::create(-size.width / 2, size.width / 2, size.height / 2, -size.height / 2, 1, 10);

--- a/examples/textures/texture2d.cpp
+++ b/examples/textures/texture2d.cpp
@@ -9,11 +9,11 @@ using namespace threepp;
 int main() {
 
     Canvas canvas("Texture2D", {{"aa", 8}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.setClearColor(Color::aliceblue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(75, canvas.getAspect(), 0.1f, 1000);
+    auto camera = PerspectiveCamera::create(75, canvas.aspect(), 0.1f, 1000);
     camera->position.z = 5;
 
     OrbitControls controls{*camera, canvas};

--- a/examples/textures/texture3d.cpp
+++ b/examples/textures/texture3d.cpp
@@ -63,12 +63,12 @@ namespace {
 int main() {
 
     Canvas canvas("DataTexture3D", {{"aa", 4}});
-    GLRenderer renderer(canvas);
+    GLRenderer renderer(canvas.size());
     renderer.checkShaderErrors = true;
     renderer.setClearColor(Color::blue);
 
     auto scene = Scene::create();
-    auto camera = PerspectiveCamera::create(60, canvas.getAspect(), 0.1f, 100);
+    auto camera = PerspectiveCamera::create(60, canvas.aspect(), 0.1f, 100);
     camera->position.z = 1.5f;
 
     OrbitControls controls{*camera, canvas};

--- a/include/threepp/canvas/Canvas.hpp
+++ b/include/threepp/canvas/Canvas.hpp
@@ -27,9 +27,9 @@ namespace threepp {
 
         Canvas(const std::string& name, const std::unordered_map<std::string, ParameterValue>& values);
 
-        [[nodiscard]] const WindowSize& getSize() const;
+        [[nodiscard]] const WindowSize& size() const;
 
-        [[nodiscard]] float getAspect() const;
+        [[nodiscard]] float aspect() const;
 
         void setSize(WindowSize size);
 

--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -74,7 +74,7 @@ namespace threepp {
 
         bool checkShaderErrors = false;
 
-        explicit GLRenderer(Canvas& canvas, const Parameters& parameters = {});
+        explicit GLRenderer(WindowSize size, const Parameters& parameters = {});
 
         const gl::GLInfo& info();
 

--- a/src/threepp/canvas/Canvas.cpp
+++ b/src/threepp/canvas/Canvas.cpp
@@ -321,14 +321,14 @@ bool Canvas::animateOnce(const std::function<void()>& f) {
     return pimpl_->animateOnce(f);
 }
 
-const WindowSize& Canvas::getSize() const {
+const WindowSize& Canvas::size() const {
 
     return pimpl_->getSize();
 }
 
-float Canvas::getAspect() const {
+float Canvas::aspect() const {
 
-    return getSize().getAspect();
+    return size().getAspect();
 }
 
 void Canvas::setSize(WindowSize size) {

--- a/src/threepp/controls/FlyControls.cpp
+++ b/src/threepp/controls/FlyControls.cpp
@@ -243,8 +243,8 @@ struct FlyControls::Impl {
 
             if (!scope.dragToLook || scope.pimpl_->mouseStatus > 0) {
 
-                const float halfWidth = static_cast<float>(scope.pimpl_->canvas.getSize().width) / 2;
-                const float halfHeight = static_cast<float>(scope.pimpl_->canvas.getSize().height) / 2;
+                const float halfWidth = static_cast<float>(scope.pimpl_->canvas.size().width) / 2;
+                const float halfHeight = static_cast<float>(scope.pimpl_->canvas.size().height) / 2;
 
                 scope.pimpl_->moveState.yawLeft = -((pos.x) - halfWidth) / halfWidth;
                 scope.pimpl_->moveState.pitchDown = ((pos.y) - halfHeight) / halfHeight;

--- a/src/threepp/controls/OrbitControls.cpp
+++ b/src/threepp/controls/OrbitControls.cpp
@@ -228,12 +228,12 @@ struct OrbitControls::Impl {
             targetDistance *= std::tan((perspective->fov / 2) * math::PI / 180.f);
 
             // we use only clientHeight here so aspect ratio does not distort speed
-            const auto size = canvas.getSize();
+            const auto size = canvas.size();
             panLeft(2 * deltaX * targetDistance / (float) size.height, *this->camera.matrix);
             panUp(2 * deltaY * targetDistance / (float) size.height, *this->camera.matrix);
         } else if (auto ortho = camera.as<OrthographicCamera>()) {
 
-            const auto size = canvas.getSize();
+            const auto size = canvas.size();
 
             // orthographic
             panLeft(
@@ -333,7 +333,7 @@ struct OrbitControls::Impl {
 
         rotateDelta.subVectors(rotateEnd, rotateStart).multiplyScalar(scope.rotateSpeed);
 
-        const auto size = canvas.getSize();
+        const auto size = canvas.size();
         rotateLeft(2 * math::PI * rotateDelta.x / static_cast<float>(size.height));// yes, height
 
         rotateUp(2 * math::PI * rotateDelta.y / static_cast<float>(size.height));

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -57,7 +57,6 @@ struct GLRenderer::Impl {
         GLRenderer::Impl* scope_;
     };
 
-    Canvas& canvas_;
     GLRenderer& scope;
 
     gl::GLState state;
@@ -132,13 +131,13 @@ struct GLRenderer::Impl {
     std::unique_ptr<gl::GLIndexedBufferRenderer> indexedBufferRenderer;
 
 
-    Impl(GLRenderer& scope, Canvas& canvas, const GLRenderer::Parameters& parameters)
-        : scope(scope), canvas_(canvas), _size(canvas.getSize()),
+    Impl(GLRenderer& scope, WindowSize size, const GLRenderer::Parameters& parameters)
+        : scope(scope), _size(size),
           _viewport(0, 0, _size.width, _size.height),
           _scissor(0, 0, _size.width, _size.height),
           background(state, parameters.premultipliedAlpha),
-          bufferRenderer(new gl::GLBufferRenderer(_info)),
-          indexedBufferRenderer(new gl::GLIndexedBufferRenderer(_info)),
+          bufferRenderer(std::make_unique<gl::GLBufferRenderer>(_info)),
+          indexedBufferRenderer(std::make_unique<gl::GLIndexedBufferRenderer>(_info)),
           clipping(properties),
           bindingStates(attributes),
           geometries(attributes, _info, bindingStates),
@@ -1086,8 +1085,8 @@ struct GLRenderer::Impl {
 };
 
 
-GLRenderer::GLRenderer(Canvas& canvas, const GLRenderer::Parameters& parameters)
-    : pimpl_(std::make_unique<Impl>(*this, canvas, parameters)) {}
+GLRenderer::GLRenderer(WindowSize size, const GLRenderer::Parameters& parameters)
+    : pimpl_(std::make_unique<Impl>(*this, size, parameters)) {}
 
 
 const gl::GLInfo& threepp::GLRenderer::info() {
@@ -1133,8 +1132,6 @@ void GLRenderer::setSize(WindowSize size) {
     int canvasWidth = pimpl_->_size.width * pimpl_->_pixelRatio;
     int canvasHeight = pimpl_->_size.height * pimpl_->_pixelRatio;
 
-    pimpl_->canvas_.setSize({canvasWidth, canvasHeight});
-
     this->setViewport(0, 0, size.width, size.height);
 }
 
@@ -1149,8 +1146,6 @@ void GLRenderer::setDrawingBufferSize(int width, int height, int pixelRatio) {
     pimpl_->_size.height = height;
 
     pimpl_->_pixelRatio = pixelRatio;
-
-    pimpl_->canvas_.setSize({width * pixelRatio, height * pixelRatio});
 
     this->setViewport(0, 0, width, height);
 }

--- a/tests/math/Box3_test.cpp
+++ b/tests/math/Box3_test.cpp
@@ -144,7 +144,7 @@ TEST_CASE("getCenter") {
     CHECK(center.equals(midpoint));
 }
 
-TEST_CASE("getSize") {
+TEST_CASE("size") {
 
     Box3 a(zero3, zero3);
     Vector3 size;


### PR DESCRIPTION
GLRenderer now takes a WindowSize rather than Canvas. This change means that the canvas will no longer be automatically adjusted when the GLRenderer::setSize() is invoked.

Also renamed Canvas::getSize and getAspect