### PR TITLE
Refactor text rendering

### DIFF
--- a/examples/bullet/bullet_demo.cpp
+++ b/examples/bullet/bullet_demo.cpp
@@ -152,8 +152,8 @@ int main() {
     });
     canvas.addKeyListener(&keyListener);
 
-    renderer.enableTextRendering();
-    auto& handle = renderer.textHandle();
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle();
 
     Clock clock;
     canvas.animate([&]() {
@@ -161,9 +161,12 @@ int main() {
         bullet.step(dt);
 
         renderer.render(*scene, *camera);
+        renderer.resetState();
 
         std::stringstream ss;
         ss << renderer.info();
         handle.setText(ss.str());
+
+        textRenderer.render();
     });
 }

--- a/examples/bullet/instanced_physics.cpp
+++ b/examples/bullet/instanced_physics.cpp
@@ -157,8 +157,8 @@ int main() {
     });
     canvas.addKeyListener(&keyListener);
 
-    renderer.enableTextRendering();
-    auto& handle = renderer.textHandle();
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle();
 
     Clock clock;
     canvas.animate([&]() {
@@ -166,9 +166,12 @@ int main() {
         bullet.step(dt);
 
         renderer.render(*scene, *camera);
+        renderer.resetState();
 
         std::stringstream ss;
         ss << renderer.info();
         handle.setText(ss.str());
+
+        textRenderer.render();
     });
 }

--- a/examples/demo.cpp
+++ b/examples/demo.cpp
@@ -118,9 +118,14 @@ int main() {
     scene->add(plane);
 
     TextRenderer textRenderer;
-    auto& handle = textRenderer.createHandle("Hello");
+    auto& handle = textRenderer.createHandle();
     handle.setPosition(canvas.size().width - 130, 0);
     handle.color = Color::red;
+
+    auto& handle2 = textRenderer.createHandle("Hello world!");
+    handle2.setPosition(0, canvas.size().height - 35);
+    handle2.color = Color::white;
+    handle2.scale = 2;
 
     canvas.onWindowResize([&](WindowSize size) {
         camera->aspect = size.aspect();

--- a/examples/demo.cpp
+++ b/examples/demo.cpp
@@ -117,8 +117,8 @@ int main() {
     auto planeMaterial = plane->material()->as<MeshBasicMaterial>();
     scene->add(plane);
 
-    renderer.enableTextRendering();
-    auto& handle = renderer.textHandle();
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle("Hello");
     handle.setPosition(canvas.size().width - 130, 0);
     handle.color = Color::red;
 
@@ -140,6 +140,8 @@ int main() {
         handle.setText("Delta=" + std::to_string(dt));
 
         renderer.render(*scene, *camera);
+        renderer.resetState();
+        textRenderer.render();
 
 #ifdef HAS_IMGUI
         ui.render();

--- a/examples/objects/instancing.cpp
+++ b/examples/objects/instancing.cpp
@@ -82,12 +82,11 @@ int main() {
     });
     canvas.addMouseListener(&l);
 
-    renderer.enableTextRendering();
-    auto& handle = renderer.textHandle();
-
-    FPSCounter counter;
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle();
 
     Clock clock;
+    FPSCounter counter;
     Raycaster raycaster;
     std::unordered_map<int, bool> map;
     canvas.animate([&]() {
@@ -107,5 +106,7 @@ int main() {
         handle.setText("FPS: " + std::to_string(counter.fps));
 
         renderer.render(*scene, *camera);
+        renderer.resetState();
+        textRenderer.render();
     });
 }

--- a/examples/objects/lod.cpp
+++ b/examples/objects/lod.cpp
@@ -32,12 +32,14 @@ int main() {
         renderer.setSize(size);
     });
 
-    renderer.enableTextRendering();
-    auto& handle = renderer.textHandle();
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle();
 
     canvas.animate([&]() {
         handle.setText("LOD level: " + std::to_string(lod.getCurrentLevel()));
 
         renderer.render(scene, camera);
+        renderer.resetState();
+        textRenderer.render();
     });
 }

--- a/examples/projects/Youbot/youbot.cpp
+++ b/examples/projects/Youbot/youbot.cpp
@@ -31,7 +31,8 @@ int main() {
     auto light2 = AmbientLight::create(0xffffff, 1.f);
     scene->add(light2);
 
-    auto& handle = renderer.textHandle("Loading model..");
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle("Loading model..");
     handle.scale = 2;
 
     utils::ThreadPool pool;
@@ -56,6 +57,9 @@ int main() {
         float dt = clock.getDelta();
 
         renderer.render(*scene, *camera);
+        renderer.resetState();
+
+        textRenderer.render();
 
         if (youbot) youbot->update(dt);
     });

--- a/examples/projects/Youbot/youbot_kine.cpp
+++ b/examples/projects/Youbot/youbot_kine.cpp
@@ -91,7 +91,8 @@ int main() {
     auto targetHelper = AxesHelper::create(2);
     targetHelper->visible = false;
 
-    auto& handle = renderer.textHandle("Loading model..");
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle("Loading model..");
     handle.scale = 2;
 
     utils::ThreadPool pool;
@@ -167,6 +168,10 @@ int main() {
 
             youbot->setJointValues(ui.values);
             youbot->update(dt);
+        } else {
+
+            renderer.resetState();
+            textRenderer.render();
         }
     });
 }

--- a/examples/projects/snake/main.cpp
+++ b/examples/projects/snake/main.cpp
@@ -16,8 +16,8 @@ int main() {
         renderer.setSize(size);
     });
 
-    renderer.enableTextRendering();
-    renderer.textHandle("Press \"r\" to reset");
+    TextRenderer textRenderer;
+    auto& handle = textRenderer.createHandle("Press \"r\" to reset");
 
     Clock clock;
     canvas.animate([&]() {
@@ -29,5 +29,8 @@ int main() {
             scene.update();
         }
         renderer.render(scene, scene.camera());
+        renderer.resetState();
+
+        textRenderer.render();
     });
 }

--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -17,8 +17,6 @@
 #include "threepp/renderers/gl/GLShadowMap.hpp"
 #include "threepp/renderers/gl/GLState.hpp"
 
-#include "TextHandle.hpp"
-
 #include <memory>
 #include <vector>
 
@@ -148,9 +146,11 @@ namespace threepp {
 
         void readPixels(const Vector2& position, const WindowSize& size, Format format, unsigned char* data);
 
-        void enableTextRendering();
+        void resetState();
 
-        TextHandle& textHandle(const std::string& str = "");
+//        void enableTextRendering();
+
+//        TextHandle& textHandle(const std::string& str = "");
 
         [[nodiscard]] const gl::GLInfo& info() const;
 

--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -148,10 +148,6 @@ namespace threepp {
 
         void resetState();
 
-//        void enableTextRendering();
-
-//        TextHandle& textHandle(const std::string& str = "");
-
         [[nodiscard]] const gl::GLInfo& info() const;
 
         ~GLRenderer();

--- a/include/threepp/renderers/TextRenderer.hpp
+++ b/include/threepp/renderers/TextRenderer.hpp
@@ -1,11 +1,12 @@
 
-#ifndef THREEPP_TEXTHANDLE_HPP
-#define THREEPP_TEXTHANDLE_HPP
+#ifndef THREEPP_TEXTRENDERER_HPP
+#define THREEPP_TEXTRENDERER_HPP
 
 #include "threepp/math/Color.hpp"
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace threepp {
 
@@ -33,7 +34,6 @@ namespace threepp {
         HorizontalAlignment horizontalAlignment{HorizontalAlignment::LEFT};
         VerticalAlignment verticalAlignment{VerticalAlignment::TOP};
 
-        explicit TextHandle(const std::string& str);
 
         void setText(const std::string& str);
 
@@ -58,20 +58,42 @@ namespace threepp {
 
         bool invalidate_ = false;
 
+        explicit TextHandle(const std::string& str);
+
         void render();
 
-        static void setViewport(int width, int height);
-
-        static bool init();
-
-        static void beginDraw(bool blendingEnabled);
-        static void endDraw(bool blendingEnabled);
-
-        static void terminate();
-
-        friend class GLRenderer;
+        friend class TextRenderer;
     };
+
+
+    class TextRenderer {
+
+    public:
+        TextRenderer();
+
+        TextRenderer(TextRenderer&&) = delete;
+        TextRenderer(const TextRenderer&) = delete;
+        TextRenderer& operator=(const TextRenderer&) = delete;
+
+        void setViewport(int width, int height);
+
+        TextHandle& createHandle(const std::string& text = "") {
+
+            auto handle = std::unique_ptr<TextHandle>(new TextHandle(text));
+            textHandles_.emplace_back(std::move(handle));
+
+            return *textHandles_.back();
+        }
+
+        void render();
+
+        ~TextRenderer();
+
+    private:
+        std::vector<std::unique_ptr<TextHandle>> textHandles_;
+    };
+
 
 }// namespace threepp
 
-#endif//THREEPP_TEXTHANDLE_HPP
+#endif//THREEPP_TEXTRENDERER_HPP

--- a/include/threepp/renderers/gl/GLState.hpp
+++ b/include/threepp/renderers/gl/GLState.hpp
@@ -150,7 +150,7 @@ namespace threepp {
 
             bool bindFramebuffer(int target, unsigned int framebuffer);
 
-            bool useProgram(unsigned int program, bool force);
+            bool useProgram(unsigned int program);
 
             void setBlending(
                     Blending blending,

--- a/include/threepp/threepp.hpp
+++ b/include/threepp/threepp.hpp
@@ -34,6 +34,7 @@
 #include "threepp/cameras/PerspectiveCamera.hpp"
 
 #include "threepp/renderers/GLRenderer.hpp"
+#include "threepp/renderers/TextRenderer.hpp"
 
 #include "threepp/loaders/loaders.hpp"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,9 +174,9 @@ set(publicHeaders
         "threepp/lights/SpotLight.hpp"
         "threepp/lights/SpotLightShadow.hpp"
 
-        "threepp/renderers/TextHandle.hpp"
         "threepp/renderers/GLRenderer.hpp"
         "threepp/renderers/GLRenderTarget.hpp"
+        "threepp/renderers/TextRenderer.hpp"
 
         "threepp/renderers/gl/GLInfo.hpp"
         "threepp/renderers/gl/GLShadowMap.hpp"

--- a/src/threepp/renderers/TextHandle.cpp
+++ b/src/threepp/renderers/TextHandle.cpp
@@ -1,8 +1,7 @@
 
-#include "threepp/renderers/TextHandle.hpp"
+#include "threepp/renderers/TextRenderer.hpp"
 
 #define GLT_IMPLEMENTATION
-#define GLT_MANUAL_VIEWPORT
 #include <glad/glad.h>
 #include <gltext.h>
 
@@ -52,10 +51,6 @@ TextHandle::TextHandle(const std::string& str)
     setText(str);
 }
 
-bool TextHandle::init() {
-    return gltInit();
-}
-
 void TextHandle::setText(const std::string& str) {
     gltSetText(pimpl_->text, str.c_str());
 }
@@ -65,30 +60,40 @@ void TextHandle::render() {
     gltDrawText2DAligned(pimpl_->text, static_cast<float>(x), static_cast<float>(y), scale, getValue(horizontalAlignment), getValue(verticalAlignment));
 }
 
-void TextHandle::setViewport(int width, int height) {
+TextHandle::~TextHandle() = default;
+
+TextRenderer::TextRenderer() {
+    gltInit();
+}
+
+TextRenderer::~TextRenderer() {
+    gltTerminate();
+}
+
+void TextRenderer::setViewport(int width, int height) {
     if (width > 0 && height > 0) {
         gltViewport(width, height);
     }
 }
 
-void TextHandle::terminate() {
-    gltTerminate();
-}
+void TextRenderer::render() {
 
-void TextHandle::beginDraw(bool blendingEnabled) {
-    if (!blendingEnabled) {
-        glEnable(GL_BLEND);
-    }
-    glDisable(GL_DEPTH_TEST);
+    if (textHandles_.empty()) return;
+
+    glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
     gltBeginDraw();
-}
 
-void TextHandle::endDraw(bool blendingEnabled) {
-    gltEndDraw();
-    if (!blendingEnabled) {
-        glDisable(GL_BLEND);
+    auto it = textHandles_.begin();
+    while (it != textHandles_.end()) {
+
+        if ((*it)->invalidate_) {
+            it = textHandles_.erase(it);
+        } else {
+            (*it)->render();
+            ++it;
+        }
     }
-    glEnable(GL_DEPTH_TEST);
-}
 
-TextHandle::~TextHandle() = default;
+    gltEndDraw();
+    glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+}

--- a/src/threepp/renderers/gl/GLState.cpp
+++ b/src/threepp/renderers/gl/GLState.cpp
@@ -386,9 +386,9 @@ bool gl::GLState::bindFramebuffer(int target, unsigned int framebuffer) {
     return false;
 }
 
-bool gl::GLState::useProgram(unsigned int program, bool force) {
+bool gl::GLState::useProgram(unsigned int program) {
 
-    if (force || currentProgram != program) {
+    if (currentProgram != program) {
 
         glUseProgram(program);
 


### PR DESCRIPTION
This PR decouples GLRenderer from text rendering using glText.

Added GLRenderer::resetState that should be used to correctly render text.

```cpp
TextRenderer textRenderer;
auto& handle = textRenderer.createHandle("Hello World!");
handle.color = Color::red;

canvas.animate([&]() {
  renderer.render(*scene, *camera);
  renderer.resetState();

  textRenderer.render();
}
```