### PR TITLE
Expose GLTextureId through API

### DIFF
--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -154,6 +154,8 @@ namespace threepp {
 
         [[nodiscard]] const gl::GLInfo& info() const;
 
+        [[nodiscard]] std::optional<unsigned int> getGlTextureId(const Texture& texture) const;
+
         ~GLRenderer();
 
     private:

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -151,6 +151,11 @@ struct GLRenderer::Impl {
           _currentDrawBuffers(GL_BACK),
           onMaterialDispose(this) {}
 
+    [[nodiscard]] std::optional<unsigned int> getGlTextureId(const Texture& texture) const {
+
+        return textures.getGlTexture(texture);
+    }
+
     void deallocateMaterial(Material* material) {
 
         releaseMaterialProgramReferences(material);
@@ -1313,6 +1318,11 @@ int threepp::GLRenderer::getActiveMipmapLevel() const {
 GLRenderTarget* threepp::GLRenderer::getRenderTarget() {
 
     return pimpl_->_currentRenderTarget;
+}
+
+std::optional<unsigned int> GLRenderer::getGlTextureId(const Texture& texture) const {
+
+    return pimpl_->getGlTextureId(texture);
 }
 
 GLRenderer::~GLRenderer() = default;

--- a/src/threepp/renderers/gl/GLTextures.cpp
+++ b/src/threepp/renderers/gl/GLTextures.cpp
@@ -523,6 +523,13 @@ void gl::GLTextures::updateRenderTargetMipmap(GLRenderTarget* renderTarget) {
     }
 }
 
+std::optional<unsigned int> gl::GLTextures::getGlTexture(const Texture& texture) const {
+
+    const auto textureProperties = properties.textureProperties.get(texture.uuid);
+
+    return textureProperties->glTexture;
+}
+
 void gl::GLTextures::TextureEventListener::onEvent(Event& event) {
 
     auto texture = static_cast<Texture*>(event.target);

--- a/src/threepp/renderers/gl/GLTextures.hpp
+++ b/src/threepp/renderers/gl/GLTextures.hpp
@@ -67,6 +67,8 @@ namespace threepp::gl {
 
         void updateRenderTargetMipmap(GLRenderTarget* renderTarget);
 
+        [[nodiscard]] std::optional<unsigned int> getGlTexture(const Texture& texture) const;
+
     private:
         struct TextureEventListener: EventListener {
 


### PR DESCRIPTION
Expose the underlying OpenGL texture id though GLRenderer.

Thus, the texture can be rendered with i.e. ImGUI as requested in #185 and #145 