### PR TITLE
Decouple glfw (windowing) from core library

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Configure and build
         run: |
-          cmake . -B build -DTHREEPP_WITH_GLFW=OFF -DTRHEEPP_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE="Release"
+          cmake . -B build -DTHREEPP_WITH_GLFW=OFF -DTHREEPP_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE="Release"
           cmake --build build
 
       - name: Test

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -40,6 +40,40 @@ jobs:
           cd build/tests
           ctest --output-on-failure
 
+  linux-no-glfw:
+
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: gcc-${{ matrix.compiler_version }}
+      CXX: g++-${{ matrix.compiler_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+        compiler_version: [ 11 ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+          libxinerama-dev \
+          libxcursor-dev \
+          xorg-dev \
+          libglu1-mesa-dev \
+          pkg-config
+
+      - name: Configure and build
+        run: |
+          cmake . -B build -DTHREEPP_WITH_GLFW=OFF -DTRHEEPP_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE="Release"
+          cmake --build build
+
+      - name: Test
+        run: |
+          cd build/tests
+          ctest --output-on-failure
+
   vcpkg-on-linux:
 
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option(THREEPP_BUILD_EXAMPLE_PROJECTS "Build example projects" OFF)
 option(THREEPP_BUILD_TESTS "Build test suite" ON)
 option(THREEPP_WITH_SVG "Build with SVGLoader" ON)
 option(THREEPP_WITH_AUDIO "Build with Audio" ON)
+option(THREEPP_WITH_GLFW "Build GLFW frontend" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 
@@ -35,11 +36,13 @@ if (DEFINED EMSCRIPTEN)
     endif ()
 else ()
 
-    find_package(glfw3 CONFIG REQUIRED)
+    if (THREEPP_WITH_GLFW)
+        find_package(glfw3 CONFIG REQUIRED)
 
-    if (NOT TARGET "glfw::glfw" AND TARGET "glfw")
-        add_library(glfw::glfw ALIAS glfw)
-    endif()
+        if (NOT TARGET "glfw::glfw" AND TARGET "glfw")
+            add_library(glfw::glfw ALIAS glfw)
+        endif ()
+    endif ()
 
 endif ()
 
@@ -105,4 +108,8 @@ install(TARGETS threepp EXPORT threepp-targets)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT threepp-targets
         NAMESPACE threepp::
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/threepp)
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/threepp")
+
+if (THREEPP_WITH_GLFW)
+    install(TARGETS threepp-glfw EXPORT threepp-targets)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,4 @@ install(TARGETS threepp EXPORT threepp-targets)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT threepp-targets
         NAMESPACE threepp::
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/threepp")
-
-if (THREEPP_WITH_GLFW)
-    install(TARGETS threepp-glfw EXPORT threepp-targets)
-endif ()
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/threepp)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-if (NOT DEFINED EMSCRIPTEN)
+if (NOT DEFINED EMSCRIPTEN AND @THREEPP_WITH_GLFW@)
     find_dependency(glfw3 CONFIG)
 
     if (NOT TARGET "glfw::glfw" AND TARGET "glfw")

--- a/examples/AddExample.cmake
+++ b/examples/AddExample.cmake
@@ -28,7 +28,7 @@ function(add_example)
         add_executable("${arg_NAME}" "${arg_SOURCES}")
     endif ()
 
-    target_link_libraries("${arg_NAME}" PRIVATE threepp)
+    target_link_libraries("${arg_NAME}" PRIVATE threepp-glfw)
 
     if ((arg_TRY_LINK_IMGUI OR arg_LINK_IMGUI) AND imgui_FOUND)
         target_link_libraries("${arg_NAME}" PRIVATE imgui::imgui)

--- a/examples/AddExample.cmake
+++ b/examples/AddExample.cmake
@@ -28,7 +28,7 @@ function(add_example)
         add_executable("${arg_NAME}" "${arg_SOURCES}")
     endif ()
 
-    target_link_libraries("${arg_NAME}" PRIVATE threepp-glfw)
+    target_link_libraries("${arg_NAME}" PRIVATE threepp)
 
     if ((arg_TRY_LINK_IMGUI OR arg_LINK_IMGUI) AND imgui_FOUND)
         target_link_libraries("${arg_NAME}" PRIVATE imgui::imgui)

--- a/include/threepp/canvas/Canvas.hpp
+++ b/include/threepp/canvas/Canvas.hpp
@@ -28,7 +28,7 @@ namespace threepp {
         Canvas(const std::string& name, const std::unordered_map<std::string, ParameterValue>& values);
 
         //the current size of the Canvas window
-        [[nodiscard]] WindowSize size() const;
+        [[nodiscard]] WindowSize size() const override;
 
         //the size of the Monitor
         [[nodiscard]] WindowSize monitorSize() const;

--- a/include/threepp/controls/FlyControls.hpp
+++ b/include/threepp/controls/FlyControls.hpp
@@ -19,7 +19,7 @@ namespace threepp {
         bool dragToLook = false;
         bool autoForward = false;
 
-        FlyControls(Object3D& object, PeripheralsEventSource& canvas);
+        FlyControls(Object3D& object, PeripheralsEventSource& eventSource);
 
         void update(float delta);
 

--- a/include/threepp/controls/FlyControls.hpp
+++ b/include/threepp/controls/FlyControls.hpp
@@ -8,7 +8,7 @@
 namespace threepp {
 
     class Object3D;
-    class Canvas;
+    class PeripheralsEventSource;
 
     class FlyControls {
 
@@ -19,7 +19,7 @@ namespace threepp {
         bool dragToLook = false;
         bool autoForward = false;
 
-        FlyControls(Object3D& object, Canvas& canvas);
+        FlyControls(Object3D& object, PeripheralsEventSource& canvas);
 
         void update(float delta);
 

--- a/include/threepp/controls/OrbitControls.hpp
+++ b/include/threepp/controls/OrbitControls.hpp
@@ -10,7 +10,7 @@
 
 namespace threepp {
 
-    class Canvas;
+    class PeripheralsEventSource;
 
     class OrbitControls {
 
@@ -61,7 +61,7 @@ namespace threepp {
         // Set to false to disable use of the keys
         bool enableKeys = true;
 
-        OrbitControls(Camera& camera, Canvas& canvas);
+        OrbitControls(Camera& camera, PeripheralsEventSource& inputSource);
 
         bool update();
 

--- a/include/threepp/controls/OrbitControls.hpp
+++ b/include/threepp/controls/OrbitControls.hpp
@@ -61,7 +61,7 @@ namespace threepp {
         // Set to false to disable use of the keys
         bool enableKeys = true;
 
-        OrbitControls(Camera& camera, PeripheralsEventSource& inputSource);
+        OrbitControls(Camera& camera, PeripheralsEventSource& eventSource);
 
         bool update();
 

--- a/include/threepp/input/PeripheralsEventSource.hpp
+++ b/include/threepp/input/PeripheralsEventSource.hpp
@@ -6,6 +6,8 @@
 #include "threepp/input/KeyListener.hpp"
 #include "threepp/input/MouseListener.hpp"
 
+#include "threepp/canvas/WindowSize.hpp"
+
 #include <vector>
 
 namespace threepp {
@@ -13,6 +15,8 @@ namespace threepp {
     class PeripheralsEventSource {
 
     public:
+        [[nodiscard]] virtual WindowSize size() const = 0;
+
         void setIOCapture(IOCapture* capture);
 
         void addKeyListener(KeyListener& listener);

--- a/include/threepp/threepp.hpp
+++ b/include/threepp/threepp.hpp
@@ -5,7 +5,9 @@
 
 #include "threepp/constants.hpp"
 
+#if __has_include("threepp/canvas/Canvas.hpp")
 #include "threepp/canvas/Canvas.hpp"
+#endif
 
 #include "threepp/lights/lights.hpp"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ set(publicHeaders
         "threepp/constants.hpp"
         "threepp/threepp.hpp"
 
-        "threepp/canvas/Canvas.hpp"
         "threepp/canvas/WindowSize.hpp"
 
         "threepp/controls/FlyControls.hpp"
@@ -232,8 +231,6 @@ set(privateHeaders
 
 set(sources
 
-        "threepp/canvas/Canvas.cpp"
-
         "threepp/cameras/Camera.cpp"
         "threepp/cameras/PerspectiveCamera.cpp"
         "threepp/cameras/OrthographicCamera.cpp"
@@ -447,12 +444,6 @@ list(APPEND sources
 add_library(threepp ${sources} ${privateHeaders} ${publicHeadersFull})
 add_library(threepp::threepp ALIAS threepp)
 target_compile_features(threepp PUBLIC "cxx_std_17")
-if (NOT DEFINED EMSCRIPTEN)
-    target_link_libraries(threepp
-            PRIVATE
-            glfw::glfw
-    )
-endif ()
 
 if (UNIX OR DEFINED EMSCRIPTEN)
     target_link_libraries(threepp PRIVATE pthread)
@@ -472,3 +463,39 @@ target_include_directories(threepp
         "${CMAKE_CURRENT_SOURCE_DIR}/external/stb"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/nlohmann"
 )
+
+if (THREEPP_WITH_GLFW)
+
+    add_library(threepp-glfw
+            "${publicHeaderDir}/threepp/canvas/Canvas.hpp"
+            "threepp/canvas/Canvas.cpp"
+    )
+    target_link_libraries(threepp-glfw
+            PUBLIC
+            threepp
+    )
+    target_include_directories(threepp-glfw
+            PRIVATE
+            "${generatedSourcesDir}"
+    )
+
+endif ()
+
+if (NOT DEFINED EMSCRIPTEN)
+
+    target_include_directories(threepp
+            PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/external/glad"
+    )
+
+    target_include_directories(threepp-glfw
+            PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/external/glad"
+    )
+
+    target_link_libraries(threepp-glfw
+            PRIVATE
+            glfw::glfw
+    )
+
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -407,12 +407,6 @@ set(sources
 
 )
 
-IF (NOT DEFINED EMSCRIPTEN)
-    list(APPEND sources
-            "external/glad/glad.c"
-    )
-endif ()
-
 if (THREEPP_WITH_SVG)
     list(APPEND publicHeaders
             "threepp/loaders/SVGLoader.hpp"
@@ -431,6 +425,22 @@ if (THREEPP_WITH_AUDIO)
 
     list(APPEND sources
             "threepp/audio/Audio.cpp"
+    )
+endif ()
+
+if (THREEPP_WITH_GLFW)
+    list(APPEND publicHeaders
+            "threepp/canvas/Canvas.hpp"
+    )
+
+    list(APPEND sources
+            "threepp/canvas/Canvas.cpp"
+    )
+endif ()
+
+if (NOT DEFINED EMSCRIPTEN)
+    list(APPEND sources
+            "external/glad/glad.c"
     )
 endif ()
 
@@ -455,31 +465,13 @@ target_include_directories(threepp
         PRIVATE
         "${generatedSourcesDir}"
         "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/external/glad"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/earcut"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/miniaudio"
+        "${CMAKE_CURRENT_SOURCE_DIR}/external/nlohmann"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/pugixml"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/quickhull"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/stb"
-        "${CMAKE_CURRENT_SOURCE_DIR}/external/nlohmann"
 )
-
-if (THREEPP_WITH_GLFW)
-
-    add_library(threepp-glfw
-            "${publicHeaderDir}/threepp/canvas/Canvas.hpp"
-            "threepp/canvas/Canvas.cpp"
-    )
-    target_link_libraries(threepp-glfw
-            PUBLIC
-            threepp
-    )
-    target_include_directories(threepp-glfw
-            PRIVATE
-            "${generatedSourcesDir}"
-    )
-
-endif ()
 
 if (NOT DEFINED EMSCRIPTEN)
 
@@ -488,14 +480,11 @@ if (NOT DEFINED EMSCRIPTEN)
             "${CMAKE_CURRENT_SOURCE_DIR}/external/glad"
     )
 
-    target_include_directories(threepp-glfw
-            PRIVATE
-            "${CMAKE_CURRENT_SOURCE_DIR}/external/glad"
-    )
-
-    target_link_libraries(threepp-glfw
-            PRIVATE
-            glfw::glfw
-    )
+    if (THREEPP_WITH_GLFW)
+        target_link_libraries(threepp
+                PRIVATE
+                glfw::glfw
+        )
+    endif ()
 
 endif ()

--- a/src/threepp/controls/FlyControls.cpp
+++ b/src/threepp/controls/FlyControls.cpp
@@ -31,8 +31,8 @@ namespace {
 
 struct FlyControls::Impl {
 
-    Impl(FlyControls& scope, Canvas& canvas, Object3D* object)
-        : canvas(canvas), scope(scope), object(object),
+    Impl(FlyControls& scope, PeripheralsEventSource& canvas, Object3D* object)
+        : eventSource(canvas), scope(scope), object(object),
           keyUp(scope), keydown(scope),
           mouseDown(scope), mouseMove(scope), mouseUp(scope) {
 
@@ -83,12 +83,12 @@ struct FlyControls::Impl {
 
     ~Impl() {
 
-        canvas.removeKeyListener(keydown);
-        canvas.removeKeyListener(keyUp);
+        eventSource.removeKeyListener(keydown);
+        eventSource.removeKeyListener(keyUp);
 
-        canvas.removeMouseListener(mouseDown);
-        canvas.removeMouseListener(mouseMove);
-        canvas.removeMouseListener(mouseUp);
+        eventSource.removeMouseListener(mouseDown);
+        eventSource.removeMouseListener(mouseMove);
+        eventSource.removeMouseListener(mouseUp);
     }
 
     struct KeyDownListener: KeyListener {
@@ -243,8 +243,8 @@ struct FlyControls::Impl {
 
             if (!scope.dragToLook || scope.pimpl_->mouseStatus > 0) {
 
-                const float halfWidth = static_cast<float>(scope.pimpl_->canvas.size().width) / 2;
-                const float halfHeight = static_cast<float>(scope.pimpl_->canvas.size().height) / 2;
+                const float halfWidth = static_cast<float>(scope.pimpl_->eventSource.size().width) / 2;
+                const float halfHeight = static_cast<float>(scope.pimpl_->eventSource.size().height) / 2;
 
                 scope.pimpl_->moveState.yawLeft = -((pos.x) - halfWidth) / halfWidth;
                 scope.pimpl_->moveState.pitchDown = ((pos.y) - halfHeight) / halfHeight;
@@ -288,7 +288,7 @@ struct FlyControls::Impl {
     };
 
 private:
-    Canvas& canvas;
+    PeripheralsEventSource& eventSource;
     FlyControls& scope;
     Object3D* object;
 
@@ -311,7 +311,7 @@ private:
     MouseUpListener mouseUp;
 };
 
-FlyControls::FlyControls(Object3D& object, Canvas& canvas)
+FlyControls::FlyControls(Object3D& object, PeripheralsEventSource& canvas)
     : pimpl_(std::make_unique<Impl>(*this, canvas, &object)) {}
 
 void threepp::FlyControls::update(float delta) {

--- a/src/threepp/controls/FlyControls.cpp
+++ b/src/threepp/controls/FlyControls.cpp
@@ -311,12 +311,12 @@ private:
     MouseUpListener mouseUp;
 };
 
-FlyControls::FlyControls(Object3D& object, PeripheralsEventSource& canvas)
-    : pimpl_(std::make_unique<Impl>(*this, canvas, &object)) {}
+FlyControls::FlyControls(Object3D& object, PeripheralsEventSource& eventSource)
+    : pimpl_(std::make_unique<Impl>(*this, eventSource, &object)) {}
 
-void threepp::FlyControls::update(float delta) {
+void FlyControls::update(float delta) {
 
     pimpl_->update(delta);
 }
 
-threepp::FlyControls::~FlyControls() = default;
+FlyControls::~FlyControls() = default;

--- a/src/threepp/controls/OrbitControls.cpp
+++ b/src/threepp/controls/OrbitControls.cpp
@@ -517,8 +517,8 @@ struct OrbitControls::Impl {
     };
 };
 
-OrbitControls::OrbitControls(Camera& camera, PeripheralsEventSource& inputSource)
-    : pimpl_(std::make_unique<Impl>(*this, inputSource, camera)) {}
+OrbitControls::OrbitControls(Camera& camera, PeripheralsEventSource& eventSource)
+    : pimpl_(std::make_unique<Impl>(*this, eventSource, camera)) {}
 
 
 bool OrbitControls::update() {

--- a/src/threepp/controls/OrbitControls.cpp
+++ b/src/threepp/controls/OrbitControls.cpp
@@ -1,7 +1,7 @@
 
 #include "threepp/controls/OrbitControls.hpp"
 
-#include "threepp/canvas/Canvas.hpp"
+#include "threepp/input/PeripheralsEventSource.hpp"
 #include "threepp/math/Spherical.hpp"
 
 #include "threepp/cameras/OrthographicCamera.hpp"
@@ -30,7 +30,7 @@ namespace {
 
 struct OrbitControls::Impl {
 
-    Canvas& canvas;
+    PeripheralsEventSource& canvas;
     OrbitControls& scope;
     Camera& camera;
 
@@ -59,7 +59,7 @@ struct OrbitControls::Impl {
     Vector2 dollyEnd;
     Vector2 dollyDelta;
 
-    Impl(OrbitControls& scope, Canvas& canvas, Camera& camera)
+    Impl(OrbitControls& scope, PeripheralsEventSource& canvas, Camera& camera)
         : scope(scope), canvas(canvas), camera(camera),
           keyListener(std::make_unique<MyKeyListener>(scope)),
           mouseListener(std::make_unique<MyMouseListener>(scope)) {
@@ -517,8 +517,8 @@ struct OrbitControls::Impl {
     };
 };
 
-OrbitControls::OrbitControls(Camera& camera, Canvas& canvas)
-    : pimpl_(std::make_unique<Impl>(*this, canvas, camera)) {}
+OrbitControls::OrbitControls(Camera& camera, PeripheralsEventSource& inputSource)
+    : pimpl_(std::make_unique<Impl>(*this, inputSource, camera)) {}
 
 
 bool OrbitControls::update() {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "threepp",
-  "dependencies": [
-    {
-      "name": "glfw3",
-      "platform": "!wasm32"
-    }
+  "dependencies": [],
+  "default-features": [
+    "glfw"
   ],
   "features": {
+    "glfw": {
+      "description": "Build with GLFW front-end",
+      "dependencies": [
+        {
+          "name": "glfw3",
+          "platform": "!wasm32"
+        }
+      ]
+    },
     "assimp": {
       "description": "Enable assimp model importer",
       "dependencies": [
@@ -19,7 +26,10 @@
       "dependencies": [
         {
           "name": "imgui",
-          "features": ["glfw-binding", "opengl3-binding"]
+          "features": [
+            "glfw-binding",
+            "opengl3-binding"
+          ]
         }
       ]
     }


### PR DESCRIPTION
This change opens for the possibility to use a different Window system without having to depend on and build the GLFW Canvas, like in the case of #205 