### PR TITLE
Load glad either in Canvas or GLRenderer

### DIFF
--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -33,12 +33,6 @@ namespace threepp {
     class GLRenderer {
 
     public:
-        struct Parameters {
-
-            bool alpha;
-            bool depth;
-            bool premultipliedAlpha;
-        };
 
         // clearing
 
@@ -72,7 +66,7 @@ namespace threepp {
 
         bool checkShaderErrors = false;
 
-        explicit GLRenderer(WindowSize size, const Parameters& parameters = {});
+        explicit GLRenderer(WindowSize size, bool loadGL = true);
 
         GLRenderer(GLRenderer&&) = delete;
         GLRenderer(const GLRenderer&) = delete;

--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -66,7 +66,7 @@ namespace threepp {
 
         bool checkShaderErrors = false;
 
-        explicit GLRenderer(WindowSize size, bool loadGL = true);
+        explicit GLRenderer(WindowSize size);
 
         GLRenderer(GLRenderer&&) = delete;
         GLRenderer(const GLRenderer&) = delete;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,7 +461,7 @@ if (THREEPP_WITH_GLFW)
 endif ()
 
 if (NOT DEFINED EMSCRIPTEN)
-    list(APPEND privateSources "load_glad.hpp")
+    list(APPEND privateHeaders "threepp/load_glad.hpp")
     list(APPEND sources "external/glad/glad.c")
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,9 +461,8 @@ if (THREEPP_WITH_GLFW)
 endif ()
 
 if (NOT DEFINED EMSCRIPTEN)
-    list(APPEND sources
-            "external/glad/glad.c"
-    )
+    list(APPEND privateSources "load_glad.hpp")
+    list(APPEND sources "external/glad/glad.c")
 endif ()
 
 include("${PROJECT_SOURCE_DIR}/cmake/embed.cmake")

--- a/src/threepp/canvas/Canvas.cpp
+++ b/src/threepp/canvas/Canvas.cpp
@@ -2,11 +2,11 @@
 #include "threepp/canvas/Canvas.hpp"
 
 #include "threepp/favicon.hpp"
+#include "threepp/load_glad.hpp"
 #include "threepp/loaders/ImageLoader.hpp"
 #include "threepp/utils/StringUtils.hpp"
 
 #ifndef EMSCRIPTEN
-#include <glad/glad.h>
 #define GLFW_INCLUDE_NONE
 #else
 #include <emscripten.h>
@@ -195,7 +195,7 @@ struct Canvas::Impl {
 #ifndef EMSCRIPTEN
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, 1);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         glfwWindowHint(GLFW_RESIZABLE, params.resizable_);
 #endif
@@ -210,14 +210,13 @@ struct Canvas::Impl {
             exit(EXIT_FAILURE);
         }
 
-#if EMSCRIPTEN
-        EM_ASM({ document.title = UTF8ToString($0); }, params.title_.c_str());
-#endif
-
         glfwSetWindowUserPointer(window, this);
+
 
 #ifndef EMSCRIPTEN
         setWindowIcon(window, params.favicon_);
+#else
+        EM_ASM({ document.title = UTF8ToString($0); }, params.title_.c_str());
 #endif
 
         glfwSetKeyCallback(window, key_callback);
@@ -229,14 +228,8 @@ struct Canvas::Impl {
         glfwMakeContextCurrent(window);
 
 #ifndef EMSCRIPTEN
-        gladLoadGL();
+        initializeOpenGL();
         glfwSwapInterval(params.vsync_ ? 1 : 0);
-
-        if (params.antialiasing_ > 0) {
-            glEnable(GL_MULTISAMPLE);
-        }
-
-        glEnable(GL_PROGRAM_POINT_SIZE);
 #endif
     }
 

--- a/src/threepp/canvas/Canvas.cpp
+++ b/src/threepp/canvas/Canvas.cpp
@@ -2,11 +2,11 @@
 #include "threepp/canvas/Canvas.hpp"
 
 #include "threepp/favicon.hpp"
-#include "threepp/load_glad.hpp"
 #include "threepp/loaders/ImageLoader.hpp"
 #include "threepp/utils/StringUtils.hpp"
 
 #ifndef EMSCRIPTEN
+#include "threepp/load_glad.hpp"
 #define GLFW_INCLUDE_NONE
 #else
 #include <emscripten.h>

--- a/src/threepp/load_glad.hpp
+++ b/src/threepp/load_glad.hpp
@@ -1,0 +1,22 @@
+
+#ifndef THREEPP_LOAD_GLAD_HPP
+#define THREEPP_LOAD_GLAD_HPP
+
+#include "glad/glad.h"
+
+#include <iostream>
+
+static bool gladInitialized = false;
+
+inline void initializeOpenGL() {
+
+    if (!gladInitialized) {
+        if (!gladLoadGL()) {
+            std::cerr << "Failed to initialize GLAD" << std::endl;
+            exit(EXIT_FAILURE);
+        }
+        gladInitialized = true;
+    }
+}
+
+#endif//THREEPP_LOAD_GLAD_HPP

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -1128,8 +1128,10 @@ struct GLRenderer::Impl {
 };
 
 
-GLRenderer::GLRenderer(WindowSize size, bool loadGL) {
+GLRenderer::GLRenderer(WindowSize size) {
+#ifndef EMSCRIPTEN
     initializeOpenGL();
+#endif
 
     pimpl_ = std::make_unique<Impl>(*this, size);
 }

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -33,7 +33,7 @@
 #include "threepp/objects/Sprite.hpp"
 
 #ifndef EMSCRIPTEN
-#include <glad/glad.h>
+#include "threepp/load_glad.hpp"
 #else
 #include <GLES3/gl32.h>
 #endif
@@ -136,9 +136,9 @@ struct GLRenderer::Impl {
 
     gl::GLShadowMap shadowMap;
 
-    Impl(GLRenderer& scope, WindowSize size, const GLRenderer::Parameters& parameters)
+    Impl(GLRenderer& scope, WindowSize size)
         : scope(scope), _size(size),
-          background(state, parameters.premultipliedAlpha),
+          background(state, false),
           bufferRenderer(std::make_unique<gl::GLBufferRenderer>(_info)),
           indexedBufferRenderer(std::make_unique<gl::GLIndexedBufferRenderer>(_info)),
           clipping(properties),
@@ -155,6 +155,9 @@ struct GLRenderer::Impl {
 
         this->setViewport(0, 0, size.width, size.height);
         this->setScissor(0, 0, _size.width, _size.height);
+
+        glEnable(GL_MULTISAMPLE);
+        glEnable(GL_PROGRAM_POINT_SIZE);
     }
 
     [[nodiscard]] std::optional<unsigned int> getGlTextureId(const Texture& texture) const {
@@ -1125,8 +1128,11 @@ struct GLRenderer::Impl {
 };
 
 
-GLRenderer::GLRenderer(WindowSize size, const GLRenderer::Parameters& parameters)
-    : pimpl_(std::make_unique<Impl>(*this, size, parameters)) {}
+GLRenderer::GLRenderer(WindowSize size, bool loadGL) {
+    initializeOpenGL();
+
+    pimpl_ = std::make_unique<Impl>(*this, size);
+}
 
 
 const gl::GLInfo& threepp::GLRenderer::info() {


### PR DESCRIPTION
This PR adresses the issue of loading Glad in cases where `Canvas` is not used. See i.e. #205 