### PR TITLE
changeable draw range for instanced mesh

### DIFF
--- a/include/threepp/objects/InstancedMesh.hpp
+++ b/include/threepp/objects/InstancedMesh.hpp
@@ -16,9 +16,11 @@ namespace threepp {
         InstancedMesh(
                 std::shared_ptr<BufferGeometry> geometry,
                 std::shared_ptr<Material> material,
-                size_t count);
+                size_t capacity);
 
-        [[nodiscard]] size_t count() const;
+        [[nodiscard]] size_t drawInstanceCount() const;
+
+        void setDrawInstanceCount(size_t drawInstanceCount);
 
         FloatBufferAttribute* instanceMatrix() const;
 
@@ -41,7 +43,7 @@ namespace threepp {
         static std::shared_ptr<InstancedMesh> create(
                 std::shared_ptr<BufferGeometry> geometry,
                 std::shared_ptr<Material> material,
-                size_t count);
+                size_t capacity);
 
         ~InstancedMesh() override;
 
@@ -49,7 +51,8 @@ namespace threepp {
         Mesh _mesh;
         bool disposed{false};
 
-        size_t count_;
+        size_t capacity_;
+        size_t drawInstanceCount_;
         std::unique_ptr<FloatBufferAttribute> instanceMatrix_;
         std::unique_ptr<FloatBufferAttribute> instanceColor_ = nullptr;
 

--- a/src/threepp/objects/InstancedMesh.cpp
+++ b/src/threepp/objects/InstancedMesh.cpp
@@ -20,16 +20,19 @@ namespace {
 InstancedMesh::InstancedMesh(
         std::shared_ptr<BufferGeometry> geometry,
         std::shared_ptr<Material> material,
-        size_t count)
+        size_t capacity)
     : Mesh(std::move(geometry), std::move(material)),
-      count_(count), instanceMatrix_(FloatBufferAttribute::create(std::vector<float>(count * 16), 16)) {
+      capacity_(capacity), drawInstanceCount_(capacity), instanceMatrix_(FloatBufferAttribute::create(std::vector<float>(capacity * 16), 16)) {
 
     this->frustumCulled = false;
 }
 
-size_t InstancedMesh::count() const {
+size_t InstancedMesh::drawInstanceCount() const {
+    return drawInstanceCount_;
+}
 
-    return count_;
+void InstancedMesh::setDrawInstanceCount(size_t drawInstanceCount) {
+    drawInstanceCount_ = capacity_ < drawInstanceCount ? capacity_ : drawInstanceCount;
 }
 
 FloatBufferAttribute* InstancedMesh::instanceMatrix() const {
@@ -62,7 +65,7 @@ void InstancedMesh::setColorAt(size_t index, const Color& color) {
 
     if (!this->instanceColor_) {
 
-        this->instanceColor_ = FloatBufferAttribute ::create(std::vector<float>(count_ * 3), 3);
+        this->instanceColor_ = FloatBufferAttribute ::create(std::vector<float>(capacity_ * 3), 3);
     }
 
     color.toArray(this->instanceColor_->array(), index * 3);
@@ -84,7 +87,7 @@ void InstancedMesh::dispose() {
 void InstancedMesh::raycast(const Raycaster& raycaster, std::vector<Intersection>& intersects) {
 
     const auto& matrixWorld = this->matrixWorld;
-    const auto raycastTimes = this->count_;
+    const auto raycastTimes = this->drawInstanceCount();
 
     _mesh.setGeometry(geometry_);
     _mesh.setMaterials(materials_);
@@ -125,7 +128,7 @@ InstancedMesh::~InstancedMesh() {
 std::shared_ptr<InstancedMesh> InstancedMesh::create(
         std::shared_ptr<BufferGeometry> geometry,
         std::shared_ptr<Material> material,
-        size_t count) {
+        size_t capacity) {
 
-    return std::make_shared<InstancedMesh>(std::move(geometry), std::move(material), count);
+    return std::make_shared<InstancedMesh>(std::move(geometry), std::move(material), capacity);
 }

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -432,7 +432,7 @@ struct GLRenderer::Impl {
 
         if (auto im = object->as<InstancedMesh>()) {
 
-            renderer->renderInstances(drawStart, drawCount, im->count());
+            renderer->renderInstances(drawStart, drawCount, im->drawInstanceCount());
 
         } else if (auto g = dynamic_cast<InstancedBufferGeometry*>(geometry)) {
 


### PR DESCRIPTION
hello markaren

I'm working on a project that turn java code into graph, draw a node for each variable and draw a line for each assignment, something like that.  And people can search code using regex, the result will be many lines in the graph.

The searching process is time consuming, so I have to draw from a stream of results generated by the searching thread.

So here is my problem:
I'm using InstancedMesh + CircleGeometry to draw nodes, and I need to control how many instance is drawn on screen because I'm using a stream of results. I know I can set instanceCount in InstancedBufferGeometry, but InstancedMesh is just easier to use. I noticed there is instanceCount also in GLInfo::update, and don't know what that dose, so I decide to modify the class InstancedMesh.

What I did:
split the role of the field InstancedMesh::count_ into capacity and drawInstanceCount

Hope you would think about this suggestion, Thanks!
