### PR TITLE
Add functionality for reading texture data back into memory

### DIFF
--- a/include/threepp/renderers/GLRenderer.hpp
+++ b/include/threepp/renderers/GLRenderer.hpp
@@ -152,6 +152,9 @@ namespace threepp {
 
         void readPixels(const Vector2& position, const WindowSize& size, Format format, unsigned char* data);
 
+        // Experimental threepp function
+        void copyTextureToImage(Texture& texture);
+
         void resetState();
 
         void invokeLater(const std::function<void()>& task, float delay = 0);

--- a/src/threepp/renderers/GLRenderTarget.cpp
+++ b/src/threepp/renderers/GLRenderTarget.cpp
@@ -17,7 +17,7 @@ GLRenderTarget::GLRenderTarget(unsigned int width, unsigned int height, const GL
       scissor(0.f, 0.f, static_cast<float>(width), static_cast<float>(height)),
       viewport(0.f, 0.f, static_cast<float>(width), static_cast<float>(height)),
       depthBuffer(options.depthBuffer), stencilBuffer(options.stencilBuffer), depthTexture(options.depthTexture),
-      texture(Texture::create({})) {
+      texture(Texture::create({Image({}, width, height)})) {
 
     if (options.mapping) texture->mapping = *options.mapping;
     if (options.wrapS) texture->wrapS = *options.wrapS;

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -1128,6 +1128,22 @@ struct GLRenderer::Impl {
         glReadPixels(static_cast<int>(position.x), static_cast<int>(position.y), size.width, size.width, glFormat, GL_UNSIGNED_BYTE, data);
     }
 
+    void copyTextureToImage(Texture& texture) {
+
+        textures.setTexture2D(texture, 0);
+
+        auto& image = texture.image.front();
+        auto& data = image.data();
+        if (data.empty()) {
+            auto newSize = image.width * image.height * (texture.format == Format::RGB ? 3 : 4);
+            data.resize(newSize);
+        }
+
+        glGetTexImage(GL_TEXTURE_2D, 0, gl::toGLFormat(texture.format), gl::toGLType(texture.type), data.data());
+
+        state.unbindTexture();
+    }
+
     void setViewport(int x, int y, int width, int height) {
 
         _viewport.set(static_cast<float>(x), static_cast<float>(y), static_cast<float>(width), static_cast<float>(height));
@@ -1346,6 +1362,11 @@ void GLRenderer::copyFramebufferToTexture(const Vector2& position, Texture& text
 void GLRenderer::readPixels(const Vector2& position, const WindowSize& size, Format format, unsigned char* data) {
 
     pimpl_->readPixels(position, size, format, data);
+}
+
+void GLRenderer::copyTextureToImage(Texture& texture) {
+
+    pimpl_->copyTextureToImage(texture);
 }
 
 void GLRenderer::resetState() {

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -1134,10 +1134,8 @@ struct GLRenderer::Impl {
 
         auto& image = texture.image.front();
         auto& data = image.data();
-        if (data.empty()) {
-            auto newSize = image.width * image.height * (texture.format == Format::RGB ? 3 : 4);
-            data.resize(newSize);
-        }
+        auto newSize = image.width * image.height * (texture.format == Format::RGB ? 3 : 4);
+        data.resize(newSize);
 
         glGetTexImage(GL_TEXTURE_2D, 0, gl::toGLFormat(texture.format), gl::toGLType(texture.type), data.data());
 


### PR DESCRIPTION
This PR makes it possible to copy texture data from the GPU back into memory when using e.g, a RenderTarget.

