### PR TITLE
initializes std::pair of std::vectors explicityly

### DIFF
--- a/src/threepp/objects/ParticleSystem.cpp
+++ b/src/threepp/objects/ParticleSystem.cpp
@@ -458,7 +458,7 @@ void ParticleSystem::Settings::makeDefault() {
 
     texture = nullptr;
 
-    size = {};
-    opacity = {};
-    color = {};
+    size = {{}, {}};
+    opacity = {{}, {}};
+    color = {{}, {}};
 }


### PR DESCRIPTION

This fixes the error during em++ build failure with the following error message

```
.../_deps/threepp-src/src/threepp/objects/ParticleSystem.cpp:461:10: error: use of overloaded operator '=' is ambiguous (with operand types 'std::pair<std::vector<float>, std::vector<float>>' and 'void')
  461 |     size = {};
         |     ~~~~ ^ ~~                                                                 
```

Compiler info

```
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 4.0.0 (97c7c2adab1791b9487d1f376934a3bdc28f8a67)
Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
This is free and open source software under the MIT license.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```