### PR TITLE
fix: make threepp compatiable with windows.h

### DIFF
--- a/include/threepp/cameras/Camera.hpp
+++ b/include/threepp/cameras/Camera.hpp
@@ -25,8 +25,8 @@ namespace threepp {
     public:
         float zoom = 1;
 
-        float near{};
-        float far{};
+        float nearPlane {};
+        float farPlane {};
 
         std::optional<CameraView> view;
 
@@ -39,7 +39,7 @@ namespace threepp {
         Matrix4 projectionMatrixInverse;
 
         Camera() = default;
-        Camera(float near, float far);
+        Camera(float _near, float _far);
 
         // Copies the world space direction in which the camera is looking into target.
         // (Note: A camera looks down its local, negative z-axis).

--- a/include/threepp/cameras/OrthographicCamera.hpp
+++ b/include/threepp/cameras/OrthographicCamera.hpp
@@ -25,7 +25,7 @@ namespace threepp {
 
         explicit OrthographicCamera(float left = -1, float right = 1,
                                     float top = 1, float bottom = -1,
-                                    float near = 0.1f, float far = 2000);
+                                    float nearPlane = 0.1f, float farPlane = 2000);
 
         // Sets an offset in a larger viewing frustum.
         // This is useful for multi-window or multi-monitor/multi-machine setups.

--- a/include/threepp/cameras/PerspectiveCamera.hpp
+++ b/include/threepp/cameras/PerspectiveCamera.hpp
@@ -28,7 +28,7 @@ namespace threepp {
         float filmOffset = 0;// horizontal film offset (same unit as gauge)
 
         explicit PerspectiveCamera(float fov = 60, float aspect = 1,
-                                   float near = 0.1, float far = 2000);
+                                   float nearPlane = 0.1, float farPlane = 2000);
 
         /**
          * Sets the FOV by focal length in respect to the current .filmGauge.

--- a/include/threepp/core/Raycaster.hpp
+++ b/include/threepp/core/Raycaster.hpp
@@ -34,8 +34,8 @@ namespace threepp {
     class Raycaster {
 
     public:
-        float near;
-        float far;
+        float nearPlane;
+        float farPlane;
 
         Ray ray;
         Camera* camera;
@@ -47,8 +47,7 @@ namespace threepp {
         };
         Params params;
 
-        explicit Raycaster(const Vector3& origin = Vector3(), const Vector3& direction = Vector3(), float near = 0, float far = std::numeric_limits<float>::infinity())
-            : near(near), far(far), ray(origin, direction), camera(nullptr) {}
+        explicit Raycaster(const Vector3& origin = Vector3(), const Vector3& direction = Vector3(), float _near = 0, float _far = std::numeric_limits<float>::infinity());
 
         void set(const Vector3& origin, const Vector3& direction);
 

--- a/include/threepp/input/KeyListener.hpp
+++ b/include/threepp/input/KeyListener.hpp
@@ -119,7 +119,7 @@ namespace threepp {
         TAB,
         BACKSPACE,
         INSERT,
-        DELETE,
+        DEL,
         RIGHT,
         LEFT,
         DOWN,

--- a/include/threepp/scenes/Fog.hpp
+++ b/include/threepp/scenes/Fog.hpp
@@ -11,10 +11,10 @@ namespace threepp {
 
     public:
         Color color;
-        float near;
-        float far;
+        float nearPlane;
+        float farPlane;
 
-        explicit Fog(const Color& color, float near = 1, float far = 1000);
+        explicit Fog(const Color& color, float _near = 1, float _far = 1000);
 
         bool operator==(const Fog& f) const;
     };

--- a/src/threepp/cameras/Camera.cpp
+++ b/src/threepp/cameras/Camera.cpp
@@ -3,9 +3,8 @@
 
 using namespace threepp;
 
-
-Camera::Camera(float near, float far)
-    : near(near), far(far) {}
+Camera::Camera(float _near, float _far)
+    : nearPlane(_near), farPlane(_far) {}
 
 void Camera::getWorldDirection(Vector3& target) {
 

--- a/src/threepp/cameras/OrthographicCamera.cpp
+++ b/src/threepp/cameras/OrthographicCamera.cpp
@@ -67,7 +67,7 @@ void OrthographicCamera::updateProjectionMatrix() {
         bottom = top - scaleH * static_cast<float>(this->view->height);
     }
 
-    this->projectionMatrix.makeOrthographic(left, right, top, bottom, this->near, this->far);
+    this->projectionMatrix.makeOrthographic(left, right, top, bottom, this->nearPlane, this->farPlane);
 
     this->projectionMatrixInverse.copy(this->projectionMatrix).invert();
 }

--- a/src/threepp/cameras/PerspectiveCamera.cpp
+++ b/src/threepp/cameras/PerspectiveCamera.cpp
@@ -86,7 +86,7 @@ void PerspectiveCamera::clearViewOffset() {
 
 void PerspectiveCamera::updateProjectionMatrix() {
 
-    float top = near * std::tan(math::DEG2RAD * 0.5f * this->fov) / this->zoom;
+    float top = nearPlane * std::tan(math::DEG2RAD * 0.5f * this->fov) / this->zoom;
     float height = 2.f * top;
     float width = this->aspect * height;
     float left = -0.5f * width;
@@ -104,10 +104,10 @@ void PerspectiveCamera::updateProjectionMatrix() {
 
     const auto skew = this->filmOffset;
     if (skew != 0) {
-        left += (near * skew / this->getFilmWidth());
+        left += (nearPlane * skew / this->getFilmWidth());
     }
 
-    this->projectionMatrix.makePerspective(left, (left + width), top, (top - height), near, far);
+    this->projectionMatrix.makePerspective(left, (left + width), top, (top - height), nearPlane, farPlane);
 
     this->projectionMatrixInverse.copy(this->projectionMatrix).invert();
 }

--- a/src/threepp/canvas/Canvas.cpp
+++ b/src/threepp/canvas/Canvas.cpp
@@ -128,7 +128,7 @@ namespace {
             case GLFW_KEY_TAB: return Key::TAB;
             case GLFW_KEY_BACKSPACE: return Key::BACKSPACE;
             case GLFW_KEY_INSERT: return Key::INSERT;
-            case GLFW_KEY_DELETE: return Key::DELETE;
+            case GLFW_KEY_DELETE: return Key::DEL;
 
             default: return Key::UNKNOWN;
 

--- a/src/threepp/core/Raycaster.cpp
+++ b/src/threepp/core/Raycaster.cpp
@@ -37,6 +37,11 @@ namespace {
 }// namespace
 
 
+Raycaster::Raycaster(const Vector3 &origin, const Vector3 &direction, float _near, float _far): nearPlane(_near), farPlane(_far), ray(origin, direction), camera(nullptr) {
+
+}
+
+
 void Raycaster::set(const Vector3& origin, const Vector3& direction) {
 
     // direction is assumed to be normalized (for accurate distance calculations)
@@ -79,7 +84,7 @@ void Raycaster::setFromCamera(const Vector2& coords, Camera& camera) {
 
     } else if (camera.is<OrthographicCamera>()) {
 
-        this->ray.origin.set(coords.x, coords.y, (camera.near + camera.far) / (camera.near - camera.far)).unproject(camera);// set origin in plane of camera
+        this->ray.origin.set(coords.x, coords.y, (camera.nearPlane + camera.farPlane) / (camera.nearPlane - camera.farPlane)).unproject(camera);// set origin in plane of camera
         this->ray.direction.set(0, 0, -1).transformDirection(*camera.matrixWorld);
         this->camera = &camera;
 

--- a/src/threepp/lights/PointLightShadow.cpp
+++ b/src/threepp/lights/PointLightShadow.cpp
@@ -49,11 +49,11 @@ void PointLightShadow::updateMatrices(PointLight& light, size_t viewportIndex) {
     auto& camera = this->camera;
     auto& shadowMatrix = this->matrix;
 
-    auto far = (light.distance > 0) ? light.distance : camera->far;
+    auto far = (light.distance > 0) ? light.distance : camera->farPlane;
 
-    if (far != camera->far) {
+    if (far != camera->farPlane) {
 
-        camera->far = far;
+        camera->farPlane = far;
         camera->updateProjectionMatrix();
     }
 

--- a/src/threepp/lights/SpotLightShadow.cpp
+++ b/src/threepp/lights/SpotLightShadow.cpp
@@ -13,15 +13,15 @@ void SpotLightShadow::updateMatrices(Light& _light) {
 
     const auto fov = math::RAD2DEG * 2 * light->angle * this->focus;
     const auto aspect = this->mapSize.x / this->mapSize.y;
-    const auto far = (light->distance > 0) ? light->distance : camera->far;
+    const auto far = (light->distance > 0) ? light->distance : camera->farPlane;
 
     auto c = camera->as<PerspectiveCamera>();
 
-    if (fov != c->fov || aspect != c->aspect || far != camera->far) {
+    if (fov != c->fov || aspect != c->aspect || far != camera->farPlane) {
 
         c->fov = fov;
         c->aspect = aspect;
-        c->far = far;
+        c->farPlane = far;
         c->updateProjectionMatrix();
     }
 

--- a/src/threepp/objects/Line.cpp
+++ b/src/threepp/objects/Line.cpp
@@ -125,7 +125,7 @@ void Line::raycast(const Raycaster& raycaster, std::vector<Intersection>& inters
 
             const auto distance = raycaster.ray.origin.distanceTo(interRay);
 
-            if (distance < raycaster.near || distance > raycaster.far) continue;
+            if (distance < raycaster.nearPlane || distance > raycaster.farPlane) continue;
 
             Intersection intersection;
             intersection.distance = distance;
@@ -154,7 +154,7 @@ void Line::raycast(const Raycaster& raycaster, std::vector<Intersection>& inters
 
             const auto distance = raycaster.ray.origin.distanceTo(interRay);
 
-            if (distance < raycaster.near || distance > raycaster.far) continue;
+            if (distance < raycaster.nearPlane || distance > raycaster.farPlane) continue;
 
             Intersection intersection;
             intersection.distance = distance;

--- a/src/threepp/objects/Mesh.cpp
+++ b/src/threepp/objects/Mesh.cpp
@@ -40,7 +40,7 @@ namespace {
 
         const auto distance = raycaster.ray.origin.distanceTo(_intersectionPointWorld);
 
-        if (distance < raycaster.near || distance > raycaster.far) return std::nullopt;
+        if (distance < raycaster.nearPlane || distance > raycaster.farPlane) return std::nullopt;
 
         Intersection intersection{};
         intersection.distance = distance;

--- a/src/threepp/objects/Points.cpp
+++ b/src/threepp/objects/Points.cpp
@@ -34,7 +34,7 @@ namespace {
 
             const auto distance = raycaster.ray.origin.distanceTo(intersectPoint);
 
-            if (distance < raycaster.near || distance > raycaster.far) return;
+            if (distance < raycaster.nearPlane || distance > raycaster.farPlane) return;
 
             Intersection intersection;
             intersection.distance = distance;

--- a/src/threepp/objects/Reflector.cpp
+++ b/src/threepp/objects/Reflector.cpp
@@ -111,7 +111,7 @@ struct Reflector::Impl {
             virtualCamera.up.applyMatrix4(rotationMatrix);
             virtualCamera.up.reflect(normal);
             virtualCamera.lookAt(target);
-            virtualCamera.far = camera->far;// Used in WebGLBackground
+            virtualCamera.farPlane = camera->farPlane;// Used in WebGLBackground
 
             virtualCamera.updateMatrixWorld();
             virtualCamera.projectionMatrix.copy(camera->projectionMatrix);// Update the texture matrix

--- a/src/threepp/objects/Sprite.cpp
+++ b/src/threepp/objects/Sprite.cpp
@@ -155,7 +155,7 @@ void Sprite::raycast(const Raycaster& raycaster, std::vector<Intersection>& inte
 
     auto distance = raycaster.ray.origin.distanceTo(_intersectPoint);
 
-    if (distance < raycaster.near || distance > raycaster.far) return;
+    if (distance < raycaster.nearPlane || distance > raycaster.farPlane) return;
 
     Intersection intersection{};
     intersection.distance = distance;

--- a/src/threepp/objects/Water.cpp
+++ b/src/threepp/objects/Water.cpp
@@ -205,7 +205,7 @@ struct Water::Impl {
             mirrorCamera->up.applyMatrix4(rotationMatrix);
             mirrorCamera->up.reflect(normal);
             mirrorCamera->lookAt(target);
-            mirrorCamera->far = camera->far;// Used in WebGLBackground
+            mirrorCamera->farPlane = camera->farPlane;// Used in WebGLBackground
 
             mirrorCamera->updateMatrixWorld();
             mirrorCamera->projectionMatrix.copy(camera->projectionMatrix);// Update the texture matrix

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -845,7 +845,7 @@ struct GLRenderer::Impl {
 
             if (gl::GLCapabilities::instance().logarithmicDepthBuffer) {
 
-                p_uniforms->setValue("logDepthBufFC", 2.f / (std::log(camera->far + 1.f) / math::LN2));
+                p_uniforms->setValue("logDepthBufFC", 2.f / (std::log(camera->farPlane + 1.f) / math::LN2));
             }
 
             if (_currentCamera != camera) {

--- a/src/threepp/renderers/gl/GLLights.cpp
+++ b/src/threepp/renderers/gl/GLLights.cpp
@@ -155,8 +155,8 @@ void GLLights::setup(std::vector<Light*>& lights) {
                 shadowUniforms->at("shadowNormalBias") = shadow->normalBias;
                 shadowUniforms->at("shadowRadius") = shadow->radius;
                 std::get<Vector2>(shadowUniforms->at("shadowMapSize")).copy(shadow->mapSize);
-                shadowUniforms->at("shadowCameraNear") = shadow->camera->near;
-                shadowUniforms->at("shadowCameraFar") = shadow->camera->far;
+                shadowUniforms->at("shadowCameraNear") = shadow->camera->nearPlane;
+                shadowUniforms->at("shadowCameraFar") = shadow->camera->farPlane;
 
                 ensureCapacity(state.pointShadow, pointLength + 1);
                 ensureCapacity(state.pointShadowMap, pointLength + 1);

--- a/src/threepp/renderers/gl/GLMaterials.cpp
+++ b/src/threepp/renderers/gl/GLMaterials.cpp
@@ -463,8 +463,8 @@ struct GLMaterials::Impl {
             auto& f = std::get<Fog>(fog);
             uniforms.at("fogColor").value<Color>().copy(f.color);
 
-            uniforms.at("fogNear").value<float>() = f.near;
-            uniforms.at("fogFar").value<float>() = f.far;
+            uniforms.at("fogNear").value<float>() = f.nearPlane;
+            uniforms.at("fogFar").value<float>() = f.farPlane;
         } else {
 
             auto& f = std::get<FogExp2>(fog);

--- a/src/threepp/renderers/gl/GLShadowMap.cpp
+++ b/src/threepp/renderers/gl/GLShadowMap.cpp
@@ -223,7 +223,7 @@ struct GLShadowMap::Impl {
 
                             if (groupMaterial && groupMaterial->visible) {
 
-                                const auto depthMaterial = getDepthMaterial(_renderer, object, geometry, groupMaterial, light, shadowCamera->near, shadowCamera->far);
+                                const auto depthMaterial = getDepthMaterial(_renderer, object, geometry, groupMaterial, light, shadowCamera->nearPlane, shadowCamera->farPlane);
 
                                 _renderer.renderBufferDirect(shadowCamera, nullptr, geometry, depthMaterial, object, group);
                             }
@@ -232,7 +232,7 @@ struct GLShadowMap::Impl {
 
                 } else if (material.front()->visible) {
 
-                    const auto depthMaterial = getDepthMaterial(_renderer, object, geometry, material.front().get(), light, shadowCamera->near, shadowCamera->far);
+                    const auto depthMaterial = getDepthMaterial(_renderer, object, geometry, material.front().get(), light, shadowCamera->nearPlane, shadowCamera->farPlane);
 
                     _renderer.renderBufferDirect(shadowCamera, nullptr, geometry, depthMaterial, object, std::nullopt);
                 }

--- a/src/threepp/scenes/Fog.cpp
+++ b/src/threepp/scenes/Fog.cpp
@@ -4,10 +4,10 @@
 using namespace threepp;
 
 
-Fog::Fog(const Color& color, float near, float far)
-    : color(color), near(near), far(far) {}
+Fog::Fog(const Color& color, float _near, float _far)
+    : color(color), nearPlane(_near), farPlane(_far) {}
 
 bool Fog::operator==(const Fog& f) const {
 
-    return f.color == this->color && f.near == this->near && f.far == this->far;
+    return f.color == this->color && f.nearPlane == this->nearPlane && f.farPlane == this->farPlane;
 }


### PR DESCRIPTION
The following word is used in windows internal header:

 * far
 * near
 * DELETE

So, if threepp is work with windows.h (include wxWidgets and other), it will not compile.

This patch renamed `far` to `farPlane`, `near` to `nearPlane`, `Key::DELETE` to `Key::DEL` to avoid conflict.