### PR TITLE
Add option to build core only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(THREEPP_BUILD_TESTS "Build test suite" ON)
 option(THREEPP_WITH_SVG "Build with SVGLoader" ON)
 option(THREEPP_WITH_AUDIO "Build with Audio" ON)
 option(THREEPP_TREAT_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+option(THREEPP_CORE_ONLY "Build only the core library (no window or rendering)" OFF)
 
 # Force THREEPP_WITH_GLFW ON when targeting Emscripten
 cmake_dependent_option(THREEPP_WITH_GLFW "Build with GLFW frontend" ON "NOT DEFINED EMSCRIPTEN" ON)
@@ -37,13 +38,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 # ==============================================================================
 
 
-if (DEFINED EMSCRIPTEN)
+if (DEFINED EMSCRIPTEN AND NOT THREEPP_CORE_ONLY)
     if ("${CMAKE_SYSTEM}" MATCHES "Linux" OR "${CMAKE_SYSTEM}" MATCHES "Darwin-*")
         find_package(OpenGL REQUIRED)
     endif ()
 else ()
 
-    if (THREEPP_USE_EXTERNAL_GLFW)
+    if (THREEPP_USE_EXTERNAL_GLFW AND NOT THREEPP_CORE_ONLY)
         find_package(glfw3 CONFIG REQUIRED)
 
         if (NOT TARGET "glfw::glfw" AND TARGET "glfw")
@@ -60,7 +61,7 @@ endif ()
 
 add_subdirectory(src)
 
-if (THREEPP_BUILD_EXAMPLES)
+if (THREEPP_BUILD_EXAMPLES AND NOT THREEPP_CORE_ONLY)
     add_subdirectory(examples)
 endif ()
 

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-if (NOT DEFINED EMSCRIPTEN AND @THREEPP_USE_EXTERNAL_GLFW@)
+if (NOT DEFINED EMSCRIPTEN AND @THREEPP_USE_EXTERNAL_GLFW@ AND NOT @THREEPP_CORE_ONLY@)
     find_dependency(glfw3 CONFIG)
 
     if (NOT TARGET "glfw::glfw" AND TARGET "glfw")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,6 @@ set(publicHeaders
         "threepp/constants.hpp"
         "threepp/threepp.hpp"
 
-        "threepp/canvas/Canvas.hpp"
-        "threepp/canvas/Monitor.hpp"
-        "threepp/canvas/WindowSize.hpp"
-
         "threepp/controls/DragControls.hpp"
         "threepp/controls/FlyControls.hpp"
         "threepp/controls/OrbitControls.hpp"
@@ -191,17 +187,6 @@ set(publicHeaders
         "threepp/lights/SpotLight.hpp"
         "threepp/lights/SpotLightShadow.hpp"
 
-        "threepp/renderers/GLRenderer.hpp"
-        "threepp/renderers/GLRenderTarget.hpp"
-
-        "threepp/renderers/gl/GLInfo.hpp"
-        "threepp/renderers/gl/GLShadowMap.hpp"
-        "threepp/renderers/gl/GLState.hpp"
-
-        "threepp/renderers/shaders/ShaderChunk.hpp"
-        "threepp/renderers/shaders/ShaderLib.hpp"
-        "threepp/renderers/shaders/UniformsLib.hpp"
-
 )
 
 set(publicHeadersFull)
@@ -212,31 +197,6 @@ endforeach ()
 set(privateHeaders
 
         "threepp/materials/MeshDistanceMaterial.hpp"
-
-        "threepp/renderers/GLCubeRenderTarget.hpp"
-
-        "threepp/renderers/gl/Buffer.hpp"
-        "threepp/renderers/gl/GLAttributes.hpp"
-        "threepp/renderers/gl/GLBackground.hpp"
-        "threepp/renderers/gl/GLBindingStates.hpp"
-        "threepp/renderers/gl/GLBufferRenderer.hpp"
-        "threepp/renderers/gl/GLCapabilities.hpp"
-        "threepp/renderers/gl/GLCubeMaps.hpp"
-        "threepp/renderers/gl/GLClipping.hpp"
-        "threepp/renderers/gl/GLGeometries.hpp"
-        "threepp/renderers/gl/GLLights.hpp"
-        "threepp/renderers/gl/GLMaterials.hpp"
-        "threepp/renderers/gl/GLMorphTargets.hpp"
-        "threepp/renderers/gl/GLObjects.hpp"
-        "threepp/renderers/gl/GLProperties.hpp"
-        "threepp/renderers/gl/GLProgram.hpp"
-        "threepp/renderers/gl/GLPrograms.hpp"
-        "threepp/renderers/gl/GLRenderLists.hpp"
-        "threepp/renderers/gl/GLRenderStates.hpp"
-        "threepp/renderers/gl/GLTextures.hpp"
-        "threepp/renderers/gl/GLUniforms.hpp"
-        "threepp/renderers/gl/GLUtils.hpp"
-        "threepp/renderers/gl/UniformUtils.hpp"
 
         "threepp/utils/RegexUtil.hpp"
 )
@@ -399,33 +359,85 @@ set(sources
         "threepp/utils/StringUtils.cpp"
         "threepp/utils/TaskManager.cpp"
 
-        "threepp/renderers/GLRenderer.cpp"
-        "threepp/renderers/GLRenderTarget.cpp"
-
-        "threepp/renderers/gl/GLAttributes.cpp"
-        "threepp/renderers/gl/GLBackground.cpp"
-        "threepp/renderers/gl/GLBindingStates.cpp"
-        "threepp/renderers/gl/GLBufferRenderer.cpp"
-        "threepp/renderers/gl/GLClipping.cpp"
-        "threepp/renderers/gl/GLCubeMaps.cpp"
-        "threepp/renderers/gl/GLGeometries.cpp"
-        "threepp/renderers/gl/GLInfo.cpp"
-        "threepp/renderers/gl/GLLights.cpp"
-        "threepp/renderers/gl/GLObjects.cpp"
-        "threepp/renderers/gl/GLProgram.cpp"
-        "threepp/renderers/gl/GLPrograms.cpp"
-        "threepp/renderers/gl/GLMaterials.cpp"
-        "threepp/renderers/gl/GLRenderLists.cpp"
-        "threepp/renderers/gl/GLRenderStates.cpp"
-        "threepp/renderers/gl/GLShadowMap.cpp"
-        "threepp/renderers/gl/GLState.cpp"
-        "threepp/renderers/gl/GLTextures.cpp"
-        "threepp/renderers/gl/GLUniforms.cpp"
-        "threepp/renderers/gl/ProgramParameters.cpp"
-
-        "threepp/renderers/shaders/ShaderLib.cpp"
-
 )
+
+if (NOT THREEPP_CORE_ONLY)
+
+    list(APPEND publicHeaders
+
+            "threepp/canvas/Monitor.hpp"
+            "threepp/canvas/WindowSize.hpp"
+
+            "threepp/renderers/GLRenderer.hpp"
+            "threepp/renderers/GLRenderTarget.hpp"
+
+            "threepp/renderers/gl/GLInfo.hpp"
+            "threepp/renderers/gl/GLShadowMap.hpp"
+            "threepp/renderers/gl/GLState.hpp"
+
+            "threepp/renderers/shaders/ShaderChunk.hpp"
+            "threepp/renderers/shaders/ShaderLib.hpp"
+            "threepp/renderers/shaders/UniformsLib.hpp"
+    )
+
+
+    list(APPEND privateHeaders
+
+            "threepp/renderers/GLCubeRenderTarget.hpp"
+
+            "threepp/renderers/gl/Buffer.hpp"
+            "threepp/renderers/gl/GLAttributes.hpp"
+            "threepp/renderers/gl/GLBackground.hpp"
+            "threepp/renderers/gl/GLBindingStates.hpp"
+            "threepp/renderers/gl/GLBufferRenderer.hpp"
+            "threepp/renderers/gl/GLCapabilities.hpp"
+            "threepp/renderers/gl/GLCubeMaps.hpp"
+            "threepp/renderers/gl/GLClipping.hpp"
+            "threepp/renderers/gl/GLGeometries.hpp"
+            "threepp/renderers/gl/GLLights.hpp"
+            "threepp/renderers/gl/GLMaterials.hpp"
+            "threepp/renderers/gl/GLMorphTargets.hpp"
+            "threepp/renderers/gl/GLObjects.hpp"
+            "threepp/renderers/gl/GLProperties.hpp"
+            "threepp/renderers/gl/GLProgram.hpp"
+            "threepp/renderers/gl/GLPrograms.hpp"
+            "threepp/renderers/gl/GLRenderLists.hpp"
+            "threepp/renderers/gl/GLRenderStates.hpp"
+            "threepp/renderers/gl/GLTextures.hpp"
+            "threepp/renderers/gl/GLUniforms.hpp"
+            "threepp/renderers/gl/GLUtils.hpp"
+            "threepp/renderers/gl/UniformUtils.hpp"
+    )
+
+
+    list(APPEND sources
+
+            "threepp/renderers/GLRenderer.cpp"
+            "threepp/renderers/GLRenderTarget.cpp"
+
+            "threepp/renderers/gl/GLAttributes.cpp"
+            "threepp/renderers/gl/GLBackground.cpp"
+            "threepp/renderers/gl/GLBindingStates.cpp"
+            "threepp/renderers/gl/GLBufferRenderer.cpp"
+            "threepp/renderers/gl/GLClipping.cpp"
+            "threepp/renderers/gl/GLCubeMaps.cpp"
+            "threepp/renderers/gl/GLGeometries.cpp"
+            "threepp/renderers/gl/GLInfo.cpp"
+            "threepp/renderers/gl/GLLights.cpp"
+            "threepp/renderers/gl/GLObjects.cpp"
+            "threepp/renderers/gl/GLProgram.cpp"
+            "threepp/renderers/gl/GLPrograms.cpp"
+            "threepp/renderers/gl/GLMaterials.cpp"
+            "threepp/renderers/gl/GLRenderLists.cpp"
+            "threepp/renderers/gl/GLRenderStates.cpp"
+            "threepp/renderers/gl/GLShadowMap.cpp"
+            "threepp/renderers/gl/GLState.cpp"
+            "threepp/renderers/gl/GLTextures.cpp"
+            "threepp/renderers/gl/GLUniforms.cpp"
+            "threepp/renderers/gl/ProgramParameters.cpp"
+
+            "threepp/renderers/shaders/ShaderLib.cpp")
+endif ()
 
 if (THREEPP_WITH_SVG)
     list(APPEND publicHeaders
@@ -438,7 +450,7 @@ if (THREEPP_WITH_SVG)
     )
 endif ()
 
-if (THREEPP_WITH_AUDIO)
+if (THREEPP_WITH_AUDIO AND NOT THREEPP_CORE_ONLY)
     list(APPEND publicHeaders
             "threepp/audio/Audio.hpp"
     )
@@ -448,7 +460,7 @@ if (THREEPP_WITH_AUDIO)
     )
 endif ()
 
-if (THREEPP_WITH_GLFW)
+if (THREEPP_WITH_GLFW AND NOT THREEPP_CORE_ONLY)
     list(APPEND publicHeaders
             "threepp/canvas/Canvas.hpp"
     )
@@ -492,7 +504,7 @@ These can be installed on Ubuntu systems via sudo apt install libxinerama-dev li
     endif ()
 endif ()
 
-if (NOT DEFINED EMSCRIPTEN)
+if (NOT DEFINED EMSCRIPTEN AND NOT THREEPP_CORE_ONLY)
     list(APPEND privateHeaders
             "threepp/utils/LoadGlad.hpp"
     )
@@ -502,12 +514,14 @@ if (NOT DEFINED EMSCRIPTEN)
     )
 endif ()
 
-include("${PROJECT_SOURCE_DIR}/cmake/embed.cmake")
+if (NOT THREEPP_CORE_ONLY)
+    include("${PROJECT_SOURCE_DIR}/cmake/embed.cmake")
 
-list(APPEND sources
-        "${generatedSourcesDir}/threepp/EmbeddedFonts.cpp"
-        "${generatedSourcesDir}/threepp/renderers/shaders/ShaderChunk.cpp"
-)
+    list(APPEND sources
+            "${generatedSourcesDir}/threepp/EmbeddedFonts.cpp"
+            "${generatedSourcesDir}/threepp/renderers/shaders/ShaderChunk.cpp"
+    )
+endif ()
 
 add_library(threepp ${sources} ${privateHeaders} ${publicHeadersFull})
 add_library(threepp::threepp ALIAS threepp)
@@ -525,14 +539,22 @@ target_include_directories(threepp
         "${generatedSourcesDir}"
         "${CMAKE_CURRENT_SOURCE_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/earcut"
-        "${CMAKE_CURRENT_SOURCE_DIR}/external/miniaudio"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/nlohmann"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/pugixml"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/quickhull"
         "${CMAKE_CURRENT_SOURCE_DIR}/external/stb"
 )
 
-if (NOT DEFINED EMSCRIPTEN)
+if (NOT THREEPP_CORE_ONLY)
+
+    target_include_directories(threepp
+            PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/external/miniaudio"
+    )
+
+endif ()
+
+if (NOT DEFINED EMSCRIPTEN AND NOT THREEPP_CORE_ONLY)
 
     target_include_directories(threepp
             PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,5 +13,9 @@ add_subdirectory(cameras)
 add_subdirectory(core)
 add_subdirectory(math)
 add_subdirectory(utils)
-add_subdirectory(renderers)
 add_subdirectory(loaders)
+
+if (NOT THREEPP_CORE_ONLY)
+    add_subdirectory(renderers)
+endif ()
+


### PR DESCRIPTION
Add option to build without canvas and renderer.

Useful when you only need access to the math, geometries etc. 
