### PR TITLE
Fix missing <algorithm> include for std::clamp

### DIFF
--- a/src/threepp/helpers/LidarSensor.cpp
+++ b/src/threepp/helpers/LidarSensor.cpp
@@ -9,6 +9,7 @@
 #include "threepp/renderers/GLRenderer.hpp"
 #include "threepp/textures/DepthTexture.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <optional>
 #include <random>


### PR DESCRIPTION
## Summary

This pull request fixes a compilation issue where `std::clamp` was reported as not being a member of `std`.

## Root cause

The implementation uses `std::clamp`, but the required standard header `<algorithm>` was not included.  
Although the project is already configured to use C++20, `std::clamp` is declared in `<algorithm>`, so the symbol is unavailable without that header.

## Changes

- Added the missing `#include <algorithm>` header

## Result

This resolves the build error:

```text
'clamp' is not a member of 'std'