### PR TITLE
Fixes for linux support

### DIFF
--- a/examples/misc/water_side_by_side.cpp
+++ b/examples/misc/water_side_by_side.cpp
@@ -9,6 +9,7 @@
 
 #include "threepp/extras/imgui/ImguiContext.hpp"
 #include <cmath>
+#include <cstring>
 
 using namespace threepp;
 

--- a/examples/misc/wgpu_gltf_samples.cpp
+++ b/examples/misc/wgpu_gltf_samples.cpp
@@ -7,6 +7,7 @@
 #include "threepp/threepp.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <future>
 

--- a/src/threepp/renderers/WgpuRenderer.cpp
+++ b/src/threepp/renderers/WgpuRenderer.cpp
@@ -72,6 +72,9 @@
 #include <emscripten.h>
 #endif
 
+// X11 defines a None macro which breaks one of the enums
+#undef None
+
 // stb_image_write — implementation is already compiled in GLRenderer.cpp.
 // Match the linkage used by the implementation (extern "C" in C++).
 #define STBIWDEF extern "C"


### PR DESCRIPTION
Guessing there are some stdlib or compiler differences which is why it compiled for other platforms even without the cstring and cmath includes, but it would not compile on linux  (gcc c++).
The undef is because an X11 header defines a None macro, which clashes with one of the enum variants