### PR TITLE
Vulkan: lossless synthetic-perception AOVs — float/int readback + stable instance & semantic segmentation

### DIFF
--- a/include/threepp/renderers/VulkanRendererCore.hpp
+++ b/include/threepp/renderers/VulkanRendererCore.hpp
@@ -84,6 +84,30 @@ namespace threepp {
         [[nodiscard]] bool sceneCaptureEnabled() const;
         [[nodiscard]] std::vector<unsigned char> readSceneRGBPixels();
 
+        // ── G-buffer AOV readback (deferred / hybrid raster prepass) ──────
+        // The raster G-buffer already computes high-precision per-pixel geometry
+        // and material data every frame. readGBufferAOV copies one attachment
+        // from the most recently rendered frame into `out` as its NATIVE GPU
+        // format — no 8-bit swapchain round-trip, no id hashing — so ML / sensor
+        // pipelines get lossless depth, normals, recoverable integer instance
+        // ids and motion vectors. Call after render().
+        //
+        // On success `out` is resized to width*height*bytesPerPixel (tightly
+        // packed, row-major, top-left origin) and true is returned. Returns
+        // false before the first frame or when the backend has no G-buffer.
+        // width/height come back as the render-scaled G-buffer extent (see
+        // setRenderScale), which may be smaller than framebufferSize().
+        //
+        // Per-AOV element layout (bytesPerPixel):
+        //   Depth  (4)  1x float32 : reversed-Z NDC depth in [0,1] (1=near, 0=far)
+        //   Normal (8)  4x float16 : world normal encoded n*0.5+0.5 in xyz, roughness in w
+        //   Motion (8)  4x float16 : screen-space motion (prevNDC - currNDC) in xy, prevDepth in z
+        //   Ids    (8)  4x uint16  : x = instanceCustomIndex+1 (0 = sky/no-hit), y = meshId, z = flag bits
+        //   Albedo (4)  4x unorm8  : linear base colour in rgb, metalness in a
+        enum class GBufferAOV { Depth, Normal, Motion, Ids, Albedo };
+        [[nodiscard]] bool readGBufferAOV(GBufferAOV aov, std::vector<uint8_t>& out,
+                                          int& width, int& height, int& bytesPerPixel);
+
         // ── GPU event camera (DVS) detector ───────────────────────────────
         struct EventCameraParams {
             float    threshold        = 0.15f;

--- a/include/threepp/renderers/VulkanRendererCore.hpp
+++ b/include/threepp/renderers/VulkanRendererCore.hpp
@@ -108,6 +108,19 @@ namespace threepp {
         [[nodiscard]] bool readGBufferAOV(GBufferAOV aov, std::vector<uint8_t>& out,
                                           int& width, int& height, int& bytesPerPixel);
 
+        // ── Segmentation labels for the Ids AOV ──────────────────────────
+        // The Ids attachment's .y channel is a STABLE per-object instance id,
+        // auto-assigned on first draw (unlike .x, the per-frame visible index,
+        // it survives add/remove/hide/LOD). setObjectInstanceId overrides it for
+        // a specific object; setObjectClassId tags an object with an 8-bit
+        // semantic class written to .z bits 8..15 — so a single readback yields
+        // both instance- and semantic-segmentation ground truth. Both take
+        // effect on the next render. instanceId is truncated to 16 bits, classId
+        // clamped to [0, 255]. Keyed by Object3D::id, so calling before the
+        // object is added to the scene is fine.
+        void setObjectInstanceId(const Object3D& obj, uint32_t instanceId);
+        void setObjectClassId(const Object3D& obj, uint32_t classId);
+
         // ── GPU event camera (DVS) detector ───────────────────────────────
         struct EventCameraParams {
             float    threshold        = 0.15f;

--- a/python/examples/vulkan_aovs.py
+++ b/python/examples/vulkan_aovs.py
@@ -40,6 +40,9 @@ scene = tp.Scene()
 scene.background = 0x202830
 
 # Three distinct objects so the segmentation AOV shows three distinct ids.
+# Instance ids are assigned automatically (stable across frames); here we also
+# tag each object with a semantic CLASS id so read_class_ids() gives semantic
+# segmentation: the three shapes share class 1, the ground is class 2.
 specs = [(0xff5555, 0.45, tp.BoxGeometry(1.1, 1.1, 1.1)),
          (0x55ff66, 0.30, tp.SphereGeometry(0.7, 32, 16)),
          (0x5599ff, 0.60, tp.TorusKnotGeometry(0.45, 0.16))]
@@ -51,6 +54,7 @@ for i, (color, rough, geo) in enumerate(specs):
     mesh = tp.Mesh(geo, mat)
     mesh.position.x = (i - 1) * 2.0
     scene.add(mesh)
+    renderer.set_class_id(mesh, 1)  # class 1 = "shape"
 
 ground_mat = tp.MeshStandardMaterial()
 ground_mat.color = 0x555560
@@ -58,6 +62,7 @@ ground = tp.Mesh(tp.PlaneGeometry(40, 40), ground_mat)
 ground.position.y = -1.0
 ground.rotate_x(-3.14159 / 2)
 scene.add(ground)
+renderer.set_class_id(ground, 2)  # class 2 = "ground"
 
 scene.add(tp.HemisphereLight(0xffffff, 0x404048, 1.0))
 sun = tp.DirectionalLight(0xffffff, 3.0)
@@ -80,10 +85,15 @@ fg = depth[depth < 99.0]  # exclude the far-plane background
 print(f"{'depth':14s} {depth.shape} {depth.dtype}  "
       f"foreground {fg.min():.2f}..{fg.max():.2f} units")
 
-# Lossless labels: recoverable integer instance ids (uint32), not hashed colours.
-# 0 = sky; every other id is instanceCustomIndex+1, directly usable as a mask.
+# Lossless labels: STABLE integer instance ids (uint32), not hashed colours.
+# 0 = sky; every other id is a per-object label that persists across frames,
+# directly usable as a mask. Assign specific ids with renderer.set_instance_id.
 ids = renderer.read_instance_ids(scene, camera)
 print(f"{'instance_ids':14s} {ids.shape} {ids.dtype}  distinct ids {np.unique(ids).tolist()}")
+
+# Semantic class ids (uint32): the classes we tagged above (0 = sky/unset).
+cls = renderer.read_class_ids(scene, camera)
+print(f"{'class_ids':14s} {cls.shape} {cls.dtype}  distinct classes {np.unique(cls).tolist()}")
 
 # Full-precision world normals (float32, unit vectors) — no 8-bit quantization.
 normals_f = renderer.read_normals_float(scene, camera)

--- a/python/examples/vulkan_aovs.py
+++ b/python/examples/vulkan_aovs.py
@@ -1,9 +1,14 @@
 """Deferred G-buffer AOVs from the Vulkan renderer, as numpy — labels for free.
 
-The deferred (RasterFirst) renderer writes a full G-buffer every frame. This
-reads several attachments back as (H, W, 3) uint8 images: the shaded RGB, world
-normals, per-instance segmentation, and albedo — the raw material for synthetic
-training data (no path tracer, no manual labelling).
+The deferred (RasterFirst) renderer writes a full G-buffer every frame. Two ways
+to read it back:
+
+  * Visualisation (uint8): render_aovs() → (H, W, 3) uint8 montage tiles.
+  * Lossless (float / int): read_depth() → metric (H,W) f32 · read_normals_float()
+    → world normals (H,W,3) f32 · read_instance_ids() → RECOVERABLE (H,W) uint32
+    labels (0 = sky, else instanceCustomIndex+1; no hashing) · read_motion() →
+    (H,W,2) f32 pixel flow. read_aovs_typed() reads several at once from a single
+    render. This is the raw material an ML / sensor pipeline actually trains on.
 
     python vulkan_aovs.py
 
@@ -74,6 +79,16 @@ depth = renderer.read_depth(scene, camera)
 fg = depth[depth < 99.0]  # exclude the far-plane background
 print(f"{'depth':14s} {depth.shape} {depth.dtype}  "
       f"foreground {fg.min():.2f}..{fg.max():.2f} units")
+
+# Lossless labels: recoverable integer instance ids (uint32), not hashed colours.
+# 0 = sky; every other id is instanceCustomIndex+1, directly usable as a mask.
+ids = renderer.read_instance_ids(scene, camera)
+print(f"{'instance_ids':14s} {ids.shape} {ids.dtype}  distinct ids {np.unique(ids).tolist()}")
+
+# Full-precision world normals (float32, unit vectors) — no 8-bit quantization.
+normals_f = renderer.read_normals_float(scene, camera)
+print(f"{'normals_f':14s} {normals_f.shape} {normals_f.dtype}  "
+      f"range {normals_f.min():.2f}..{normals_f.max():.2f}")
 
 # Normalize the metric depth to a grayscale tile for the montage (near = bright).
 lo, hi = (float(fg.min()), float(fg.max())) if fg.size else (0.0, 1.0)

--- a/python/src/bind_vulkan.cpp
+++ b/python/src/bind_vulkan.cpp
@@ -173,8 +173,9 @@ namespace {
             return arr;
         }
 
-        // Recoverable integer instance ids (H, W) uint32. 0 = sky / no hit;
-        // otherwise instanceCustomIndex + 1. No hashing, no collisions.
+        // Stable, recoverable integer instance ids (H, W) uint32. 0 = sky / no
+        // hit; otherwise a per-object id that persists across frames (outIds.y).
+        // No hashing, no collisions. Assign specific ids with set_instance_id.
         py::array_t<uint32_t> ids_last() {
             std::vector<uint8_t> raw;
             int w = 0, h = 0, bpp = 0;
@@ -184,9 +185,27 @@ namespace {
             }
             py::array_t<uint32_t> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w)});
             auto* dst     = arr.mutable_data();
-            const auto* s = reinterpret_cast<const uint16_t*>(raw.data());// RGBA16_UINT, .x = id
+            const auto* s = reinterpret_cast<const uint16_t*>(raw.data());// RGBA16_UINT, .y = stable id
             const size_t px = static_cast<size_t>(w) * h;
-            for (size_t i = 0; i < px; ++i) dst[i] = static_cast<uint32_t>(s[i * 4 + 0]);
+            for (size_t i = 0; i < px; ++i) dst[i] = static_cast<uint32_t>(s[i * 4 + 1]);
+            return arr;
+        }
+
+        // Semantic class ids (H, W) uint32 from outIds.z bits 8..15. 0 = unset;
+        // tag objects with set_class_id. Gives semantic segmentation alongside
+        // the instance ids above, from the same G-buffer read.
+        py::array_t<uint32_t> class_last() {
+            std::vector<uint8_t> raw;
+            int w = 0, h = 0, bpp = 0;
+            if (!renderer_.readGBufferAOV(VulkanRenderer::GBufferAOV::Ids, raw, w, h, bpp) ||
+                w <= 0 || h <= 0) {
+                return py::array_t<uint32_t>({py::ssize_t(0), py::ssize_t(0)});
+            }
+            py::array_t<uint32_t> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w)});
+            auto* dst     = arr.mutable_data();
+            const auto* s = reinterpret_cast<const uint16_t*>(raw.data());// RGBA16_UINT, .z = flags|class
+            const size_t px = static_cast<size_t>(w) * h;
+            for (size_t i = 0; i < px; ++i) dst[i] = static_cast<uint32_t>((s[i * 4 + 2] >> 8) & 0xFFu);
             return arr;
         }
 
@@ -239,10 +258,20 @@ namespace {
             drive_frames(scene, camera);
             return ids_last();
         }
+        py::array_t<uint32_t> read_class_ids(Object3D& scene, Camera& camera) {
+            drive_frames(scene, camera);
+            return class_last();
+        }
         py::array_t<float> read_motion(Object3D& scene, Camera& camera) {
             drive_frames(scene, camera);
             return motion_last();
         }
+
+        // Label assignment for the segmentation AOVs. instance id overrides the
+        // auto-assigned stable id (outIds.y); class id (0..255) tags the object
+        // for semantic segmentation (outIds.z). Take effect on the next render.
+        void set_instance_id(Object3D& obj, uint32_t id) { renderer_.setObjectInstanceId(obj, id); }
+        void set_class_id(Object3D& obj, uint32_t cls) { renderer_.setObjectClassId(obj, cls); }
 
         // Render ONCE, then read every requested AOV from that same frame, each
         // as its natural numpy dtype: depth (H,W) f32 · normals (H,W,3) f32 ·
@@ -259,6 +288,8 @@ namespace {
                     out[py::str(name)] = normals_last();
                 } else if (name == "instance_ids" || name == "ids" || name == "segmentation") {
                     out[py::str(name)] = ids_last();
+                } else if (name == "class_ids" || name == "class" || name == "semantic") {
+                    out[py::str(name)] = class_last();
                 } else if (name == "motion" || name == "flow") {
                     out[py::str(name)] = motion_last();
                 } else if (name == "rgb" || name == "shaded" || name == "color") {
@@ -267,7 +298,7 @@ namespace {
                     out[py::str(name)] = albedo_last();
                 } else {
                     throw std::invalid_argument("unknown typed AOV '" + name +
-                            "' — use: depth, normals, instance_ids, motion, rgb, albedo");
+                            "' — use: depth, normals, instance_ids, class_ids, motion, rgb, albedo");
                 }
             }
             return out;
@@ -390,11 +421,21 @@ namespace threepp_py {
                 // ── Lossless float / int AOV readback (native G-buffer copy) ──
                 .def("read_instance_ids", &PyVulkanRenderer::read_instance_ids,
                      py::arg("scene"), py::arg("camera"),
-                     "Recoverable per-pixel instance ids as (H, W) uint32. 0 = sky / no hit; "
-                     "otherwise instanceCustomIndex + 1. No hashing, no collisions — the "
-                     "labels an ML segmentation pipeline can index directly. NOTE: ids are "
-                     "per-frame visible-set indices (stable for a static scene; may change "
-                     "across frames on add/remove/hide/LOD).")
+                     "Stable per-pixel instance ids as (H, W) uint32. 0 = sky / no hit; otherwise "
+                     "a per-object id that persists across frames and visible-set changes (no "
+                     "hashing, no collisions). Auto-assigned; override with set_instance_id().")
+                .def("read_class_ids", &PyVulkanRenderer::read_class_ids,
+                     py::arg("scene"), py::arg("camera"),
+                     "Semantic class ids as (H, W) uint32 (0..255; 0 = unset). Tag objects with "
+                     "set_class_id() to get semantic segmentation alongside the instance ids.")
+                .def("set_instance_id", &PyVulkanRenderer::set_instance_id,
+                     py::arg("object"), py::arg("instance_id"),
+                     "Assign a specific stable instance id (0..65535) to an object for the ids "
+                     "AOV. Overrides the auto-assigned id. Takes effect on the next render.")
+                .def("set_class_id", &PyVulkanRenderer::set_class_id,
+                     py::arg("object"), py::arg("class_id"),
+                     "Tag an object with a semantic class id (0..255) for read_class_ids(). "
+                     "Objects sharing a class id share a semantic label.")
                 .def("read_normals_float", &PyVulkanRenderer::read_normals_float,
                      py::arg("scene"), py::arg("camera"),
                      "World-space unit normals as (H, W, 3) float32, components in [-1, 1] "

--- a/python/src/bind_vulkan.cpp
+++ b/python/src/bind_vulkan.cpp
@@ -5,12 +5,19 @@
 // when THREEPP_WITH_VULKAN is ON). Otherwise init_vulkan only sets HAS_VULKAN.
 //
 // The deferred renderer writes a full G-buffer every frame (world normals,
-// optical flow, instance-segmentation ids, albedo, depth). The renderer's
-// debug-resolve compute pass (setHybridDebugView) encodes a chosen attachment
-// into the swapchain, where readRGBPixels() can read it back — so the AOVs come
-// out as (H, W, 3) uint8 images: normals as n*0.5+0.5, segmentation as per-id
-// hashed colours, albedo passthrough. (Raw float depth has no readback path in
-// the renderer yet; it is the natural next step.)
+// optical flow, instance-segmentation ids, albedo, depth). Two readback paths:
+//
+//   * Visualisation (8-bit): render_aov / render_aovs go through the debug-
+//     resolve compute pass (setHybridDebugView) → swapchain → readRGBPixels,
+//     returning (H, W, 3) uint8 (normals as n*0.5+0.5, segmentation as per-id
+//     hashed colour, albedo passthrough). Good for montages / eyeballing.
+//
+//   * Lossless (float / int): read_depth, read_normals_float, read_instance_ids,
+//     read_motion and read_aovs_typed copy the native G-buffer attachment
+//     straight to host memory via VulkanRendererCore::readGBufferAOV — full-
+//     precision depth (f32), world normals (f32), RECOVERABLE integer instance
+//     ids (u32, no hashing) and metric motion (f32). This is the material an ML
+//     / sensor pipeline actually trains on.
 #include "bindings.hpp"
 
 #ifdef THREEPP_PY_HAS_VULKAN
@@ -26,6 +33,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -34,6 +42,36 @@ namespace py = pybind11;// the threepp_py::py alias isn't visible in the anon na
 using namespace threepp;
 
 namespace {
+
+    // IEEE-754 half (binary16) -> float32. The G-buffer normal/motion attachments
+    // are R16G16B16A16_SFLOAT; the native AOV readback returns their raw bytes, so
+    // we decode the halves host-side (numpy has no lossless half decode we can rely
+    // on across versions). Handles subnormals, inf and NaN.
+    inline float half_to_float(uint16_t hbits) {
+        const uint32_t sign = static_cast<uint32_t>(hbits & 0x8000u) << 16;
+        const uint32_t exp  = (hbits & 0x7C00u) >> 10;
+        const uint32_t mant = (hbits & 0x03FFu);
+        uint32_t bits;
+        if (exp == 0u) {
+            if (mant == 0u) {
+                bits = sign;// signed zero
+            } else {
+                // Subnormal: normalize into a float32 normal.
+                int e    = 0;
+                uint32_t m = mant;
+                while ((m & 0x0400u) == 0u) { m <<= 1; ++e; }
+                m &= 0x03FFu;
+                bits = sign | (static_cast<uint32_t>(127 - 15 - e) << 23) | (m << 13);
+            }
+        } else if (exp == 0x1Fu) {
+            bits = sign | 0x7F800000u | (mant << 13);// inf / NaN
+        } else {
+            bits = sign | ((exp + (127u - 15u)) << 23) | (mant << 13);
+        }
+        float f;
+        std::memcpy(&f, &bits, sizeof(f));
+        return f;
+    }
 
     // AOV name -> setHybridDebugView code. 0 = the shaded RGB output (Off).
     int aov_code(const std::string& aov) {
@@ -88,33 +126,151 @@ namespace {
         void set_scissor(int x, int y, int w, int h) { renderer_.setScissor(x, y, w, h); }
         void set_scissor_test(bool enabled) { renderer_.setScissorTest(enabled); }
 
-        // Metric depth as (H, W) float32 in scene units (distance from the
-        // camera). The depth debug-view packs the reverse-Z depth into 24-bit
-        // RGB; here we decode it and linearize with the camera near/far. Sky /
-        // background pixels (cleared to far) read as `far`.
-        py::array_t<float> read_depth(Object3D& scene, Camera& camera) {
-            renderer_.setHybridDebugView(5);// Depth → 24-bit packed reverse-Z
-            drive_frames(scene, camera);
-            const std::vector<unsigned char> px = renderer_.readRGBPixels();
-            renderer_.setHybridDebugView(0);
+        // ── Native G-buffer AOV readback (lossless float / int) ──────────
+        // These decode the *last rendered frame's* G-buffer attachment straight
+        // from its native GPU format via VulkanRendererCore::readGBufferAOV — no
+        // 8-bit swapchain round-trip, no id hashing. The *_last() helpers assume a
+        // frame is already on screen (call render()/drive first); the public
+        // read_* wrappers below drive a frame themselves for one-shot use.
 
-            const auto s = renderer_.framebufferSize();
-            const int w = s.width(), h = s.height();
+        // Metric depth (H, W) float32 — distance from the camera in scene units.
+        // Background (cleared to the far plane) reads as `far`. Full 32-bit
+        // precision from the D32 depth buffer (the old path quantized to 24 bits).
+        py::array_t<float> depth_last(Camera& camera) {
+            std::vector<uint8_t> raw;
+            int w = 0, h = 0, bpp = 0;
+            if (!renderer_.readGBufferAOV(VulkanRenderer::GBufferAOV::Depth, raw, w, h, bpp) ||
+                w <= 0 || h <= 0) {
+                return py::array_t<float>({py::ssize_t(0), py::ssize_t(0)});
+            }
             py::array_t<float> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w)});
-            const size_t pxCount = static_cast<size_t>(w) * h;
-            const size_t ch = pxCount ? px.size() / pxCount : 3;
-            auto* dst = arr.mutable_data();
-            const float nearP = camera.nearPlane;
-            const float farP = camera.farPlane;
-            if (px.size() >= pxCount * ch && (ch == 3 || ch == 4)) {
-                for (size_t i = 0; i < pxCount; ++i) {
-                    const uint32_t r = px[i * ch + 0], gg = px[i * ch + 1], b = px[i * ch + 2];
-                    const float d = static_cast<float>((r << 16) | (gg << 8) | b) / 16777215.0f;
-                    // reverse-Z [0,1] (1=near, 0=far) → distance from camera.
-                    dst[i] = (d <= 0.f) ? farP : (nearP * farP) / (nearP + d * (farP - nearP));
-                }
+            auto* dst        = arr.mutable_data();
+            const auto* d    = reinterpret_cast<const float*>(raw.data());// D32_SFLOAT
+            const float nearP = camera.nearPlane, farP = camera.farPlane;
+            const size_t px   = static_cast<size_t>(w) * h;
+            for (size_t i = 0; i < px; ++i) {
+                const float z = d[i];// reverse-Z NDC depth [0,1] (1=near, 0=far)
+                dst[i] = (z <= 0.f) ? farP : (nearP * farP) / (nearP + z * (farP - nearP));
             }
             return arr;
+        }
+
+        // World-space unit normals (H, W, 3) float32, components in [-1, 1].
+        py::array_t<float> normals_last() {
+            std::vector<uint8_t> raw;
+            int w = 0, h = 0, bpp = 0;
+            if (!renderer_.readGBufferAOV(VulkanRenderer::GBufferAOV::Normal, raw, w, h, bpp) ||
+                w <= 0 || h <= 0) {
+                return py::array_t<float>({py::ssize_t(0), py::ssize_t(0), py::ssize_t(3)});
+            }
+            py::array_t<float> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w), py::ssize_t(3)});
+            auto* dst     = arr.mutable_data();
+            const auto* s = reinterpret_cast<const uint16_t*>(raw.data());// RGBA16F, xyz = n*0.5+0.5
+            const size_t px = static_cast<size_t>(w) * h;
+            for (size_t i = 0; i < px; ++i)
+                for (int c = 0; c < 3; ++c)
+                    dst[i * 3 + c] = half_to_float(s[i * 4 + c]) * 2.f - 1.f;
+            return arr;
+        }
+
+        // Recoverable integer instance ids (H, W) uint32. 0 = sky / no hit;
+        // otherwise instanceCustomIndex + 1. No hashing, no collisions.
+        py::array_t<uint32_t> ids_last() {
+            std::vector<uint8_t> raw;
+            int w = 0, h = 0, bpp = 0;
+            if (!renderer_.readGBufferAOV(VulkanRenderer::GBufferAOV::Ids, raw, w, h, bpp) ||
+                w <= 0 || h <= 0) {
+                return py::array_t<uint32_t>({py::ssize_t(0), py::ssize_t(0)});
+            }
+            py::array_t<uint32_t> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w)});
+            auto* dst     = arr.mutable_data();
+            const auto* s = reinterpret_cast<const uint16_t*>(raw.data());// RGBA16_UINT, .x = id
+            const size_t px = static_cast<size_t>(w) * h;
+            for (size_t i = 0; i < px; ++i) dst[i] = static_cast<uint32_t>(s[i * 4 + 0]);
+            return arr;
+        }
+
+        // Screen-space motion vectors (H, W, 2) float32, in PIXELS: where each
+        // surface was last frame minus where it is now (prev - curr). +x is
+        // rightward; the y sign follows the Vulkan NDC (down-positive) convention.
+        py::array_t<float> motion_last() {
+            std::vector<uint8_t> raw;
+            int w = 0, h = 0, bpp = 0;
+            if (!renderer_.readGBufferAOV(VulkanRenderer::GBufferAOV::Motion, raw, w, h, bpp) ||
+                w <= 0 || h <= 0) {
+                return py::array_t<float>({py::ssize_t(0), py::ssize_t(0), py::ssize_t(2)});
+            }
+            py::array_t<float> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w), py::ssize_t(2)});
+            auto* dst     = arr.mutable_data();
+            const auto* s = reinterpret_cast<const uint16_t*>(raw.data());// RGBA16F, .xy = NDC delta
+            const float sx = 0.5f * static_cast<float>(w);
+            const float sy = 0.5f * static_cast<float>(h);
+            const size_t px = static_cast<size_t>(w) * h;
+            for (size_t i = 0; i < px; ++i) {
+                dst[i * 2 + 0] = half_to_float(s[i * 4 + 0]) * sx;// NDC delta → pixels
+                dst[i * 2 + 1] = half_to_float(s[i * 4 + 1]) * sy;
+            }
+            return arr;
+        }
+
+        // Linear base colour + metalness (H, W, 4) uint8: rgb = linear albedo,
+        // a = metalness. Native G-buffer read (no debug-blit re-render).
+        py::array_t<uint8_t> albedo_last() {
+            std::vector<uint8_t> raw;
+            int w = 0, h = 0, bpp = 0;
+            if (!renderer_.readGBufferAOV(VulkanRenderer::GBufferAOV::Albedo, raw, w, h, bpp) ||
+                w <= 0 || h <= 0) {
+                return py::array_t<uint8_t>({py::ssize_t(0), py::ssize_t(0), py::ssize_t(4)});
+            }
+            py::array_t<uint8_t> arr({static_cast<py::ssize_t>(h), static_cast<py::ssize_t>(w), py::ssize_t(4)});
+            std::memcpy(arr.mutable_data(), raw.data(), raw.size());// RGBA8, tightly packed
+            return arr;
+        }
+
+        py::array_t<float> read_depth(Object3D& scene, Camera& camera) {
+            drive_frames(scene, camera);
+            return depth_last(camera);
+        }
+        py::array_t<float> read_normals_float(Object3D& scene, Camera& camera) {
+            drive_frames(scene, camera);
+            return normals_last();
+        }
+        py::array_t<uint32_t> read_instance_ids(Object3D& scene, Camera& camera) {
+            drive_frames(scene, camera);
+            return ids_last();
+        }
+        py::array_t<float> read_motion(Object3D& scene, Camera& camera) {
+            drive_frames(scene, camera);
+            return motion_last();
+        }
+
+        // Render ONCE, then read every requested AOV from that same frame, each
+        // as its natural numpy dtype: depth (H,W) f32 · normals (H,W,3) f32 ·
+        // instance_ids (H,W) u32 · motion (H,W,2) f32 · rgb/segmentation/albedo
+        // (H,W,3) u8. The efficient multi-AOV entry point for dataset generation.
+        py::dict read_aovs_typed(Object3D& scene, Camera& camera,
+                                 const std::vector<std::string>& aovs) {
+            drive_frames(scene, camera);
+            py::dict out;
+            for (const auto& name : aovs) {
+                if (name == "depth") {
+                    out[py::str(name)] = depth_last(camera);
+                } else if (name == "normals" || name == "normal") {
+                    out[py::str(name)] = normals_last();
+                } else if (name == "instance_ids" || name == "ids" || name == "segmentation") {
+                    out[py::str(name)] = ids_last();
+                } else if (name == "motion" || name == "flow") {
+                    out[py::str(name)] = motion_last();
+                } else if (name == "rgb" || name == "shaded" || name == "color") {
+                    out[py::str(name)] = to_numpy(renderer_.readRGBPixels());
+                } else if (name == "albedo") {
+                    out[py::str(name)] = albedo_last();
+                } else {
+                    throw std::invalid_argument("unknown typed AOV '" + name +
+                            "' — use: depth, normals, instance_ids, motion, rgb, albedo");
+                }
+            }
+            return out;
         }
 
         py::array_t<uint8_t> render_aov(Object3D& scene, Camera& camera, const std::string& aov) {
@@ -229,7 +385,31 @@ namespace threepp_py {
                      py::arg("scene"), py::arg("camera"))
                 .def("read_depth", &PyVulkanRenderer::read_depth, py::arg("scene"), py::arg("camera"),
                      "Metric depth as (H, W) float32 — distance from the camera in scene units. "
-                     "Background reads as the camera far plane.")
+                     "Background reads as the camera far plane. Full 32-bit precision "
+                     "(native D32 read; supersedes the old 24-bit-packed path).")
+                // ── Lossless float / int AOV readback (native G-buffer copy) ──
+                .def("read_instance_ids", &PyVulkanRenderer::read_instance_ids,
+                     py::arg("scene"), py::arg("camera"),
+                     "Recoverable per-pixel instance ids as (H, W) uint32. 0 = sky / no hit; "
+                     "otherwise instanceCustomIndex + 1. No hashing, no collisions — the "
+                     "labels an ML segmentation pipeline can index directly. NOTE: ids are "
+                     "per-frame visible-set indices (stable for a static scene; may change "
+                     "across frames on add/remove/hide/LOD).")
+                .def("read_normals_float", &PyVulkanRenderer::read_normals_float,
+                     py::arg("scene"), py::arg("camera"),
+                     "World-space unit normals as (H, W, 3) float32, components in [-1, 1] "
+                     "(full precision; read_normals() stays the 8-bit visualisation).")
+                .def("read_motion", &PyVulkanRenderer::read_motion,
+                     py::arg("scene"), py::arg("camera"),
+                     "Screen-space motion vectors as (H, W, 2) float32, in pixels "
+                     "(previous - current surface position; +x rightward, y down-positive).")
+                .def("read_aovs_typed", &PyVulkanRenderer::read_aovs_typed,
+                     py::arg("scene"), py::arg("camera"),
+                     py::arg("aovs") = std::vector<std::string>{"rgb", "depth", "normals", "instance_ids"},
+                     "Render ONCE and read every requested AOV from that same frame, each as "
+                     "its natural dtype: depth (H,W) f32 · normals (H,W,3) f32 · instance_ids "
+                     "(H,W) u32 · motion (H,W,2) f32 · rgb (H,W,3) u8 · albedo (H,W,4) u8 "
+                     "(linear rgb + metalness). The efficient multi-AOV entry point.")
                 .def("set_clear_color", &PyVulkanRenderer::set_clear_color, py::arg("color"), py::arg("alpha") = 1.f)
                 // No-op shadow toggle for GLRenderer API parity: Vulkan analytic
                 // lights always cast ray-traced shadows, so this is stored but

--- a/python/threepp/threepp.pyi
+++ b/python/threepp/threepp.pyi
@@ -1770,8 +1770,12 @@ class VulkanRenderer:
     def read_aovs_typed(self, scene: Object3D, camera: Camera, aovs: list[str] = ['rgb', 'depth', 'normals', 'instance_ids']) -> dict:
         """
         Render ONCE and read every requested AOV from that same frame, each as its natural dtype:
-        depth (H,W) f32 · normals (H,W,3) f32 · instance_ids (H,W) u32 · motion (H,W,2) f32 ·
-        rgb (H,W,3) u8 · albedo (H,W,4) u8 (linear rgb + metalness). The efficient multi-AOV entry point.
+        depth (H,W) f32 · normals (H,W,3) f32 · instance_ids (H,W) u32 · class_ids (H,W) u32 ·
+        motion (H,W,2) f32 · rgb (H,W,3) u8 · albedo (H,W,4) u8. The efficient multi-AOV entry point.
+        """
+    def read_class_ids(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.uint32]:
+        """
+        Semantic class ids as (H, W) uint32 (0..255; 0 = unset). Tag objects with set_class_id().
         """
     def read_depth(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.float32]:
         """
@@ -1780,8 +1784,8 @@ class VulkanRenderer:
         """
     def read_instance_ids(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.uint32]:
         """
-        Recoverable per-pixel instance ids as (H, W) uint32. 0 = sky / no hit; otherwise
-        instanceCustomIndex + 1. No hashing, no collisions.
+        Stable per-pixel instance ids as (H, W) uint32. 0 = sky / no hit; otherwise a per-object
+        id that persists across frames (no hashing, no collisions). Override with set_instance_id().
         """
     def read_motion(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.float32]:
         """
@@ -1792,6 +1796,16 @@ class VulkanRenderer:
     def read_normals_float(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.float32]:
         """
         World-space unit normals as (H, W, 3) float32, components in [-1, 1] (full precision).
+        """
+    def set_instance_id(self, object: Object3D, instance_id: int) -> None:
+        """
+        Assign a stable instance id (0..65535) to an object for the ids AOV. Overrides the
+        auto-assigned id. Takes effect on the next render.
+        """
+    def set_class_id(self, object: Object3D, class_id: int) -> None:
+        """
+        Tag an object with a semantic class id (0..255) for read_class_ids(). Objects sharing a
+        class id share a semantic label.
         """
     def read_pixels(self) -> numpy.ndarray[numpy.uint8]:
         """

--- a/python/threepp/threepp.pyi
+++ b/python/threepp/threepp.pyi
@@ -1767,8 +1767,32 @@ class VulkanRenderer:
         """
     def read_albedo(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.uint8]:
         ...
+    def read_aovs_typed(self, scene: Object3D, camera: Camera, aovs: list[str] = ['rgb', 'depth', 'normals', 'instance_ids']) -> dict:
+        """
+        Render ONCE and read every requested AOV from that same frame, each as its natural dtype:
+        depth (H,W) f32 · normals (H,W,3) f32 · instance_ids (H,W) u32 · motion (H,W,2) f32 ·
+        rgb (H,W,3) u8 · albedo (H,W,4) u8 (linear rgb + metalness). The efficient multi-AOV entry point.
+        """
+    def read_depth(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.float32]:
+        """
+        Metric depth as (H, W) float32 — distance from the camera in scene units.
+        Background reads as the camera far plane. Full 32-bit precision (native D32 read).
+        """
+    def read_instance_ids(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.uint32]:
+        """
+        Recoverable per-pixel instance ids as (H, W) uint32. 0 = sky / no hit; otherwise
+        instanceCustomIndex + 1. No hashing, no collisions.
+        """
+    def read_motion(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.float32]:
+        """
+        Screen-space motion vectors as (H, W, 2) float32, in pixels (previous - current surface position).
+        """
     def read_normals(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.uint8]:
         ...
+    def read_normals_float(self, scene: Object3D, camera: Camera) -> numpy.ndarray[numpy.float32]:
+        """
+        World-space unit normals as (H, W, 3) float32, components in [-1, 1] (full precision).
+        """
     def read_pixels(self) -> numpy.ndarray[numpy.uint8]:
         """
         Final shaded RGB of the last render as (H, W, 3) uint8.

--- a/src/threepp/renderers/VulkanRenderer.cpp
+++ b/src/threepp/renderers/VulkanRenderer.cpp
@@ -787,6 +787,14 @@ namespace threepp {
         return true;
     }
 
+    void VulkanRendererCore::setObjectInstanceId(const Object3D& obj, uint32_t instanceId) {
+        core()->instanceIdOverride_[obj.id] = static_cast<uint16_t>(instanceId & 0xFFFFu);
+    }
+
+    void VulkanRendererCore::setObjectClassId(const Object3D& obj, uint32_t classId) {
+        core()->classIds_[obj.id] = static_cast<uint16_t>(classId > 255u ? 255u : classId);
+    }
+
     void VulkanRendererCore::setEventCameraEnabled(bool enabled) {
         auto& impl = *core();
         if (enabled == impl.eventCamEnabled_) return;

--- a/src/threepp/renderers/VulkanRenderer.cpp
+++ b/src/threepp/renderers/VulkanRenderer.cpp
@@ -635,6 +635,158 @@ namespace threepp {
         return rgb;
     }
 
+    bool VulkanRendererCore::readGBufferAOV(GBufferAOV aov, std::vector<uint8_t>& out,
+                                            int& width, int& height, int& bytesPerPixel) {
+        auto& impl = *core();
+        auto* ctx  = impl.ctx.get();
+        if (!ctx) return false;
+
+        // The just-rendered G-buffer sits in the slot BEFORE the current one:
+        // endFrame advances currentFrame after recording (VulkanCoreImpl.hpp),
+        // so the freshest attachment contents are (currentFrame - 1) mod N —
+        // the same slot arithmetic the fog history uses.
+        const uint32_t n    = static_cast<uint32_t>(impl.rasterGbufs.size());
+        const uint32_t slot = (impl.currentFrame + n - 1u) % n;
+        const auto& g       = impl.rasterGbufs[slot];
+
+        // Select the attachment, its aspect, and the layout it rests in after a
+        // frame (the raster render pass' finalLayout; the MSAA resolve leaves the
+        // resolved single-sample images in the same layouts). Depth carries the
+        // depth aspect + DEPTH_STENCIL_READ_ONLY; every colour AOV is SHADER_READ_ONLY.
+        const vulkan::Image2D* img = nullptr;
+        VkImageAspectFlags aspect  = VK_IMAGE_ASPECT_COLOR_BIT;
+        VkImageLayout restLayout   = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        switch (aov) {
+            case GBufferAOV::Depth:
+                img = &g.depth; aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+                restLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL; break;
+            case GBufferAOV::Normal: img = &g.normal; break;
+            case GBufferAOV::Motion: img = &g.motion; break;
+            case GBufferAOV::Ids:    img = &g.ids;    break;
+            case GBufferAOV::Albedo: img = &g.albedo; break;
+        }
+        if (!img || img->image == VK_NULL_HANDLE || img->width == 0 || img->height == 0) {
+            return false;// no frame rendered yet
+        }
+
+        const uint32_t w = img->width;
+        const uint32_t h = img->height;
+        // Element size of the attachment format: RGBA16 (normal/motion/ids) = 8,
+        // D32_SFLOAT (depth) and RGBA8_UNORM (albedo) = 4.
+        uint32_t bpp = 4;
+        if (img->format == VK_FORMAT_R16G16B16A16_SFLOAT ||
+            img->format == VK_FORMAT_R16G16B16A16_UINT) {
+            bpp = 8;
+        }
+        const VkDeviceSize bytes = static_cast<VkDeviceSize>(w) * h * bpp;
+
+        // Wait so the last frame's writes to this attachment are complete and no
+        // in-flight frame is still sampling it — same trade-off as readRGBPixels.
+        vkDeviceWaitIdle(ctx->device());
+
+        vulkan::Buffer staging = vulkan::createBuffer(
+                ctx->allocator(), ctx->device(), bytes,
+                VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                VMA_MEMORY_USAGE_AUTO_PREFER_HOST,
+                VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
+                        VMA_ALLOCATION_CREATE_MAPPED_BIT);
+
+        VkCommandPoolCreateInfo cpci{};
+        cpci.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        cpci.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        cpci.queueFamilyIndex = ctx->queueFamilies().graphics;
+        VkCommandPool cpool = VK_NULL_HANDLE;
+        vulkan::check(vkCreateCommandPool(ctx->device(), &cpci, nullptr, &cpool),
+                      "vkCreateCommandPool(readGBufferAOV)");
+
+        VkCommandBufferAllocateInfo cbai{};
+        cbai.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        cbai.commandPool        = cpool;
+        cbai.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cbai.commandBufferCount = 1;
+        VkCommandBuffer cb = VK_NULL_HANDLE;
+        vulkan::check(vkAllocateCommandBuffers(ctx->device(), &cbai, &cb),
+                      "vkAllocateCommandBuffers(readGBufferAOV)");
+
+        VkCommandBufferBeginInfo bi{};
+        bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vulkan::check(vkBeginCommandBuffer(cb, &bi), "vkBeginCommandBuffer(readGBufferAOV)");
+
+        // restLayout → TRANSFER_SRC for the copy. srcAccess 0 is safe: the prior
+        // vkDeviceWaitIdle already retired every access, so this barrier only
+        // performs the layout transition.
+        VkImageMemoryBarrier toSrc{};
+        toSrc.sType                       = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        toSrc.oldLayout                   = restLayout;
+        toSrc.newLayout                   = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        toSrc.srcAccessMask               = 0;
+        toSrc.dstAccessMask               = VK_ACCESS_TRANSFER_READ_BIT;
+        toSrc.srcQueueFamilyIndex         = VK_QUEUE_FAMILY_IGNORED;
+        toSrc.dstQueueFamilyIndex         = VK_QUEUE_FAMILY_IGNORED;
+        toSrc.image                       = img->image;
+        toSrc.subresourceRange.aspectMask = aspect;
+        toSrc.subresourceRange.levelCount = 1;
+        toSrc.subresourceRange.layerCount = 1;
+        vkCmdPipelineBarrier(cb,
+                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &toSrc);
+
+        VkBufferImageCopy region{};
+        region.imageSubresource.aspectMask = aspect;
+        region.imageSubresource.layerCount = 1;
+        region.imageExtent                 = {w, h, 1};
+        vkCmdCopyImageToBuffer(cb, img->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               staging.handle, 1, &region);
+
+        // Restore the resting layout so the next frame's consumers (deferred
+        // shade / TAA / raygen) find the attachment where they expect it.
+        VkImageMemoryBarrier toRest = toSrc;
+        toRest.oldLayout            = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        toRest.newLayout            = restLayout;
+        toRest.srcAccessMask        = VK_ACCESS_TRANSFER_READ_BIT;
+        toRest.dstAccessMask        = 0;
+        vkCmdPipelineBarrier(cb,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &toRest);
+
+        vulkan::check(vkEndCommandBuffer(cb), "vkEndCommandBuffer(readGBufferAOV)");
+
+        VkFenceCreateInfo fci{};
+        fci.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        VkFence fence = VK_NULL_HANDLE;
+        vulkan::check(vkCreateFence(ctx->device(), &fci, nullptr, &fence),
+                      "vkCreateFence(readGBufferAOV)");
+
+        VkSubmitInfo si{};
+        si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        si.commandBufferCount = 1;
+        si.pCommandBuffers    = &cb;
+        vulkan::check(vkQueueSubmit(ctx->graphicsQueue(), 1, &si, fence),
+                      "vkQueueSubmit(readGBufferAOV)");
+        vulkan::check(vkWaitForFences(ctx->device(), 1, &fence, VK_TRUE, UINT64_MAX),
+                      "vkWaitForFences(readGBufferAOV)");
+
+        out.resize(static_cast<size_t>(bytes));
+        void* mapped = nullptr;
+        vmaInvalidateAllocation(ctx->allocator(), staging.alloc, 0, bytes);
+        vulkan::check(vmaMapMemory(ctx->allocator(), staging.alloc, &mapped),
+                      "vmaMapMemory(readGBufferAOV)");
+        std::memcpy(out.data(), mapped, static_cast<size_t>(bytes));
+        vmaUnmapMemory(ctx->allocator(), staging.alloc);
+
+        vkDestroyFence(ctx->device(), fence, nullptr);
+        vkDestroyCommandPool(ctx->device(), cpool, nullptr);
+        vulkan::destroyBuffer(ctx->allocator(), staging);
+
+        width         = static_cast<int>(w);
+        height        = static_cast<int>(h);
+        bytesPerPixel = static_cast<int>(bpp);
+        return true;
+    }
+
     void VulkanRendererCore::setEventCameraEnabled(bool enabled) {
         auto& impl = *core();
         if (enabled == impl.eventCamEnabled_) return;

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -7574,12 +7574,43 @@ namespace threepp {
             uint64_t indexAddr;        // 8 (0 → non-indexed)
             uint64_t colorAddr;        // 8 (0 → no per-vertex color / vertexColors off)
             uint32_t instanceCustomIndex;
-            uint32_t flags;
+            uint32_t flags;            // bits 0..7 render flags | bits 8..15 semantic class id
             uint32_t indexed;
             float    polygonOffset;    // clip-z depth bias (reverse-Z: + = toward near = on top)
+            uint32_t stableId;         // stable per-object instance id (-> outIds.y)
+            uint32_t _pad;             // keep 8-byte array stride (matches scalar buffer_reference)
         };
-        static_assert(sizeof(DrawInfoGpu) == 128,
+        static_assert(sizeof(DrawInfoGpu) == 136,
                       "DrawInfoGpu layout drifted from gbuffer_indirect.vert");
+
+        // ── Stable / semantic object IDs for the segmentation AOVs ───────
+        // outIds.x is the per-frame visible-set index; outIds.y must be STABLE
+        // across frames. We assign a dense 16-bit id per Object3D (keyed by the
+        // process-stable Object3D::id) the first time it is drawn, so the label
+        // survives add/remove/hide/LOD. Callers may override the instance id and
+        // set an 8-bit semantic class (folded into outIds.z bits 8..15 by
+        // buildIndirectDrawData). Maps are keyed by Object3D::id (never a raw
+        // pointer) so a deleted object leaves an inert entry, never a dangling read.
+        std::unordered_map<unsigned int, uint16_t> autoStableIds_;      // Object3D::id -> dense id
+        std::unordered_map<unsigned int, uint16_t> instanceIdOverride_; // user-set instance id
+        std::unordered_map<unsigned int, uint16_t> classIds_;           // user-set semantic class
+        uint32_t nextAutoStableId_ = 1;// 0 reserved for sky / unassigned
+
+        uint16_t stableIdForObject(const Object3D& o) {
+            if (const auto it = instanceIdOverride_.find(o.id); it != instanceIdOverride_.end()) {
+                return it->second;
+            }
+            const auto [it, inserted] = autoStableIds_.try_emplace(o.id, uint16_t(0));
+            if (inserted) {
+                it->second = static_cast<uint16_t>(nextAutoStableId_);
+                if (nextAutoStableId_ < 0xFFFFu) ++nextAutoStableId_;// saturate at 65535
+            }
+            return it->second;
+        }
+        uint16_t classIdForObject(const Object3D& o) const {
+            const auto it = classIds_.find(o.id);
+            return it == classIds_.end() ? uint16_t(0) : it->second;
+        }
 
         // Per-cull-mode dispatch span into indirectCmdBuffers[frame].
         struct DrawGroup {
@@ -7746,8 +7777,16 @@ namespace threepp {
                 // wobble). The shader pins a constant history cap on this bit;
                 // the TAA resolve floors its blend α (shading changes per frame).
                 if (en.isTet) flags |= 32u;
+                // Semantic CLASS id (0..255) packed into bits 8..15 — inert to
+                // every flag bit-test (they mask the low byte) and carried
+                // through the MSAA resolve. Read back via outIds.z >> 8.
+                flags |= (static_cast<uint32_t>(classIdForObject(*en.mesh)) & 0xFFu) << 8;
                 di.flags   = flags;
                 di.indexed = indexed ? 1u : 0u;
+                // STABLE per-object instance id -> outIds.y (survives visible-set
+                // reordering, unlike instanceCustomIndex/.x).
+                di.stableId = stableIdForObject(*en.mesh);
+                di._pad     = 0u;
                 // polygonOffset → per-mesh clip-z depth bias (decals). Reverse-Z:
                 // a +clip-z bias pushes the surface toward NEAR so it renders on
                 // top of coplanar geometry (no z-fight). threepp/GL uses NEGATIVE

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -9295,13 +9295,20 @@ namespace threepp {
             // Omitted at msaa=1 to keep that path's image usage flags exactly
             // as they were (byte-identical guarantee — no behavioural surface
             // added when the feature is off).
+            // TRANSFER_SRC is added so the AOV readback path
+            // (VulkanRendererCore::readGBufferAOV) can vkCmdCopyImageToBuffer the
+            // resolved single-sample attachments to a host staging buffer. It is
+            // a pure capability flag (no render-pass / layout / perf effect); the
+            // STORAGE bit below stays MSAA-gated for its byte-identical guarantee.
             const VkImageUsageFlags colorUsage =
                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
                     VK_IMAGE_USAGE_SAMPLED_BIT |
+                    VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                     (gbufMsaaSamples_ > 1 ? VK_IMAGE_USAGE_STORAGE_BIT : 0);
             const VkImageUsageFlags depthUsage =
                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-                    VK_IMAGE_USAGE_SAMPLED_BIT;
+                    VK_IMAGE_USAGE_SAMPLED_BIT |
+                    VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
             for (size_t fi = 0; fi < rasterGbufs.size(); ++fi) {
                 auto& g = rasterGbufs[fi];
                 char nameBuf[64];

--- a/src/threepp/renderers/vulkan/shaders/gbuffer.frag
+++ b/src/threepp/renderers/vulkan/shaders/gbuffer.frag
@@ -52,6 +52,7 @@ layout(location = 4) flat in uint vFlags;
 layout(location = 5) in vec2 vUv;
 layout(location = 6) in vec3 vWorldPos;
 layout(location = 7) in vec3 vColor;// per-vertex color (material.vertexColors); white when unused
+layout(location = 8) flat in uint vStableId;// stable per-object id (host-assigned; NOT the visible-set index)
 
 // Attachment 0: world-space normal (rgba16f). .xyz = n*0.5+0.5 encoded world
 // normal, .w = linear roughness (raster-first deferred pass reads it; raygen
@@ -67,11 +68,17 @@ layout(location = 1) out vec4 outMotion;
 // Attachment 2: per-pixel IDs + flags (rgba16ui).
 //   .x = instanceCustomIndex + 1 (matches raygen Payload.hitInstanceId
 //        convention; 0 reserved for sky/miss because the render pass
-//        clears IDs to 0 before any draw)
-//   .y = mesh-ID for the reproject same-mesh guard (currently == .x but
-//        kept separate so future stages can decouple)
-//   .z = flags (bit 0 is_water, bit 1 transmissive, bit 2 thinWalled, ...)
-//   .w = reserved
+//        clears IDs to 0 before any draw). This is the PER-FRAME visible-set
+//        index — used internally (reproject/motionMat), NOT stable across frames.
+//   .y = STABLE per-object instance id (host-assigned, persists across frames
+//        and visible-set changes; 0 = sky). The recoverable label for
+//        instance segmentation — see VulkanRendererCore::setObjectInstanceId.
+//   .z = flags in bits 0..7 (bit 0 is_water, bit 1 transmissive, bit 2
+//        thinWalled, bit 3 skinned, bit 4 double, bit 5 deformer, bit 6
+//        tex-anim) | semantic CLASS id in bits 8..15 (0 = unset). Consumers
+//        bit-test the low byte, so the class byte is inert to them; the MSAA
+//        resolve carries the dominant sample's .z through unchanged.
+//   .w = reserved (repacked with MSAA coverage metadata by gbuf_resolve.comp)
 layout(location = 2) out uvec4 outIds;
 
 // Attachment 3: material UV + LOD bias (rgba16f). .rg = UV (chit normally
@@ -283,9 +290,11 @@ void main() {
     // wrongly reset any surface that moves in depth → dust on animated meshes.
     outMotion = vec4(motion, vPrevClip.z / vPrevClip.w, 0.0);
 
-    // +1 so the renderpass's clear-to-0 means "sky/no draw", matching
-    // raygen's Payload.hitInstanceId convention exactly.
-    outIds = uvec4(vInstanceIdx + 1u, vInstanceIdx + 1u, vFlags, 0u);
+    // .x = per-frame visible index +1 (clear-to-0 = sky, matches raygen's
+    // Payload.hitInstanceId). .y = stable per-object id (host-assigned; 0 when
+    // unassigned/sky). .z = flags | class byte (already packed into vFlags host-
+    // side, bits 8..15). Truncates to uint16 per channel — class fits in 8..15.
+    outIds = uvec4(vInstanceIdx + 1u, vStableId, vFlags, 0u);
 
     // log2 of the per-pixel UV-footprint diameter (texture-size-independent).
     // raygen turns this into a per-texture LOD via `bias + log2(textureSize.x)`.

--- a/src/threepp/renderers/vulkan/shaders/gbuffer.vert
+++ b/src/threepp/renderers/vulkan/shaders/gbuffer.vert
@@ -60,6 +60,10 @@ layout(location = 6) out vec3 vWorldPos;// for fragment-shader TBN via dFdx/dFdy
 layout(location = 7) out vec3 vColor;// per-vertex color; this fixed-input path has no
                                      // color binding, so always white (the indirect
                                      // path — gbuffer_indirect.vert — does real vertex colors)
+layout(location = 8) flat out uint vStableId;// stable per-object id — matches the shared
+                                             // gbuffer.frag interface. This fixed path is not
+                                             // used for the ids pass (indirect draws are), so
+                                             // it just mirrors the visible index as before.
 
 void main() {
     vec4 worldPos     = pc.model * vec4(inPos, 1.0);
@@ -84,6 +88,7 @@ void main() {
     vUv            = inUv;
     vWorldPos      = worldPos.xyz;
     vColor         = vec3(1.0);// no color binding on this path
+    vStableId      = pc.instanceCustomIndex + 1u;// fixed path: mirror .x (unused for ids)
 
     // threepp's projection matrix follows the GL convention (Y up in NDC).
     // Vulkan NDC has Y pointing down, so we negate Y at the gl_Position

--- a/src/threepp/renderers/vulkan/shaders/gbuffer_indirect.vert
+++ b/src/threepp/renderers/vulkan/shaders/gbuffer_indirect.vert
@@ -47,9 +47,11 @@ struct DrawInfo {
     uint64_t indexAddr;        // 0 → non-indexed (gl_VertexIndex IS the vertex ID)
     uint64_t colorAddr;        // 0 → no per-vertex color (material.vertexColors off / geometry has no "color")
     uint     instanceCustomIndex;
-    uint     flags;
+    uint     flags;            // bits 0..7 render flags | bits 8..15 semantic class id
     uint     indexed;          // 0 / 1
     float    polygonOffset;    // clip-z depth bias (reverse-Z: + = toward near = on top of coplanar geom)
+    uint     stableId;         // stable per-object instance id (host-assigned; -> outIds.y)
+    uint     _pad;             // keep 8-byte array stride (scalar buffer_reference)
 };
 layout(set = 0, binding = 4, scalar) readonly buffer DrawInfoBuf {
     DrawInfo draws[];
@@ -63,6 +65,7 @@ layout(location = 4) flat out uint vFlags;
 layout(location = 5) out vec2 vUv;
 layout(location = 6) out vec3 vWorldPos;
 layout(location = 7) out vec3 vColor;// per-vertex color (vec3(1) when no "color" / vertexColors off)
+layout(location = 8) flat out uint vStableId;// stable per-object id -> outIds.y
 
 vec3 fetchVec3(uint64_t addr, uint i) {
     FloatBuf b = FloatBuf(addr);
@@ -100,7 +103,8 @@ void main() {
     vCurrClipUnjit = cam.currVPunjittered * worldPos;
     vPrevClip      = cam.prevVP           * prevWorldPos;
     vInstanceIdx   = d.instanceCustomIndex;
-    vFlags         = d.flags;
+    vFlags         = d.flags;// render flags in bits 0..7 | class id in bits 8..15
+    vStableId      = d.stableId;
     vUv            = inUv;
     vWorldPos      = worldPos.xyz;
     // Per-vertex color (material.vertexColors). gbuffer.frag multiplies albedo


### PR DESCRIPTION

Turns the deferred Vulkan G-buffer into a real synthetic-data source. Previously the
only way out was `setHybridDebugView` → 8-bit swapchain blit: normals quantized to
~0.4°, depth 24-bit RGB-packed, and segmentation returned as a Knuth-hashed RGB triple
an ML pipeline can't invert. This adds a native, lossless readback path and turns the
instance-id channel into stable, labelled ground truth.

Two commits, both additive (no behavior change to existing rendering):

### 1. Native multi-AOV float/int readback (`6b1fda5e`)
`VulkanRendererCore::readGBufferAOV(GBufferAOV, out, w, h, bpp)` staging-copies a chosen
attachment from the last rendered frame in its **native** GPU format:

| AOV | format | Python |
| --- | --- | --- |
| Depth | D32_SFLOAT | `read_depth` → `(H,W)` **f32** metric (was 24-bit) |
| Normal | RGBA16F | `read_normals_float` → `(H,W,3)` **f32** |
| Ids | RGBA16_UINT | `read_instance_ids` → `(H,W)` **u32** |
| Motion | RGBA16F | `read_motion` → `(H,W,2)` **f32** px |
| Albedo | RGBA8 | `(H,W,4)` u8 (rgb + metalness) |

Reads `rasterGbufs[(currentFrame-1)%N]` (the resolved single-sample images, so one path
covers MSAA and non-MSAA); adds `TRANSFER_SRC` to the G-buffer image usage. New
`read_aovs_typed(...)` renders once and returns many AOVs from the same frame.

### 2. Stable instance ids + semantic class channel (`e60601f1`)
`outIds.y` was a dead duplicate of `.x` (the per-frame visible-set index — unstable
across add/remove/hide/LOD). Now:
- **`.y` = stable per-object instance id** — renderer assigns a dense 16-bit id keyed by
  the process-stable `Object3D::id` on first draw. `.x` stays the visible index for the
  internal reproject/motion path (no same-mesh gate today, so nothing regresses).
- **`.z` bits 8-15 = 8-bit semantic class id**, folded into the existing `flags` channel
  host-side — consumers only bit-test the low byte and `.z` survives the MSAA resolve, so
  the fragile descriptor set is untouched.

`DrawInfoGpu`/`DrawInfo` gain `stableId`+pad (128→136 B, 8-aligned for the scalar
`buffer_reference` stride). New API: C++ `setObjectInstanceId`/`setObjectClassId`;
Python `read_class_ids`, `set_instance_id`, `set_class_id`.