### PR TITLE
Vulkan: automatic mesh LOD — background-simplified index chains, on by default

### DIFF
--- a/examples/vulkan/vulkan_fjord.cpp
+++ b/examples/vulkan/vulkan_fjord.cpp
@@ -1287,6 +1287,18 @@ int main(int argc, char** argv) {
             ImGui::TextDisabled("gbuf %.2f shade %.2f denoise %.2f taa %.2f",
                                 t.rasterGbufMs, t.shadeBMs, t.denoiseMs, t.taaMs);
             ImGui::TextDisabled("terrain tiles %d (baking %d)", tiles->activeTiles(), tiles->pendingBakes());
+            // Auto-LOD engagement: entries drawing a simplified level vs full
+            // detail. The win is geometry-bound phases (flight through the
+            // fjord — press C); near-field orbits keep everything at L0 by
+            // design (sub-pixel error threshold), so gbuf ms + this line are
+            // where the effect is visible, not necessarily headline FPS.
+            const auto al = renderer.autoLodStats();
+            ImGui::TextDisabled("lod L0 %u | simplified %u (chains %u, %.0f MB)",
+                                al.entriesPerLevel[0],
+                                al.entriesPerLevel[1] + al.entriesPerLevel[2] + al.entriesPerLevel[3] +
+                                        al.entriesPerLevel[4] + al.entriesPerLevel[5],
+                                al.chainsReady,
+                                static_cast<double>(al.indexBytes + al.blasBytes) / (1024.0 * 1024.0));
         }
         ImGui::SeparatorText("Time of day");
         ImGui::SliderFloat("hour", &timeOfDay, 0.f, 24.f, "%.2f");
@@ -1305,6 +1317,10 @@ int main(int argc, char** argv) {
         ImGui::SeparatorText("Camera / perf");
         ImGui::Checkbox("cinematic flight (C)", &cinematic);
         if (ImGui::SliderFloat("render scale", &uiRenderScale, 0.4f, 1.f, "%.2f")) perfDirty = true;
+        {
+            bool lodOn = renderer.autoLod();
+            if (ImGui::Checkbox("auto LOD", &lodOn)) renderer.setAutoLod(lodOn);
+        }
         ImGui::TextDisabled("drag=orbit scroll=zoom SPACE=pause");
         ImGui::End();
     });

--- a/include/threepp/core/Object3D.hpp
+++ b/include/threepp/core/Object3D.hpp
@@ -99,6 +99,13 @@ namespace threepp {
         // When this is set, it checks every frame if the object is in the frustum of the camera before rendering the object.
         // If set to false the object gets rendered every frame even if it is not in the frustum of the camera. Default is true.
         bool frustumCulled = true;
+        // Opt-out for the renderer's automatic mesh LOD (Vulkan setAutoLod).
+        // Set false on meshes that manage their own level of detail (e.g.
+        // TileTerrain quadtree tiles) — stacking automatic simplification on
+        // top of system-managed LOD flattens shading against neighbours at
+        // other levels for little performance return. Default is true
+        // (checked on the mesh itself, not inherited).
+        bool autoLod = true;
         // This value allows the default rendering order of scene graph objects to be overridden although opaque and transparent objects remain sorted independently.
         // When this property is set for an instance of Group, all descendants objects will be sorted and rendered together. Sorting is from lowest to highest renderOrder. Default value is 0.
         unsigned int renderOrder = 0;

--- a/include/threepp/extras/terrain/TerrainTiles.hpp
+++ b/include/threepp/extras/terrain/TerrainTiles.hpp
@@ -470,6 +470,12 @@ namespace threepp::terrain {
             }
 
             n.mesh = Mesh::create(geo, mat);
+            // Tiles ARE the LOD system here (quadtree level per ring) — the
+            // renderer's auto-LOD stacking on top double-simplifies: adjacent
+            // tiles land on different auto levels and shade differently at
+            // the seams (positional error stays sub-pixel, shading response
+            // doesn't), and every rebake churns a simplification chain.
+            n.mesh->autoLod = false;
             n.mesh->name = "terrain_tile_L" + std::to_string(n.level);
             add(n.mesh);
             ++activeTiles_;

--- a/include/threepp/renderers/VulkanRendererCore.hpp
+++ b/include/threepp/renderers/VulkanRendererCore.hpp
@@ -224,6 +224,33 @@ namespace threepp {
         void setNormalMapToksvig(bool enabled);
         [[nodiscard]] bool normalMapToksvig() const;
 
+        // ── Automatic mesh LOD (debug, default OFF) ───────────────────────
+        // Per-geometry chains of simplified INDEX buffers (vertex positions/
+        // normals/UVs untouched — index-only), generated in the background
+        // with meshoptimizer and selected per-entry per-frame by projected
+        // screen-space error. Consumed identically by the raster G-buffer
+        // and the ray-tracing TLAS, fighting sub-pixel geometric coverage
+        // flicker under TAA jitter on distant/simplifiable geometry.
+        // Exempt (always LOD0): skinned/displaced/grass/morphed/tet meshes,
+        // overlay/particle entries, emissive materials, and anything under
+        // a manual threepp::LOD node (its levels are hand-authored already).
+        // OFF by default — v1 of the feature, debug escape only.
+        void setAutoLod(bool enabled);
+        [[nodiscard]] bool autoLod() const;
+
+        // Debug/harness stats snapshot from the last render()'s LOD
+        // selection pass. entriesPerLevel[0] is LOD0 (unsimplified); [1..4]
+        // are the generated chain levels; [5] is a defensive catch-all
+        // beyond the 4-level cap (should always read 0).
+        struct AutoLodStats {
+            uint32_t entriesPerLevel[6] = {};
+            uint64_t indexBytes = 0;// resident LOD index-buffer bytes (all levels, all geometries)
+            uint64_t blasBytes  = 0;// resident LOD BLAS storage bytes
+            uint32_t chainsReady  = 0;// unique geometries with a finalized chain
+            uint32_t chainsQueued = 0;// unique geometries with a chain job in flight
+        };
+        [[nodiscard]] AutoLodStats autoLodStats() const;
+
         // HDR bloom, added in linear HDR before the tone-map curve. 0 disables.
         void setBloomIntensity(float intensity);
         [[nodiscard]] float bloomIntensity() const;

--- a/include/threepp/renderers/VulkanRendererCore.hpp
+++ b/include/threepp/renderers/VulkanRendererCore.hpp
@@ -240,7 +240,12 @@ namespace threepp {
         // Object3D::autoLod == false (self-managed LOD — TileTerrain sets it
         // on its quadtree tiles), and anything under a manual threepp::LOD
         // node (its levels are hand-authored already).
-        // setAutoLod(false) is the manual override / debug escape.
+        // setAutoLod(false) is the manual override / debug escape. Toggle
+        // semantics: takes effect at the next render() (every entry snaps
+        // back to full detail on disable); generated chains and in-flight
+        // background jobs are KEPT across a disable/enable cycle (results are
+        // geometry-version-guarded, so nothing stale is ever consumed), and
+        // autoLodStats() reflects the most recent render, not the setter.
         void setAutoLod(bool enabled);
         [[nodiscard]] bool autoLod() const;
 

--- a/include/threepp/renderers/VulkanRendererCore.hpp
+++ b/include/threepp/renderers/VulkanRendererCore.hpp
@@ -236,8 +236,10 @@ namespace threepp {
         // reduce TAA edge shimmer (that is sub-pixel coverage + the 1-spp
         // shading floor, not triangle density).
         // Exempt (always LOD0): skinned/displaced/grass/morphed/tet meshes,
-        // overlay/particle entries, emissive materials, and anything under
-        // a manual threepp::LOD node (its levels are hand-authored already).
+        // overlay/particle entries, emissive materials, meshes with
+        // Object3D::autoLod == false (self-managed LOD — TileTerrain sets it
+        // on its quadtree tiles), and anything under a manual threepp::LOD
+        // node (its levels are hand-authored already).
         // setAutoLod(false) is the manual override / debug escape.
         void setAutoLod(bool enabled);
         [[nodiscard]] bool autoLod() const;

--- a/include/threepp/renderers/VulkanRendererCore.hpp
+++ b/include/threepp/renderers/VulkanRendererCore.hpp
@@ -224,17 +224,21 @@ namespace threepp {
         void setNormalMapToksvig(bool enabled);
         [[nodiscard]] bool normalMapToksvig() const;
 
-        // ── Automatic mesh LOD (debug, default OFF) ───────────────────────
+        // ── Automatic mesh LOD (ON by default) ────────────────────────────
         // Per-geometry chains of simplified INDEX buffers (vertex positions/
         // normals/UVs untouched — index-only), generated in the background
         // with meshoptimizer and selected per-entry per-frame by projected
-        // screen-space error. Consumed identically by the raster G-buffer
-        // and the ray-tracing TLAS, fighting sub-pixel geometric coverage
-        // flicker under TAA jitter on distant/simplifiable geometry.
+        // screen-space error (sub-pixel at the switch, so transitions are
+        // invisible). Consumed identically by the raster G-buffer and the
+        // ray-tracing TLAS. This is a PERFORMANCE feature for geometry-bound
+        // scenes (measured: fjord flythrough +32% FPS, per-pixel-bound
+        // Bistro neutral) — measurement showed it does NOT meaningfully
+        // reduce TAA edge shimmer (that is sub-pixel coverage + the 1-spp
+        // shading floor, not triangle density).
         // Exempt (always LOD0): skinned/displaced/grass/morphed/tet meshes,
         // overlay/particle entries, emissive materials, and anything under
         // a manual threepp::LOD node (its levels are hand-authored already).
-        // OFF by default — v1 of the feature, debug escape only.
+        // setAutoLod(false) is the manual override / debug escape.
         void setAutoLod(bool enabled);
         [[nodiscard]] bool autoLod() const;
 

--- a/include/threepp/utils/GeometryLod.hpp
+++ b/include/threepp/utils/GeometryLod.hpp
@@ -1,0 +1,85 @@
+// Renderer-agnostic index-only LOD chain generator, built on the bundled
+// meshoptimizer (src/external/meshoptimizer). Used by the Vulkan renderer's
+// auto-LOD feature (VulkanCoreScene.cpp / VulkanCoreGeometry.cpp) to fight
+// sub-pixel geometric coverage flicker under TAA jitter: far-away triangles
+// that cover less than a pixel still rasterize/trace at full density, and
+// their sub-pixel silhouette motion under camera jitter never converges.
+//
+// Deliberately narrow: this header/cpp knows nothing about Vulkan, buffers,
+// or BLAS. It takes a position + index array and returns a chain of
+// alternative INDEX buffers only — vertex positions/normals/uvs are never
+// touched, reordered, or duplicated. Every returned index still refers into
+// the CALLER's original vertex array, so a consumer that already keeps
+// vertex attributes in a separate, tightly-packed, vertex-id-addressed
+// buffer (as the Vulkan renderer's BlasRecord does) can swap in a coarser
+// level by rebinding just the index buffer — unchanged in both the raster
+// vertex-pulling path and the ray-tracing BLAS/TLAS.
+#ifndef THREEPP_GEOMETRYLOD_HPP
+#define THREEPP_GEOMETRYLOD_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace threepp::geometrylod {
+
+    // One simplified index level in a chain.
+    //   indices : the level's triangle list, indexing into the ORIGINAL
+    //             vertex array passed to generateChain (never remapped).
+    //   error   : ABSOLUTE object-space deviation this level introduces
+    //             relative to the source mesh (meshopt's relative error
+    //             converted via meshopt_simplifyScale). Monotonically
+    //             non-decreasing across the returned chain, so a caller
+    //             doing screen-space-error LOD selection can walk the
+    //             chain coarsest-first / finest-first without the error
+    //             metric ever going backwards.
+    struct Level {
+        std::vector<uint32_t> indices;
+        float error = 0.f;
+    };
+
+    // Generates a progressive simplification chain from a single geometry's
+    // position + index arrays.
+    //
+    // Ordering: chain[0] is the FIRST (finest) simplification beyond the
+    // source mesh (~50% of the source triangle count); chain.back() is the
+    // COARSEST level produced. Each level is generated from the PREVIOUS
+    // level's index buffer (not always from the original), so simplification
+    // cost is roughly linear in the chain length rather than growing with
+    // level count — standard "progressive chain" construction. A caller
+    // pairs chain[i] with LOD-select level (i+1); level 0 (not present in
+    // the returned vector) is always the source mesh itself.
+    //
+    // positions: tightly packed xyz floats (stride 3 floats/vertex).
+    // indices: the source mesh's triangle list (indices into `positions`).
+    //
+    // Policy (tuned for ~sub-pixel-error targeting, see VulkanCoreScene.cpp's
+    // selection code for how `error` is consumed):
+    //   - Each level targets ~50% of the previous level's index count.
+    //   - meshopt_simplify runs with a generous relative target_error (0.05)
+    //     so the INDEX-COUNT target dominates the stopping point, not the
+    //     error bound — the chain is meant to be dense (small count steps),
+    //     with the actual screen-space decision made later from `error`.
+    //   - meshopt_SimplifyLockBorder is set: open-mesh boundary vertices
+    //     (common on partial/clipped assets) never move, avoiding cracks
+    //     between a simplified region and untouched neighboring geometry.
+    //   - A level is discarded (chain generation stops) when: meshopt
+    //     returns 0 indices (degenerate), the new index count doesn't drop
+    //     below ~85% of the previous count (refuses to simplify further —
+    //     continuing would waste a level on an imperceptible reduction), or
+    //     the next target would fall below 384 indices (128 triangles).
+    //   - Capped at 4 levels beyond the source mesh.
+    //   - `error` is clamped non-decreasing (error[i] = max(error[i], error[i-1]))
+    //     so a later, coarser level can never report a smaller screen-space
+    //     error than an earlier, finer one (meshopt's greedy simplifier
+    //     doesn't strictly guarantee monotonic error growth level-to-level).
+    //
+    // Returns an empty vector if the source is too small/degenerate to
+    // simplify at all (already below the minimum index count, unindexed
+    // triangle soup with < 3 indices, or a null pointer).
+    std::vector<Level> generateChain(const float* positions, size_t vertexCount,
+                                      const uint32_t* indices, size_t indexCount);
+
+}// namespace threepp::geometrylod
+
+#endif//THREEPP_GEOMETRYLOD_HPP

--- a/include/threepp/utils/GeometryLod.hpp
+++ b/include/threepp/utils/GeometryLod.hpp
@@ -69,16 +69,61 @@ namespace threepp::geometrylod {
     //     continuing would waste a level on an imperceptible reduction), or
     //     the next target would fall below 384 indices (128 triangles).
     //   - Capped at 4 levels beyond the source mesh.
-    //   - `error` is clamped non-decreasing (error[i] = max(error[i], error[i-1]))
-    //     so a later, coarser level can never report a smaller screen-space
-    //     error than an earlier, finer one (meshopt's greedy simplifier
-    //     doesn't strictly guarantee monotonic error growth level-to-level).
+    //   - `error` accumulates ADDITIVELY down the chain: meshopt's
+    //     result_error is measured against each call's INPUT (the previous
+    //     level), so the honest — conservative — bound vs the ORIGINAL mesh
+    //     is the running sum. Monotonically non-decreasing by construction.
+    //
+    // sparse: pass TRUE when `indices` references only a small subset of the
+    // vertex array — i.e. canonical welded-soup indices from
+    // buildCanonicalIndices below, where ~5/6 of the vertices are unreferenced
+    // duplicates. It maps to meshopt_SimplifySparse, which is REQUIRED for
+    // correctness there, not just speed: without it, meshopt's wedge analysis
+    // runs over ALL vertices (simplifier.cpp buildPositionRemap), so every
+    // referenced vertex picks up its unreferenced same-position duplicates as
+    // extra wedges, classifies as complex/locked, and the simplifier returns
+    // the mesh untouched. Sparse excludes unreferenced vertices from the
+    // analysis and hands back indices in ORIGINAL vid space. Error caveat:
+    // meshopt then reports error relative to the REFERENCED subset's extents;
+    // we still convert with the full mesh's simplifyScale, which can only
+    // OVER-estimate (subset extents <= full extents) — conservative for
+    // screen-space-error selection. Leave FALSE for regular indexed input.
     //
     // Returns an empty vector if the source is too small/degenerate to
     // simplify at all (already below the minimum index count, unindexed
     // triangle soup with < 3 indices, or a null pointer).
     std::vector<Level> generateChain(const float* positions, size_t vertexCount,
-                                      const uint32_t* indices, size_t indexCount);
+                                      const uint32_t* indices, size_t indexCount,
+                                      bool sparse = false);
+
+    // Welds NON-indexed triangle soup into a canonical index buffer so
+    // generateChain has topology to collapse. Soup (three unshared vertices
+    // per triangle — what FBX-style loaders that never call setIndex
+    // produce) has no shared edges, so the quadric simplifier sees every
+    // triangle as a bordered island and refuses to reduce anything; welding
+    // reconnects the mesh WITHOUT touching the vertex data.
+    //
+    // Vertices are grouped by binary equality over ALL the streams passed
+    // (positions required, 12B stride; normals/uvs optional, 12B/8B — via
+    // meshopt_generateVertexRemapMulti), and each group elects its FIRST-
+    // occurring original vertex id as representative. The returned buffer
+    // has one entry per input vertex (it IS the soup's implicit triangle
+    // list, 3 entries per triangle, truncated to whole triangles) whose
+    // VALUES are those representative ORIGINAL vertex ids — so it can drive
+    // an indexed draw or BLAS against the caller's UNCHANGED soup vertex
+    // buffer, and feed straight into generateChain as `indices`.
+    //
+    // Only identical-attribute duplicates weld: smooth-surface soup
+    // reconnects into real shared edges, while genuine seams and hard edges
+    // (position matches but normal/uv differs) stay split — those remain
+    // topological borders, which generateChain's meshopt_SimplifyLockBorder
+    // then protects, exactly like an indexed mesh with the same seams.
+    //
+    // Returns empty on degenerate input (< 1 whole triangle, null positions).
+    std::vector<uint32_t> buildCanonicalIndices(const float* positions,
+                                                 const float* normals,
+                                                 const float* uvs,
+                                                 size_t vertexCount);
 
 }// namespace threepp::geometrylod
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,7 @@ set(publicHeaders
         "threepp/textures/Texture.hpp"
 
         "threepp/utils/BufferGeometryUtils.hpp"
+        "threepp/utils/GeometryLod.hpp"
         "threepp/utils/ImageUtils.hpp"
         "threepp/utils/StringUtils.hpp"
         "threepp/utils/TaskManager.hpp"
@@ -478,6 +479,7 @@ set(sources
         "threepp/textures/DepthTexture.cpp"
 
         "threepp/utils/BufferGeometryUtils.cpp"
+        "threepp/utils/GeometryLod.cpp"
         "threepp/utils/ImageUtils.cpp"
         "threepp/utils/StringUtils.cpp"
         "threepp/utils/TaskManager.cpp"

--- a/src/threepp/renderers/VulkanRenderer.cpp
+++ b/src/threepp/renderers/VulkanRenderer.cpp
@@ -427,7 +427,7 @@ namespace threepp {
         // The ortho overlay record path walks the HUD scene directly instead.
         if (!camera.is<OrthographicCamera>() && !secondaryOverlayPane) {
             const auto sceneStart = std::chrono::high_resolution_clock::now();
-            core()->ensureSceneBuilt(scene);
+            core()->ensureSceneBuilt(scene, camera);
             // World-space Sprites (screenSpace == false) are drawn by the overlay
             // billboard pass, not the deferred/G-buffer path. Snapshot them each frame
             // with fresh world matrices (ensureSceneBuilt just ran

--- a/src/threepp/renderers/VulkanRenderer.cpp
+++ b/src/threepp/renderers/VulkanRenderer.cpp
@@ -1408,6 +1408,18 @@ namespace threepp {
         return core()->normalMapToksvig_;
     }
 
+    void VulkanRendererCore::setAutoLod(bool enabled) {
+        core()->autoLod_ = enabled;
+    }
+
+    bool VulkanRendererCore::autoLod() const {
+        return core()->autoLod_;
+    }
+
+    VulkanRendererCore::AutoLodStats VulkanRendererCore::autoLodStats() const {
+        return core()->autoLodStats_;
+    }
+
     VulkanRendererCore::FrameTimings VulkanRendererCore::lastFrameTimings() const {
         return core()->gpuTimings_->timings();
     }

--- a/src/threepp/renderers/vulkan/DeferredShade.cpp
+++ b/src/threepp/renderers/vulkan/DeferredShade.cpp
@@ -378,7 +378,7 @@ namespace threepp::vulkan {
             matInfo.range  = VK_WHOLE_SIZE;
 
             VkDescriptorBufferInfo geomInfo{};
-            geomInfo.buffer = in.geomDescBuf;// single buffer shared across frames
+            geomInfo.buffer = in.geomDescBuf[f];// per-FIF ring (auto-LOD level switches flush per slot)
             geomInfo.offset = 0;
             geomInfo.range  = VK_WHOLE_SIZE;
 

--- a/src/threepp/renderers/vulkan/DeferredShade.hpp
+++ b/src/threepp/renderers/vulkan/DeferredShade.hpp
@@ -74,7 +74,7 @@ namespace threepp::vulkan {
             const VkImageView* reservoirW   = nullptr;// [2] W_sum/M/W/p_hat (rgba16f)
             VkAccelerationStructureKHR tlas = VK_NULL_HANDLE;// shared scene TLAS (shadow + reflection rays)
             const VkBuffer*    materialBuf = nullptr;// [framesInFlight] MaterialDesc[] (emissive)
-            VkBuffer           geomDescBuf = VK_NULL_HANDLE;// GeometryDesc[] (reflection-hit normals/UVs)
+            const VkBuffer*    geomDescBuf = nullptr;// [framesInFlight] GeometryDesc[] (reflection-hit normals/UVs; ringed for auto-LOD level switches)
             const VkDescriptorImageInfo* materialTex = nullptr;// bindless array (reflection-hit textures)
             uint32_t           materialTexCount = 0;          // == kMaxMaterialTextures
             const VkBuffer*    emissiveTriBuf = nullptr;// [framesInFlight] EmTri[] (emissive NEE)

--- a/src/threepp/renderers/vulkan/ProbeGI.cpp
+++ b/src/threepp/renderers/vulkan/ProbeGI.cpp
@@ -177,7 +177,7 @@ namespace threepp::vulkan {
             matInfo.buffer = in.materialBuf[f];
             matInfo.range  = VK_WHOLE_SIZE;
             VkDescriptorBufferInfo geomInfo{};
-            geomInfo.buffer = in.geomDescBuf;
+            geomInfo.buffer = in.geomDescBuf[f];// per-FIF ring (auto-LOD level switches flush per slot)
             geomInfo.range  = VK_WHOLE_SIZE;
             VkDescriptorBufferInfo emInfo{};
             emInfo.buffer = in.emissiveTriBuf[f];

--- a/src/threepp/renderers/vulkan/ProbeGI.hpp
+++ b/src/threepp/renderers/vulkan/ProbeGI.hpp
@@ -69,7 +69,7 @@ namespace threepp::vulkan {
             VkSampler       envSampler  = VK_NULL_HANDLE;
             VkAccelerationStructureKHR tlas = VK_NULL_HANDLE;
             const VkBuffer* materialBuf = nullptr;// [framesInFlight] MaterialDesc[]
-            VkBuffer        geomDescBuf = VK_NULL_HANDLE;// GeometryDesc[]
+            const VkBuffer* geomDescBuf = nullptr;// [framesInFlight] GeometryDesc[] (ringed for auto-LOD level switches)
             const VkDescriptorImageInfo* materialTex = nullptr;// bindless array
             uint32_t        materialTexCount = 0;
             const VkBuffer* emissiveTriBuf = nullptr;// [framesInFlight] EmTri[]

--- a/src/threepp/renderers/vulkan/VulkanCoreDescriptors.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreDescriptors.cpp
@@ -225,7 +225,10 @@ void VulkanRendererCore::CoreImpl::rewriteDeferredDescriptors() {
             in.fogRange         = sizeof(GpuFogUbo);
             in.tlas             = tlas;
             in.materialBuf      = matBufs.data();
-            in.geomDescBuf      = geometryDescsBuffer.handle;
+            std::array<VkBuffer, kFramesInFlight> geomBufs{};
+            for (uint32_t f = 0; f < kFramesInFlight; ++f)
+                geomBufs[f] = geometryDescsBuffers[f].handle;
+            in.geomDescBuf      = geomBufs.data();
             in.materialTex      = matTexInfos.data();
             in.materialTexCount = kMaxMaterialTextures;
             in.emissiveTriBuf   = emBufs.data();
@@ -290,7 +293,7 @@ void VulkanRendererCore::CoreImpl::rewriteDeferredDescriptors() {
                 pin.envSampler       = envImage.sampler;
                 pin.tlas             = tlas;
                 pin.materialBuf      = matBufs.data();
-                pin.geomDescBuf      = geometryDescsBuffer.handle;
+                pin.geomDescBuf      = geomBufs.data();
                 pin.materialTex      = matTexInfos.data();
                 pin.materialTexCount = kMaxMaterialTextures;
                 pin.emissiveTriBuf   = emBufs.data();

--- a/src/threepp/renderers/vulkan/VulkanCoreFrame.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreFrame.cpp
@@ -123,11 +123,14 @@ void VulkanRendererCore::CoreImpl::scanLidar(const std::vector<LidarBeam>& beams
             // are stable while we read them.
             vkDeviceWaitIdle(ctx->device());
 
-            // Force-flush MaterialDescs into buffer slot 0 — gives us a
-            // known-good frame target without having to chase `currentFrame`
-            // semantics across render() calls.
+            // Force-flush Material/GeometryDescs into buffer slot 0 — gives us
+            // a known-good frame target without having to chase `currentFrame`
+            // semantics across render() calls. (Safe: the device-wide drain
+            // above means nothing is reading either slot.)
             matDescsDirty_[0] = true;
             flushMaterialDescsIfDirty(0);
+            geomDescsDirty_[0] = true;
+            flushGeometryDescsIfDirty(0);
 
             // Push constants encode the LIDAR equation parameters. The
             // shader multiplies the raw `laserPower · f_back · cos θ · η / r²`
@@ -187,7 +190,7 @@ void VulkanRendererCore::CoreImpl::scanLidar(const std::vector<LidarBeam>& beams
 
             lidar_->scan(ctx->graphicsQueue(),
                          tlas,
-                         geometryDescsBuffer.handle, geometryDescsBuffer.size,
+                         geometryDescsBuffers[0].handle, geometryDescsBuffers[0].size,
                          materialDescsBuffers[0].handle, materialDescsBuffers[0].size,
                          fogUbos[fogSlot].handle, fogUbos[fogSlot].size,
                          pc,
@@ -332,6 +335,13 @@ bool VulkanRendererCore::CoreImpl::beginDeferredFrame(Object3D& scene, Camera& c
             // matDescsCached_ + flipped matDescsDirty_[*]=true; flush this
             // slot now (the other slot flushes when its frame comes around).
             flushMaterialDescsIfDirty(currentFrame);
+            // Same fence guarantee covers geometryDescsBuffers[currentFrame]:
+            // an auto-LOD level switch patched geomDescsCached_ + flipped
+            // geomDescsDirty_[*] in ensureSceneBuilt; landing the flush here —
+            // post-fence, pre-record — keeps this frame's GeometryDescs
+            // consistent with this frame's TLAS (which references the newly
+            // selected level BLASes) without any device stall.
+            flushGeometryDescsIfDirty(currentFrame);
             // Per-frame frustum cull: tags every entry with `inFrustum`
             // for the raster passes to consume.
             cullEntriesAgainstFrustum(camera);

--- a/src/threepp/renderers/vulkan/VulkanCoreGeometry.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreGeometry.cpp
@@ -464,6 +464,21 @@ void VulkanRendererCore::CoreImpl::drainLodResults() {
 
                 rec.lodLevels.reserve(result.levels.size());
                 for (const auto& lvl : result.levels) {
+                    // HARD budget enforcement at allocation time. The enqueue
+                    // gate only sees RESIDENT bytes — a burst of jobs queued
+                    // while still under budget would otherwise finalize far
+                    // past the cap once their results return. Stopping
+                    // mid-chain keeps the FINER levels already built (a valid,
+                    // conservative chain — errors stay monotonic); levels that
+                    // didn't fit are simply never selectable.
+                    if (lodIndexBytes_ + lodBlasBytes_ >= kLodByteBudget) {
+                        if (!lodBudgetWarned_) {
+                            std::cerr << "[VulkanRenderer] auto-LOD: 256 MiB byte budget reached — "
+                                         "truncating chains; no further levels will be built this session\n";
+                            lodBudgetWarned_ = true;
+                        }
+                        break;
+                    }
                     BlasRecord::LodLevel out{};
                     if (!buildLodLevelFor(rec, lvl, out, pending)) continue;
                     lodIndexBytes_ += out.index.size;
@@ -472,6 +487,9 @@ void VulkanRendererCore::CoreImpl::drainLodResults() {
                     rec.lodLevels.push_back(out);
                 }
                 if (rec.lodLevels.empty()) {
+                    // Includes the over-budget-before-first-level case: Failed
+                    // (not None) so selection doesn't spin re-enqueuing while
+                    // the cap holds. Deliberately never retried this session.
                     rec.lodState = BlasRecord::LodState::Failed;
                 } else {
                     rec.lodState = BlasRecord::LodState::Ready;

--- a/src/threepp/renderers/vulkan/VulkanCoreGeometry.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreGeometry.cpp
@@ -258,6 +258,158 @@ std::unique_ptr<VulkanRendererCore::CoreImpl::BlasRecord> VulkanRendererCore::Co
             return rec;
         }
 
+// Builds one auto-LOD chain level: a new index buffer + a static BLAS built
+// against `rec`'s EXISTING vertex buffer (positions are never touched by
+// simplification — every index in `level.indices` still refers into
+// rec->vertex, same as LOD0). Subset of buildBlasFor's shape restricted to
+// index-only geometry input; no normal/uv/color buffers (those are shared
+// with LOD0 via the same vertexAddress-keyed lookup the shaders already do).
+bool VulkanRendererCore::CoreImpl::buildLodLevelFor(BlasRecord& rec,
+                                                     const geometrylod::Level& level,
+                                                     BlasRecord::LodLevel& out) {
+            if (level.indices.empty()) return false;
+            if (rec.vertex.handle == VK_NULL_HANDLE || rec.vertexCount == 0) return false;
+            const uint32_t primitiveCount = static_cast<uint32_t>(level.indices.size() / 3);
+            if (primitiveCount == 0) return false;
+
+            const VkBufferUsageFlags idxUsage =
+                    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
+                    VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                    VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+                    VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+
+            const VkDeviceSize ibBytes = level.indices.size() * sizeof(uint32_t);
+            out.index = createBuffer(
+                    ctx->allocator(), ctx->device(), ibBytes,
+                    idxUsage, VMA_MEMORY_USAGE_AUTO,
+                    VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT);
+            void* mapped = nullptr;
+            vmaMapMemory(ctx->allocator(), out.index.alloc, &mapped);
+            std::memcpy(mapped, level.indices.data(), ibBytes);
+            vmaUnmapMemory(ctx->allocator(), out.index.alloc);
+
+            VkAccelerationStructureGeometryTrianglesDataKHR triData{};
+            triData.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+            triData.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
+            triData.vertexData.deviceAddress = rec.vertex.address;
+            triData.vertexStride = 3 * sizeof(float);
+            triData.maxVertex = rec.vertexCount - 1;
+            triData.indexType = VK_INDEX_TYPE_UINT32;
+            triData.indexData.deviceAddress = out.index.address;
+
+            VkAccelerationStructureGeometryKHR blasGeom{};
+            blasGeom.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+            blasGeom.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+            blasGeom.geometry.triangles = triData;
+            // Same any-hit-visible flags as LOD0 (0, not OPAQUE) — a
+            // simplified level of an alpha-tested surface must still run
+            // the any-hit alpha cutout, not just its opaque triangles.
+            blasGeom.flags = 0;
+
+            VkAccelerationStructureBuildGeometryInfoKHR blasBuild{};
+            blasBuild.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+            blasBuild.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+            // No ALLOW_UPDATE: LOD levels are static once built (their vertex
+            // source never refits in place — a geometry-version bump instead
+            // destroys the whole chain, see the geomVersion-changed rebuild
+            // path in VulkanCoreScene.cpp), so PREFER_FAST_TRACE alone is
+            // strictly better (smaller build, faster trace).
+            blasBuild.flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+            blasBuild.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+            blasBuild.geometryCount = 1;
+            blasBuild.pGeometries = &blasGeom;
+
+            VkAccelerationStructureBuildSizesInfoKHR blasSizes{};
+            blasSizes.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
+            ctx->rt().getAccelerationStructureBuildSizes(
+                    ctx->device(),
+                    VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+                    &blasBuild, &primitiveCount, &blasSizes);
+
+            out.storage = createBuffer(
+                    ctx->allocator(), ctx->device(), blasSizes.accelerationStructureSize,
+                    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |
+                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                    VMA_MEMORY_USAGE_AUTO);
+
+            VkAccelerationStructureCreateInfoKHR blasCreate{};
+            blasCreate.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
+            blasCreate.buffer = out.storage.handle;
+            blasCreate.size = blasSizes.accelerationStructureSize;
+            blasCreate.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+            check(ctx->rt().createAccelerationStructure(ctx->device(), &blasCreate, nullptr, &out.as),
+                  "vkCreateAccelerationStructureKHR(LOD level BLAS)");
+
+            Buffer scratch = createAsScratchBuffer(ctx->allocator(), ctx->device(), blasSizes.buildScratchSize);
+            blasBuild.dstAccelerationStructure = out.as;
+            blasBuild.scratchData.deviceAddress = scratch.address;
+
+            VkAccelerationStructureBuildRangeInfoKHR range{};
+            range.primitiveCount = primitiveCount;
+            const VkAccelerationStructureBuildRangeInfoKHR* pRange = &range;
+
+            VkCommandBuffer cb = beginOneShot();
+            ctx->rt().cmdBuildAccelerationStructures(cb, 1, &blasBuild, &pRange);
+            endAndSubmitOneShot(cb, "buildLodLevelFor");
+            destroyBuffer(ctx->allocator(), scratch);
+
+            VkAccelerationStructureDeviceAddressInfoKHR addrInfo{};
+            addrInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
+            addrInfo.accelerationStructure = out.as;
+            out.address = ctx->rt().getAccelerationStructureDeviceAddress(ctx->device(), &addrInfo);
+
+            out.indexCount  = static_cast<uint32_t>(level.indices.size());
+            out.errorBound  = level.error;
+            return true;
+        }
+
+// Drains at most ONE finished chain per call (see the "budget one geometry
+// finalized per frame" doc comment on the declaration) and turns it into
+// GPU resources on `rec`. Discards stale results: the record may have been
+// evicted (geometry destroyed) or its geomVersion may have moved on (the
+// user mutated vertices in place after the job was snapshotted) since the
+// job was enqueued — either way the simplified data no longer matches
+// anything live, so it's dropped and lodState reset to None so a fresh job
+// gets queued next time the (now-different) geometry is seen as eligible.
+void VulkanRendererCore::CoreImpl::drainLodResults() {
+            LodResult result;
+            {
+                std::lock_guard<std::mutex> lk(lodResultMutex_);
+                if (lodResultQueue_.empty()) return;
+                result = std::move(lodResultQueue_.front());
+                lodResultQueue_.pop_front();
+            }
+            --lodChainsQueuedCount_;
+
+            auto it = blasCache.find(result.geom);
+            if (it == blasCache.end()) return;// record evicted while the job was in flight
+            BlasRecord& rec = *it->second;
+            if (rec.geomVersion != result.geomVersion) {
+                rec.lodState = BlasRecord::LodState::None;// stale — re-enqueue will pick up the new version
+                return;
+            }
+            if (result.levels.empty()) {
+                rec.lodState = BlasRecord::LodState::Failed;
+                return;
+            }
+
+            rec.lodLevels.reserve(result.levels.size());
+            for (const auto& lvl : result.levels) {
+                BlasRecord::LodLevel out{};
+                if (!buildLodLevelFor(rec, lvl, out)) continue;
+                lodIndexBytes_ += out.index.size;
+                lodBlasBytes_  += out.storage.size;
+                rec.lodLevels.push_back(out);
+            }
+            if (rec.lodLevels.empty()) {
+                rec.lodState = BlasRecord::LodState::Failed;
+            } else {
+                rec.lodState = BlasRecord::LodState::Ready;
+                ++lodChainsReadyCount_;
+            }
+        }
+
 void VulkanRendererCore::CoreImpl::refreshSkinnedBlas(SkinnedMesh& sm, SkinnedMeshState& st) {
             if (!st.blas || !sm.skeleton || st.boneCount == 0) return;
 

--- a/src/threepp/renderers/vulkan/VulkanCoreGeometry.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreGeometry.cpp
@@ -258,15 +258,20 @@ std::unique_ptr<VulkanRendererCore::CoreImpl::BlasRecord> VulkanRendererCore::Co
             return rec;
         }
 
-// Builds one auto-LOD chain level: a new index buffer + a static BLAS built
-// against `rec`'s EXISTING vertex buffer (positions are never touched by
-// simplification — every index in `level.indices` still refers into
-// rec->vertex, same as LOD0). Subset of buildBlasFor's shape restricted to
-// index-only geometry input; no normal/uv/color buffers (those are shared
-// with LOD0 via the same vertexAddress-keyed lookup the shaders already do).
+// Creates one auto-LOD chain level's resources: a new index buffer + a
+// static BLAS built against `rec`'s EXISTING vertex buffer (positions are
+// never touched by simplification — every index in `level.indices` still
+// refers into rec->vertex, same as LOD0; for welded soup the canonical
+// index VALUES are original vertex ids, so the same holds). Subset of
+// buildBlasFor's shape restricted to index-only geometry input; no normal/
+// uv/color buffers (those are shared with LOD0 via the same vertexAddress-
+// keyed lookup the shaders already do). The build itself is DEFERRED into
+// `pending` — drainLodResults batches a whole frame's builds into one
+// one-shot submit via flushLodLevelBuilds.
 bool VulkanRendererCore::CoreImpl::buildLodLevelFor(BlasRecord& rec,
                                                      const geometrylod::Level& level,
-                                                     BlasRecord::LodLevel& out) {
+                                                     BlasRecord::LodLevel& out,
+                                                     std::vector<LodPendingBuild>& pending) {
             if (level.indices.empty()) return false;
             if (rec.vertex.handle == VK_NULL_HANDLE || rec.vertexCount == 0) return false;
             const uint32_t primitiveCount = static_cast<uint32_t>(level.indices.size() / 3);
@@ -289,6 +294,9 @@ bool VulkanRendererCore::CoreImpl::buildLodLevelFor(BlasRecord& rec,
             std::memcpy(mapped, level.indices.data(), ibBytes);
             vmaUnmapMemory(ctx->allocator(), out.index.alloc);
 
+            // Size query needs a fully-specified build info; a LOCAL struct is
+            // fine here (only the final batched cmdBuildAccelerationStructures
+            // needs pointer-stable storage — flushLodLevelBuilds rebuilds it).
             VkAccelerationStructureGeometryTrianglesDataKHR triData{};
             triData.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
             triData.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
@@ -341,73 +349,138 @@ bool VulkanRendererCore::CoreImpl::buildLodLevelFor(BlasRecord& rec,
             check(ctx->rt().createAccelerationStructure(ctx->device(), &blasCreate, nullptr, &out.as),
                   "vkCreateAccelerationStructureKHR(LOD level BLAS)");
 
-            Buffer scratch = createAsScratchBuffer(ctx->allocator(), ctx->device(), blasSizes.buildScratchSize);
-            blasBuild.dstAccelerationStructure = out.as;
-            blasBuild.scratchData.deviceAddress = scratch.address;
-
-            VkAccelerationStructureBuildRangeInfoKHR range{};
-            range.primitiveCount = primitiveCount;
-            const VkAccelerationStructureBuildRangeInfoKHR* pRange = &range;
-
-            VkCommandBuffer cb = beginOneShot();
-            ctx->rt().cmdBuildAccelerationStructures(cb, 1, &blasBuild, &pRange);
-            endAndSubmitOneShot(cb, "buildLodLevelFor");
-            destroyBuffer(ctx->allocator(), scratch);
-
+            // The AS device address is a property of the storage binding —
+            // valid immediately at creation, before the build executes.
             VkAccelerationStructureDeviceAddressInfoKHR addrInfo{};
             addrInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
             addrInfo.accelerationStructure = out.as;
             out.address = ctx->rt().getAccelerationStructureDeviceAddress(ctx->device(), &addrInfo);
+
+            LodPendingBuild build{};
+            build.as = out.as;
+            build.vertexAddress = rec.vertex.address;
+            build.indexAddress = out.index.address;
+            build.maxVertex = rec.vertexCount - 1;
+            build.primitiveCount = primitiveCount;
+            // Per-build scratch — concurrent builds recorded into one command
+            // buffer must not alias scratch memory (same rule as
+            // refreshGeomBlasBatch's per-record persistent scratch).
+            build.scratch = createAsScratchBuffer(ctx->allocator(), ctx->device(), blasSizes.buildScratchSize);
+            pending.push_back(build);
 
             out.indexCount  = static_cast<uint32_t>(level.indices.size());
             out.errorBound  = level.error;
             return true;
         }
 
-// Drains at most ONE finished chain per call (see the "budget one geometry
-// finalized per frame" doc comment on the declaration) and turns it into
-// GPU resources on `rec`. Discards stale results: the record may have been
-// evicted (geometry destroyed) or its geomVersion may have moved on (the
-// user mutated vertices in place after the job was snapshotted) since the
-// job was enqueued — either way the simplified data no longer matches
-// anything live, so it's dropped and lodState reset to None so a fresh job
-// gets queued next time the (now-different) geometry is seen as eligible.
+void VulkanRendererCore::CoreImpl::flushLodLevelBuilds(std::vector<LodPendingBuild>& pending) {
+            if (pending.empty()) return;
+            const uint32_t N = static_cast<uint32_t>(pending.size());
+            // The build-info structs must stay pointer-stable until the GPU
+            // executes them (pGeometries / rangePtrs are read at submit), so
+            // they live in N-sized vectors that outlast the submit-wait —
+            // same shape as refreshGeomBlasBatch's Phase D.
+            std::vector<VkAccelerationStructureGeometryTrianglesDataKHR> triDatas(N);
+            std::vector<VkAccelerationStructureGeometryKHR>              blasGeoms(N);
+            std::vector<VkAccelerationStructureBuildGeometryInfoKHR>     blasBuilds(N);
+            std::vector<VkAccelerationStructureBuildRangeInfoKHR>        ranges(N);
+            std::vector<const VkAccelerationStructureBuildRangeInfoKHR*> rangePtrs(N);
+            for (uint32_t k = 0; k < N; ++k) {
+                const auto& b = pending[k];
+                triDatas[k].sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+                triDatas[k].vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
+                triDatas[k].vertexData.deviceAddress = b.vertexAddress;
+                triDatas[k].vertexStride = 3 * sizeof(float);
+                triDatas[k].maxVertex = b.maxVertex;
+                triDatas[k].indexType = VK_INDEX_TYPE_UINT32;
+                triDatas[k].indexData.deviceAddress = b.indexAddress;
+
+                blasGeoms[k].sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+                blasGeoms[k].geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+                blasGeoms[k].geometry.triangles = triDatas[k];
+                blasGeoms[k].flags = 0;
+
+                blasBuilds[k].sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+                blasBuilds[k].type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+                blasBuilds[k].flags = VK_BUILD_ACCELERATION_STRUCTURE_PREFER_FAST_TRACE_BIT_KHR;
+                blasBuilds[k].mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+                blasBuilds[k].geometryCount = 1;
+                blasBuilds[k].pGeometries = &blasGeoms[k];
+                blasBuilds[k].dstAccelerationStructure = b.as;
+                blasBuilds[k].scratchData.deviceAddress = b.scratch.address;
+
+                ranges[k].primitiveCount = b.primitiveCount;
+                rangePtrs[k] = &ranges[k];
+            }
+
+            VkCommandBuffer cb = beginOneShot();
+            ctx->rt().cmdBuildAccelerationStructures(cb, N, blasBuilds.data(), rangePtrs.data());
+            endAndSubmitOneShot(cb, "auto-LOD level BLAS batch");
+
+            for (auto& b : pending) destroyBuffer(ctx->allocator(), b.scratch);
+            pending.clear();
+        }
+
+// Drains finished chains up to the per-frame budget (16 geometries OR 8 MiB
+// of new level resources, whichever hits first — see the declaration) and
+// turns them into GPU resources. All of the frame's level BLAS builds are
+// recorded into ONE one-shot submit at the end. Discards stale results: the
+// record may have been evicted (geometry destroyed) or its geomVersion may
+// have moved on (the user mutated vertices in place after the job was
+// snapshotted) since the job was enqueued — either way the simplified data
+// no longer matches anything live, so it's dropped; lodState resets to None
+// so a fresh job gets queued next time the (now-different) geometry is seen
+// as eligible. Stale/failed results don't count against the budget — they
+// create no resources.
 void VulkanRendererCore::CoreImpl::drainLodResults() {
-            LodResult result;
-            {
-                std::lock_guard<std::mutex> lk(lodResultMutex_);
-                if (lodResultQueue_.empty()) return;
-                result = std::move(lodResultQueue_.front());
-                lodResultQueue_.pop_front();
-            }
-            --lodChainsQueuedCount_;
+            constexpr uint32_t kMaxGeomsPerFrame = 16;
+            constexpr uint64_t kMaxNewBytesPerFrame = 8ull * 1024ull * 1024ull;
 
-            auto it = blasCache.find(result.geom);
-            if (it == blasCache.end()) return;// record evicted while the job was in flight
-            BlasRecord& rec = *it->second;
-            if (rec.geomVersion != result.geomVersion) {
-                rec.lodState = BlasRecord::LodState::None;// stale — re-enqueue will pick up the new version
-                return;
-            }
-            if (result.levels.empty()) {
-                rec.lodState = BlasRecord::LodState::Failed;
-                return;
+            uint32_t finalizedGeoms = 0;
+            uint64_t newBytes = 0;
+            std::vector<LodPendingBuild> pending;
+
+            while (finalizedGeoms < kMaxGeomsPerFrame && newBytes < kMaxNewBytesPerFrame) {
+                LodResult result;
+                {
+                    std::lock_guard<std::mutex> lk(lodResultMutex_);
+                    if (lodResultQueue_.empty()) break;
+                    result = std::move(lodResultQueue_.front());
+                    lodResultQueue_.pop_front();
+                }
+                --lodChainsQueuedCount_;
+
+                auto it = blasCache.find(result.geom);
+                if (it == blasCache.end()) continue;// record evicted while the job was in flight
+                BlasRecord& rec = *it->second;
+                if (rec.geomVersion != result.geomVersion) {
+                    rec.lodState = BlasRecord::LodState::None;// stale — re-enqueue will pick up the new version
+                    continue;
+                }
+                if (result.levels.empty()) {
+                    rec.lodState = BlasRecord::LodState::Failed;
+                    continue;
+                }
+
+                rec.lodLevels.reserve(result.levels.size());
+                for (const auto& lvl : result.levels) {
+                    BlasRecord::LodLevel out{};
+                    if (!buildLodLevelFor(rec, lvl, out, pending)) continue;
+                    lodIndexBytes_ += out.index.size;
+                    lodBlasBytes_  += out.storage.size;
+                    newBytes       += out.index.size + out.storage.size;
+                    rec.lodLevels.push_back(out);
+                }
+                if (rec.lodLevels.empty()) {
+                    rec.lodState = BlasRecord::LodState::Failed;
+                } else {
+                    rec.lodState = BlasRecord::LodState::Ready;
+                    ++lodChainsReadyCount_;
+                    ++finalizedGeoms;
+                }
             }
 
-            rec.lodLevels.reserve(result.levels.size());
-            for (const auto& lvl : result.levels) {
-                BlasRecord::LodLevel out{};
-                if (!buildLodLevelFor(rec, lvl, out)) continue;
-                lodIndexBytes_ += out.index.size;
-                lodBlasBytes_  += out.storage.size;
-                rec.lodLevels.push_back(out);
-            }
-            if (rec.lodLevels.empty()) {
-                rec.lodState = BlasRecord::LodState::Failed;
-            } else {
-                rec.lodState = BlasRecord::LodState::Ready;
-                ++lodChainsReadyCount_;
-            }
+            flushLodLevelBuilds(pending);
         }
 
 void VulkanRendererCore::CoreImpl::refreshSkinnedBlas(SkinnedMesh& sm, SkinnedMeshState& st) {

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -351,15 +351,24 @@ namespace threepp {
             VkDeviceAddress asAddress;
             VkDeviceAddress indexAddress;
             uint32_t indexCount;
+            // A selected LEVEL is always an indexed draw — even when the
+            // record itself is non-indexed soup (the chain generator welds
+            // soup into canonical indices whose VALUES are original vertex
+            // ids, so levels index the record's unchanged soup vertex
+            // buffer). Fallback = the record's own indexed-ness. Consumers
+            // (DrawInfo::indexed, GeometryDesc::indexed) must read THIS,
+            // never rec.index.handle directly.
+            bool indexed;
         };
         static LodGeomSel selectLodGeom(const BlasRecord& rec, uint8_t lodLevel) {
             if (lodLevel > 0 && static_cast<size_t>(lodLevel - 1) < rec.lodLevels.size()) {
                 const auto& lvl = rec.lodLevels[lodLevel - 1];
                 if (lvl.as != VK_NULL_HANDLE) {
-                    return {lvl.address, lvl.index.address, lvl.indexCount};
+                    return {lvl.address, lvl.index.address, lvl.indexCount, true};
                 }
             }
-            return {rec.address, rec.index.address, rec.indexCount};
+            return {rec.address, rec.index.address, rec.indexCount,
+                    rec.index.handle != VK_NULL_HANDLE};
         }
 
         // Per-SkinnedMesh deformed-geometry BLAS. Unlike static meshes, skinned
@@ -1127,7 +1136,18 @@ namespace threepp {
             const BufferGeometry* geom = nullptr;
             unsigned int geomVersion = 0;
             std::vector<float> positions;// tightly packed xyz
+            // Indexed geometry: the source index array; normals/uvs stay
+            // empty (the weld step is skipped, topology already exists).
+            // NON-indexed soup (FBX-style loaders never call setIndex):
+            // empty — the worker first welds identical-attribute duplicates
+            // into canonical indices (buildCanonicalIndices) so the
+            // simplifier has shared edges to collapse. normals/uvs feed that
+            // weld's equality test so genuine seams/hard edges stay split;
+            // they carry copies only when the stream exists with matching
+            // counts.
             std::vector<uint32_t> indices;
+            std::vector<float> normals;// soup only; tightly packed xyz
+            std::vector<float> uvs;    // soup only; tightly packed xy
         };
         std::deque<LodJob> lodJobQueue_;
         struct LodResult {
@@ -1172,28 +1192,72 @@ namespace threepp {
                     job = std::move(lodJobQueue_.front());
                     lodJobQueue_.pop_front();
                 }
+                const size_t vertexCount = job.positions.size() / 3;
+                // Soup input: weld first (identical-attribute duplicates →
+                // canonical indices over the ORIGINAL vertex ids), then
+                // simplify those. An empty weld result flows through as an
+                // empty chain ⇒ LodState::Failed at drain, same as any other
+                // degenerate geometry.
+                std::vector<uint32_t> canonical;
+                const uint32_t* idxData = job.indices.data();
+                size_t idxCount = job.indices.size();
+                if (job.indices.empty()) {
+                    canonical = geometrylod::buildCanonicalIndices(
+                            job.positions.data(),
+                            job.normals.empty() ? nullptr : job.normals.data(),
+                            job.uvs.empty() ? nullptr : job.uvs.data(),
+                            vertexCount);
+                    idxData = canonical.data();
+                    idxCount = canonical.size();
+                }
+                // sparse=true for welded soup: the canonical indices reference
+                // only ~1/6 of the soup vertex buffer (the representatives),
+                // and meshopt needs SimplifySparse to keep the unreferenced
+                // duplicates out of its wedge/seam analysis — see the
+                // parameter doc in GeometryLod.hpp.
                 auto levels = geometrylod::generateChain(
-                        job.positions.data(), job.positions.size() / 3,
-                        job.indices.data(), job.indices.size());
+                        job.positions.data(), vertexCount, idxData, idxCount,
+                        /*sparse=*/job.indices.empty());
                 std::lock_guard<std::mutex> lk(lodResultMutex_);
                 lodResultQueue_.push_back({job.geom, job.geomVersion, std::move(levels)});
             }
         }
-        // Snapshots geom's position/index arrays and hands them to the
-        // worker. Called from the selection pass the first time an eligible
-        // entry references a record whose lodState is None (never attempted,
-        // or reset after a stale-result discard in drainLodResults).
-        void enqueueLodJob(const BufferGeometry* geomPtr, unsigned int geomVersion, BufferGeometry& geom) {
+        // Snapshots geom's position/index (or, for non-indexed soup, its
+        // position/normal/uv) arrays and hands them to the worker. Called
+        // from the selection pass the first time an eligible entry
+        // references a record whose lodState is None (never attempted, or
+        // reset after a stale-result discard in drainLodResults). Returns
+        // false when nothing was enqueued (no position attribute) so the
+        // caller never strands the record in Queued with no result coming.
+        bool enqueueLodJob(const BufferGeometry* geomPtr, unsigned int geomVersion, BufferGeometry& geom) {
             auto* posAttr = geom.getAttribute<float>("position");
-            auto* idxAttr = geom.getIndex();
-            if (!posAttr || !idxAttr) return;
+            if (!posAttr) return false;
             LodJob job;
             job.geom = geomPtr;
             job.geomVersion = geomVersion;
             const auto& pos = posAttr->array();
             job.positions.assign(pos.begin(), pos.end());
-            const auto& idx = idxAttr->array();
-            job.indices.assign(idx.begin(), idx.end());
+            if (const auto* idxAttr = geom.getIndex()) {
+                const auto& idx = idxAttr->array();
+                job.indices.assign(idx.begin(), idx.end());
+            } else {
+                // Soup: the worker welds before simplifying — give the weld
+                // every attribute stream that exists with a matching count
+                // so its binary-equality test preserves genuine seams.
+                const auto vtxCount = posAttr->count();
+                if (auto* nrmAttr = geom.getAttribute<float>("normal");
+                    nrmAttr && nrmAttr->count() == vtxCount &&
+                    nrmAttr->array().size() == static_cast<size_t>(vtxCount) * 3) {
+                    const auto& nrm = nrmAttr->array();
+                    job.normals.assign(nrm.begin(), nrm.end());
+                }
+                if (auto* uvAttr = geom.getAttribute<float>("uv");
+                    uvAttr && uvAttr->count() == vtxCount &&
+                    uvAttr->array().size() == static_cast<size_t>(vtxCount) * 2) {
+                    const auto& uv = uvAttr->array();
+                    job.uvs.assign(uv.begin(), uv.end());
+                }
+            }
             ensureLodWorkerStarted();
             {
                 std::lock_guard<std::mutex> lk(lodJobMutex_);
@@ -1201,22 +1265,45 @@ namespace threepp {
             }
             lodJobCv_.notify_one();
             ++lodChainsQueuedCount_;
+            return true;
         }
-        // Pops AT MOST ONE completed chain per call (called once per frame
-        // from ensureSceneBuilt) and finalizes it into GPU resources — the
-        // "budget one geometry finalized per frame" rule. Building a level's
-        // BLAS is a one-shot submit+wait (see buildLodLevelFor); bounding it
-        // to one geometry/frame keeps a chain-ready burst (e.g. right after
-        // setAutoLod(true) on a big scene) from stalling the frame on a run
-        // of synchronous AS builds.
+        // Per-frame chain-finalization budget (drainLodResults, called once
+        // per frame from ensureSceneBuilt): up to 16 geometries OR 8 MiB of
+        // new level resources (index buffers + BLAS storage), whichever hits
+        // first. All of a frame's level BLAS builds are recorded into ONE
+        // one-shot submit+wait (flushLodLevelBuilds) — a submit per level
+        // (or even per geometry) at Bistro-scale entry counts costs more in
+        // queue round-trips than the batching saves. Stale results (record
+        // evicted / geomVersion moved on) and failed chains are processed
+        // outside the budget — they create no resources and cost only a
+        // hash lookup + state write each.
         void drainLodResults();
-        // Builds one level's index buffer + static BLAS (PREFER_FAST_TRACE,
-        // no ALLOW_UPDATE — LOD levels are immutable once built) against
-        // `rec`'s EXISTING vertex buffer/address. Mirrors buildBlasFor's
-        // BLAS-build shape for the subset that differs (index-only geometry
-        // input). Returns false (leaves `out` default) on a degenerate/zero-
+        // One level's deferred BLAS build, produced by buildLodLevelFor and
+        // consumed by flushLodLevelBuilds — resources (AS handle, storage,
+        // index buffer, scratch) already exist; only the build execution is
+        // deferred so a whole frame's worth records into one command buffer.
+        struct LodPendingBuild {
+            VkAccelerationStructureKHR as = VK_NULL_HANDLE;
+            VkDeviceAddress vertexAddress = 0;
+            VkDeviceAddress indexAddress = 0;
+            uint32_t maxVertex = 0;
+            uint32_t primitiveCount = 0;
+            Buffer scratch{};// per-build scratch: concurrent builds in one cmdbuf must not alias
+        };
+        // Creates one level's index buffer + AS handle/storage/address
+        // (PREFER_FAST_TRACE, no ALLOW_UPDATE — LOD levels are immutable
+        // once built) against `rec`'s EXISTING vertex buffer, and appends
+        // the deferred build to `pending`. Mirrors buildBlasFor's BLAS-build
+        // shape for the subset that differs (index-only geometry input; the
+        // AS device address is queried at creation — it's a property of the
+        // storage binding, valid before the build executes). Returns false
+        // (leaves `out` default, appends nothing) on a degenerate/zero-
         // primitive level.
-        bool buildLodLevelFor(BlasRecord& rec, const geometrylod::Level& level, BlasRecord::LodLevel& out);
+        bool buildLodLevelFor(BlasRecord& rec, const geometrylod::Level& level,
+                              BlasRecord::LodLevel& out, std::vector<LodPendingBuild>& pending);
+        // Records every pending level build into one one-shot command
+        // buffer, submits, waits, and frees the per-build scratches.
+        void flushLodLevelBuilds(std::vector<LodPendingBuild>& pending);
         // Destroys every level's AS/storage/index and decrements the running
         // byte totals — called from every blasCache erase site (destructor,
         // eviction prune, geomVersion-changed rebuild) so a record's LOD

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -1155,7 +1155,7 @@ namespace threepp {
         // already hand-authored; auto-LOD swapping index buffers underneath
         // an author-selected discrete level would fight that choice. Membership
         // test walks Object3D::parent by raw pointer — no dynamic_cast.
-        std::unordered_set<const Object3D*> manualLodRoots_;
+        std::unordered_set<const Object3D*> manualLodLevelRoots_;
         // Background chain-generation worker: a single lazily-started
         // std::thread (not a pool — LOD job volume is low: one job per
         // eligible unique geometry, ever, per geomVersion) draining a

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -972,7 +972,9 @@ namespace threepp {
             // version paid a dynamic_cast + ancestor hash-walk + shared_ptr
             // derefs PER ENTRY PER FRAME (~2-4 ms on 4k-entry scenes; measured
             // as the whole feature's CPU cost on Bistro/fjord).
-            //   lodUnderManualLod — mesh sits under a threepp::LOD subtree
+            //   lodExemptStatic — mesh opted out (Object3D::autoLod == false,
+            //     e.g. TileTerrain tiles, which are their own LOD system) or
+            //     sits under a threepp::LOD subtree
             //     (structure changes force a full expansion ⇒ can't go stale).
             //   lodEmissive — cached MaterialWithEmissive cast (material
             //     POINTER swaps force a full expansion). VALUES are read live
@@ -984,7 +986,7 @@ namespace threepp {
             //     unknown ⇒ entry stays LOD0. lodSphereDirty re-derives it
             //     after an in-place geometry edit (set by the geom-dirty
             //     detection, consumed lazily by the next selection pass).
-            bool lodUnderManualLod = false;
+            bool lodExemptStatic = false;
             bool lodSphereDirty    = false;
             const MaterialWithEmissive* lodEmissive = nullptr;
             const BufferGeometry* lodGeomKey = nullptr;

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -958,6 +958,29 @@ namespace threepp {
             // re-expansion (rare, and the selection pass re-picks it that
             // same frame anyway).
             uint8_t  lodLevel    = 0;
+            // Auto-LOD selection caches, derived ONCE at full expansion so the
+            // per-frame selection pass is pure float math — the uncached
+            // version paid a dynamic_cast + ancestor hash-walk + shared_ptr
+            // derefs PER ENTRY PER FRAME (~2-4 ms on 4k-entry scenes; measured
+            // as the whole feature's CPU cost on Bistro/fjord).
+            //   lodUnderManualLod — mesh sits under a threepp::LOD subtree
+            //     (structure changes force a full expansion ⇒ can't go stale).
+            //   lodEmissive — cached MaterialWithEmissive cast (material
+            //     POINTER swaps force a full expansion). VALUES are read live
+            //     each frame, so an emissive that turns on later (dusk-driven
+            //     lantern intensity) exempts immediately, cast-free.
+            //   lodGeomKey — blasCache key (geometry pointer swaps force a
+            //     full expansion).
+            //   lodCenter/lodRadius — object-space bounding sphere; radius 0 ⇒
+            //     unknown ⇒ entry stays LOD0. lodSphereDirty re-derives it
+            //     after an in-place geometry edit (set by the geom-dirty
+            //     detection, consumed lazily by the next selection pass).
+            bool lodUnderManualLod = false;
+            bool lodSphereDirty    = false;
+            const MaterialWithEmissive* lodEmissive = nullptr;
+            const BufferGeometry* lodGeomKey = nullptr;
+            float lodCenter[3] = {0.f, 0.f, 0.f};
+            float lodRadius = 0.f;
         };
 
         // ── Scene-structure SNAPSHOT (ensureSceneBuilt fast path) ────────────

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -1123,8 +1123,12 @@ namespace threepp {
         // shimmer otherwise — a "just right" default, not an opt-in.
         bool     normalMapToksvig_ = true;
 
-        // ── Automatic mesh LOD (setAutoLod; default OFF) ────────────────────
-        bool autoLod_ = false;
+        // ── Automatic mesh LOD (setAutoLod; ON by default) ──────────────────
+        // Default-on since the full measurement pass: Bistro (per-pixel-bound
+        // worst case) neutral, fjord flight +32% FPS, quality below animation
+        // noise, switch frames stall-free (geomDescs ring). setAutoLod(false)
+        // remains as the manual override / debug escape (Toksvig pattern).
+        bool autoLod_ = true;
         // Set by the selection pass in ensureSceneBuilt (VulkanCoreScene.cpp)
         // when ANY entry's chosen level changed this frame; read right after
         // to fold into the same "force a full TLAS rebuild" trigger the

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -41,6 +41,7 @@
 #include "threepp/materials/Material.hpp"
 #include "threepp/materials/MeshBasicMaterial.hpp"
 #include "threepp/materials/interfaces.hpp"
+#include "threepp/objects/LOD.hpp"
 #include "threepp/objects/Line.hpp"
 #include "threepp/objects/LineSegments.hpp"
 #include "threepp/objects/Points.hpp"
@@ -908,6 +909,7 @@ namespace threepp {
             InstancedMesh* inst = nullptr;
             Line*          line = nullptr;
             Points*        pts  = nullptr;
+            LOD*           lod  = nullptr;// kSnapLod nodes: replay walk re-runs level selection
             const void* geom = nullptr;               // mesh/line/points geometry
             BufferGeometry* geomB = nullptr;          // typed view of geom (attributesVersion reads)
             const Material* mat = nullptr;            // mesh material
@@ -936,6 +938,10 @@ namespace threepp {
         // LineEntry — matches three.js / GLRenderer, which drops a
         // material-hidden object from the render list. [[#mat-visible]]
         static constexpr uint32_t kSnapMatHidden  = 256u;
+        // threepp::LOD node (kind Other + typed sn.lod view). Both walks run
+        // the camera-driven level selection on it — three.js/GLRenderer
+        // parity (projectObject calls lod.update(camera) as it projects).
+        static constexpr uint32_t kSnapLod        = 512u;
         std::vector<SnapNode> sceneSnapshot_;
 
         // Classification-routing flags for a mesh — shared by the snapshot
@@ -944,8 +950,11 @@ namespace threepp {
 
         // Replay the last expansion's traversal against the snapshot. true ⇒
         // tree shape, visibility, classification routing and all mesh/geom/mat
-        // pointers are unchanged since the last full expansion.
-        bool sceneSnapshotMatches(Object3D& scene);
+        // pointers are unchanged since the last full expansion. Also re-runs
+        // LOD level selection (camera-driven visibility mutation) on kSnapLod
+        // nodes — a level switch makes the walk diverge from the snapshot ⇒
+        // false ⇒ the full pass re-expands with the new level.
+        bool sceneSnapshotMatches(Object3D& scene, Camera& camera);
 
         // Previous-frame camera (proj_prev * view_prev) for primary-hit
         // reprojection. One UBO per frame-in-flight so updates don't race the
@@ -3534,7 +3543,7 @@ namespace threepp {
         // compares. Cheap. The rare rebuild path waits the GPU idle, retires
         // the TLAS + scene desc buffers, and rewrites bindings 0/3/4 across
         // every descriptor set without re-allocating from the pool.
-        void ensureSceneBuilt(Object3D& scene);
+        void ensureSceneBuilt(Object3D& scene, Camera& camera);
 
         void createCameraUbos();
 

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -30,6 +30,7 @@
 
 #include "threepp/cameras/Camera.hpp"
 #include "threepp/cameras/OrthographicCamera.hpp"
+#include "threepp/cameras/PerspectiveCamera.hpp"
 #include "threepp/canvas/Canvas.hpp"
 #include "threepp/core/InterleavedBufferAttribute.hpp"
 #include "threepp/core/Object3D.hpp"
@@ -77,6 +78,7 @@
 // (debug_resolve.comp.spv moved into vulkan/VulkanCoreIndirect.cpp)
 
 #include "threepp/renderers/common/BCnDecode.hpp"
+#include "threepp/utils/GeometryLod.hpp"
 
 #include <GLFW/glfw3.h>
 
@@ -84,14 +86,18 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
+#include <deque>
 #include <limits>
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -299,8 +305,62 @@ namespace threepp {
             // vector every frame → persistent denoiser/TAA history rejection
             // (runtime-updated geometry stays noisy / visibly shakes).
             bool prevVertexResyncPending = false;
+
+            // ── Automatic mesh LOD (setAutoLod) ─────────────────────────
+            // One simplified INDEX buffer + its own static BLAS per chain
+            // level, built beyond this record's own (LOD0) vertex/normal/uv/
+            // color buffers — those stay shared across every level (meshopt
+            // never moves or reorders vertices, only drops/reweaves
+            // triangles), so a level swap is purely an index-buffer +
+            // BLAS-reference change, consumed identically by the raster
+            // vertex-pulling path (buildIndirectDrawData) and the TLAS
+            // instance fill (ensureSceneBuilt).
+            struct LodLevel {
+                VkAccelerationStructureKHR as = VK_NULL_HANDLE;
+                Buffer storage;
+                Buffer index;// uint32, indexes into THIS record's own `vertex`
+                VkDeviceAddress address = 0;// BLAS device address
+                uint32_t indexCount = 0;
+                // Absolute object-space screen-space-error bound for this
+                // level (see threepp::geometrylod::Level::error). Multiplied
+                // by world scale + px/unit at selection time.
+                float errorBound = 0.f;
+            };
+            // Chain-generation state. None → not yet attempted (or the prior
+            // attempt's geometry version is stale); Queued → a background
+            // job is in flight; Ready → lodLevels is usable; Failed →
+            // generateChain produced nothing (too small/degenerate) — never
+            // retried for this geomVersion. Touched ONLY on the main thread
+            // (the worker only ever sees copied job data, never the record).
+            enum class LodState : uint8_t { None, Queued, Ready, Failed };
+            LodState lodState = LodState::None;
+            // Index i backs MeshEntry::lodLevel == i+1 (level 0 is this
+            // record's own vertex/index/etc — never stored here).
+            std::vector<LodLevel> lodLevels;
         };
         std::unordered_map<const BufferGeometry*, std::unique_ptr<BlasRecord>> blasCache;
+
+        // Resolved index/AS data for whichever LOD level an entry currently
+        // selects. Falls back to the record's own LOD0 buffers when
+        // lodLevel==0 or that level isn't built yet — the ONLY two call
+        // sites that pick per-entry geometry for rendering (buildIndirectDrawData's
+        // raster path, and the TLAS instance / GeometryDesc fill below) go
+        // through this so the rasterized and ray-traced views of an entry
+        // can never disagree about which triangles exist.
+        struct LodGeomSel {
+            VkDeviceAddress asAddress;
+            VkDeviceAddress indexAddress;
+            uint32_t indexCount;
+        };
+        static LodGeomSel selectLodGeom(const BlasRecord& rec, uint8_t lodLevel) {
+            if (lodLevel > 0 && static_cast<size_t>(lodLevel - 1) < rec.lodLevels.size()) {
+                const auto& lvl = rec.lodLevels[lodLevel - 1];
+                if (lvl.as != VK_NULL_HANDLE) {
+                    return {lvl.address, lvl.index.address, lvl.indexCount};
+                }
+            }
+            return {rec.address, rec.index.address, rec.indexCount};
+        }
 
         // Per-SkinnedMesh deformed-geometry BLAS. Unlike static meshes, skinned
         // meshes can't share BLAS even when they share BufferGeometry — each
@@ -879,6 +939,16 @@ namespace threepp {
             // Skinned / displaced / morphed entries always stay true; their
             // local AABB doesn't reflect deformed extents.
             bool     inFrustum   = true;
+            // Automatic mesh LOD (setAutoLod): 0 == the geometry's own
+            // (finest) buffers; N>0 selects BlasRecord::lodLevels[N-1].
+            // Written once per frame by the LOD selection pass in
+            // ensureSceneBuilt and read verbatim by both buildIndirectDrawData
+            // (raster) and the TLAS instance fill — never re-derived. Carries
+            // hysteresis state across lean (snapshot-fast-path) frames since
+            // entries persist in lastVisibleEntries_; resets to 0 on a full
+            // re-expansion (rare, and the selection pass re-picks it that
+            // same frame anyway).
+            uint8_t  lodLevel    = 0;
         };
 
         // ── Scene-structure SNAPSHOT (ensureSceneBuilt fast path) ────────────
@@ -1011,6 +1081,161 @@ namespace threepp {
         // mip 0 (nLen ~= 1), and strictly reduces normal-map minification
         // shimmer otherwise — a "just right" default, not an opt-in.
         bool     normalMapToksvig_ = true;
+
+        // ── Automatic mesh LOD (setAutoLod; default OFF) ────────────────────
+        bool autoLod_ = false;
+        // Set by the selection pass in ensureSceneBuilt (VulkanCoreScene.cpp)
+        // when ANY entry's chosen level changed this frame; read right after
+        // to fold into the same "force a full TLAS rebuild" trigger the
+        // deformer paths already use (blasDeformed) — an AS-reference change
+        // per VkAccelerationStructureInstanceKHR is only unambiguously legal
+        // under MODE_BUILD, not the incremental MODE_UPDATE refit. Also
+        // gates the one-time geomDescsCached_ → geometryDescsBuffer patch
+        // (see below) so RT secondary rays (reflections/GI/lidar/probe
+        // update) read the SAME index buffer the swapped BLAS was built
+        // from — without it, gl_PrimitiveID from a hit against a coarser
+        // BLAS would misindex the still-LOD0 GeometryDesc::indexAddress.
+        bool lodChangedThisFrame_ = false;
+        // Host mirror of the last-uploaded GeometryDesc array (entries-
+        // indexed, same layout as the `geomDescs` local built in the full
+        // rebuild). geometryDescsBuffer is a SINGLE buffer (not per-frame-
+        // in-flight — see its declaration), so patching it requires the
+        // same vkDeviceWaitIdle-gated pattern already used elsewhere in
+        // ensureSceneBuilt for shared-buffer mutations; kept cheap by only
+        // touching it on the rare frame a LOD level actually changed.
+        std::vector<GeometryDesc> geomDescsCached_;
+        // Manual threepp::LOD subtrees, rebuilt every FULL scene expansion
+        // (cleared at the start of the traverseVisible walk). A mesh entry
+        // under one of these is exempt from auto-LOD — its levels are
+        // already hand-authored; auto-LOD swapping index buffers underneath
+        // an author-selected discrete level would fight that choice. Membership
+        // test walks Object3D::parent by raw pointer — no dynamic_cast.
+        std::unordered_set<const Object3D*> manualLodRoots_;
+        // Background chain-generation worker: a single lazily-started
+        // std::thread (not a pool — LOD job volume is low: one job per
+        // eligible unique geometry, ever, per geomVersion) draining a
+        // mutex+condvar job queue. Jobs snapshot (copy) position/index data
+        // at enqueue time, so the worker never touches live BufferGeometry /
+        // Vulkan state — no lifetime races with a scene the main thread
+        // mutates or tears down while a job runs. Joined in ~CoreImpl before
+        // anything Vulkan-related is torn down (the worker is pure CPU).
+        std::thread lodWorker_;
+        std::mutex lodJobMutex_;
+        std::condition_variable lodJobCv_;
+        bool lodWorkerStop_ = false;
+        struct LodJob {
+            const BufferGeometry* geom = nullptr;
+            unsigned int geomVersion = 0;
+            std::vector<float> positions;// tightly packed xyz
+            std::vector<uint32_t> indices;
+        };
+        std::deque<LodJob> lodJobQueue_;
+        struct LodResult {
+            const BufferGeometry* geom = nullptr;
+            unsigned int geomVersion = 0;
+            std::vector<geometrylod::Level> levels;// empty ⇒ degenerate/failed
+        };
+        std::mutex lodResultMutex_;
+        std::deque<LodResult> lodResultQueue_;
+        // Running byte totals for every finalized LOD index buffer + BLAS
+        // storage, updated as chains finalize / are evicted — cheap O(1)
+        // bookkeeping instead of a full blasCache walk every frame. Gates
+        // the hard cap on new chain GENERATION (already-finalized chains are
+        // never evicted early to enforce it — see setAutoLod's doc comment).
+        uint64_t lodIndexBytes_ = 0;
+        uint64_t lodBlasBytes_  = 0;
+        bool lodBudgetWarned_ = false;
+        static constexpr uint64_t kLodByteBudget = 256ull * 1024ull * 1024ull;
+        // Unique-geometry chain-state counters (NOT per-entry), maintained
+        // at enqueue/drain time — surfaced via autoLodStats().
+        uint32_t lodChainsReadyCount_  = 0;
+        uint32_t lodChainsQueuedCount_ = 0;
+        VulkanRendererCore::AutoLodStats autoLodStats_{};
+
+        void ensureLodWorkerStarted() {
+            if (lodWorker_.joinable()) return;
+            lodWorker_ = std::thread([this] { lodWorkerMain(); });
+        }
+        void lodWorkerMain() {
+            for (;;) {
+                LodJob job;
+                {
+                    std::unique_lock<std::mutex> lk(lodJobMutex_);
+                    lodJobCv_.wait(lk, [this] { return lodWorkerStop_ || !lodJobQueue_.empty(); });
+                    // Exit immediately on stop, even with jobs still queued —
+                    // shutdown must be bounded; nothing will ever drain their
+                    // results after this. A job already popped and mid-
+                    // simplify (the loop body below, no lock held) still
+                    // runs to completion — can't interrupt meshopt mid-call,
+                    // and its result is simply never drained.
+                    if (lodWorkerStop_) return;
+                    job = std::move(lodJobQueue_.front());
+                    lodJobQueue_.pop_front();
+                }
+                auto levels = geometrylod::generateChain(
+                        job.positions.data(), job.positions.size() / 3,
+                        job.indices.data(), job.indices.size());
+                std::lock_guard<std::mutex> lk(lodResultMutex_);
+                lodResultQueue_.push_back({job.geom, job.geomVersion, std::move(levels)});
+            }
+        }
+        // Snapshots geom's position/index arrays and hands them to the
+        // worker. Called from the selection pass the first time an eligible
+        // entry references a record whose lodState is None (never attempted,
+        // or reset after a stale-result discard in drainLodResults).
+        void enqueueLodJob(const BufferGeometry* geomPtr, unsigned int geomVersion, BufferGeometry& geom) {
+            auto* posAttr = geom.getAttribute<float>("position");
+            auto* idxAttr = geom.getIndex();
+            if (!posAttr || !idxAttr) return;
+            LodJob job;
+            job.geom = geomPtr;
+            job.geomVersion = geomVersion;
+            const auto& pos = posAttr->array();
+            job.positions.assign(pos.begin(), pos.end());
+            const auto& idx = idxAttr->array();
+            job.indices.assign(idx.begin(), idx.end());
+            ensureLodWorkerStarted();
+            {
+                std::lock_guard<std::mutex> lk(lodJobMutex_);
+                lodJobQueue_.push_back(std::move(job));
+            }
+            lodJobCv_.notify_one();
+            ++lodChainsQueuedCount_;
+        }
+        // Pops AT MOST ONE completed chain per call (called once per frame
+        // from ensureSceneBuilt) and finalizes it into GPU resources — the
+        // "budget one geometry finalized per frame" rule. Building a level's
+        // BLAS is a one-shot submit+wait (see buildLodLevelFor); bounding it
+        // to one geometry/frame keeps a chain-ready burst (e.g. right after
+        // setAutoLod(true) on a big scene) from stalling the frame on a run
+        // of synchronous AS builds.
+        void drainLodResults();
+        // Builds one level's index buffer + static BLAS (PREFER_FAST_TRACE,
+        // no ALLOW_UPDATE — LOD levels are immutable once built) against
+        // `rec`'s EXISTING vertex buffer/address. Mirrors buildBlasFor's
+        // BLAS-build shape for the subset that differs (index-only geometry
+        // input). Returns false (leaves `out` default) on a degenerate/zero-
+        // primitive level.
+        bool buildLodLevelFor(BlasRecord& rec, const geometrylod::Level& level, BlasRecord::LodLevel& out);
+        // Destroys every level's AS/storage/index and decrements the running
+        // byte totals — called from every blasCache erase site (destructor,
+        // eviction prune, geomVersion-changed rebuild) so a record's LOD
+        // resources never outlive the record itself.
+        void destroyBlasLodLevels(BlasRecord& rec) {
+            for (auto& lvl : rec.lodLevels) {
+                if (lvl.as) ctx->rt().destroyAccelerationStructure(ctx->device(), lvl.as, nullptr);
+                lodBlasBytes_  -= std::min<uint64_t>(lodBlasBytes_,  lvl.storage.size);
+                lodIndexBytes_ -= std::min<uint64_t>(lodIndexBytes_, lvl.index.size);
+                destroyBuffer(ctx->allocator(), lvl.storage);
+                destroyBuffer(ctx->allocator(), lvl.index);
+            }
+            if (rec.lodState == BlasRecord::LodState::Ready && !rec.lodLevels.empty()) {
+                lodChainsReadyCount_ = lodChainsReadyCount_ > 0 ? lodChainsReadyCount_ - 1 : 0;
+            }
+            rec.lodLevels.clear();
+            rec.lodState = BlasRecord::LodState::None;
+        }
+
         // Cached CDF blob (16 floats per tri) reused across frames when no
         // emissive mesh moved + entries-list size unchanged. The CPU walk in
         // buildAndUploadEmissiveTris is the dominant per-frame cost on
@@ -1926,6 +2151,22 @@ namespace threepp {
         }
 
         ~CoreImpl() {
+            // Stop the auto-LOD background worker first — it's pure CPU (no
+            // Vulkan handles touched), so this is safe even when ctx is
+            // null. Must happen before the blasCache teardown below, which
+            // destroys the same records' lodLevels AS/buffers the worker
+            // could otherwise still be racing to enqueue results against
+            // (drainLodResults only ever runs from ensureSceneBuilt, which
+            // can't run concurrently with this destructor, but the queue
+            // itself is shared state the worker thread still owns until
+            // joined).
+            {
+                std::lock_guard<std::mutex> lk(lodJobMutex_);
+                lodWorkerStop_ = true;
+            }
+            lodJobCv_.notify_all();
+            if (lodWorker_.joinable()) lodWorker_.join();
+
             if (!ctx) return;
             VkDevice d = ctx->device();
             // If a frame was mid-record when the renderer was destroyed (the
@@ -1964,6 +2205,7 @@ namespace threepp {
             if (debugResolveDsLayout_)       vkDestroyDescriptorSetLayout(d, debugResolveDsLayout_, nullptr);
 
             for (auto& [_, rec] : blasCache) {
+                destroyBlasLodLevels(*rec);
                 if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
                 destroyBuffer(ctx->allocator(), rec->storage);
                 destroyBuffer(ctx->allocator(), rec->vertex);

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -660,7 +660,16 @@ namespace threepp {
         // `MaterialDesc md{};` call sites unchanged.
         using MaterialDesc = threepp::vulkan_pt::MaterialDesc;
 
-        Buffer geometryDescsBuffer;
+        // Per-frame-in-flight GeometryDesc storage — same fence-gated ring as
+        // materialDescsBuffers below. Ringed for auto-LOD: a level switch
+        // repoints GeometryDesc::indexAddress/indexed, and the single-buffer
+        // version needed a vkDeviceWaitIdle on every switch frame to patch it
+        // in place — a stall exactly when the camera moves (the frames where
+        // responsiveness matters most). Hot path stages in geomDescsCached_ +
+        // flips geomDescsDirty_[*]; renderFrame's flushGeometryDescsIfDirty
+        // memcpys into this frame's slot once its fence has signaled.
+        std::array<Buffer, kFramesInFlight> geometryDescsBuffers{};
+        std::array<bool, kFramesInFlight> geomDescsDirty_{};
         // Per-frame-in-flight MaterialDesc storage. Was a single shared buffer
         // gated by vkDeviceWaitIdle on every animated-pbr update; now one buffer
         // per kFramesInFlight slot so the upload after a fence wait races
@@ -1122,19 +1131,17 @@ namespace threepp {
         // deformer paths already use (blasDeformed) — an AS-reference change
         // per VkAccelerationStructureInstanceKHR is only unambiguously legal
         // under MODE_BUILD, not the incremental MODE_UPDATE refit. Also
-        // gates the one-time geomDescsCached_ → geometryDescsBuffer patch
-        // (see below) so RT secondary rays (reflections/GI/lidar/probe
-        // update) read the SAME index buffer the swapped BLAS was built
-        // from — without it, gl_PrimitiveID from a hit against a coarser
-        // BLAS would misindex the still-LOD0 GeometryDesc::indexAddress.
+        // flips geomDescsDirty_[*] so RT secondary rays (reflections/GI/
+        // lidar/probe update) read the SAME index buffer the swapped BLAS
+        // was built from — without it, gl_PrimitiveID from a hit against a
+        // coarser BLAS would misindex the still-LOD0
+        // GeometryDesc::indexAddress.
         bool lodChangedThisFrame_ = false;
         // Host mirror of the last-uploaded GeometryDesc array (entries-
         // indexed, same layout as the `geomDescs` local built in the full
-        // rebuild). geometryDescsBuffer is a SINGLE buffer (not per-frame-
-        // in-flight — see its declaration), so patching it requires the
-        // same vkDeviceWaitIdle-gated pattern already used elsewhere in
-        // ensureSceneBuilt for shared-buffer mutations; kept cheap by only
-        // touching it on the rare frame a LOD level actually changed.
+        // rebuild). The lean auto-LOD path patches indexAddress/indexed in
+        // place here; the per-frame ring flush (flushGeometryDescsIfDirty)
+        // carries it to the GPU stall-free.
         std::vector<GeometryDesc> geomDescsCached_;
         // Manual threepp::LOD subtrees, rebuilt every FULL scene expansion
         // (cleared at the start of the traverseVisible walk). A mesh entry
@@ -2301,7 +2308,7 @@ namespace threepp {
             destroyBuffer(ctx->allocator(), tlasBuffer);
             for (auto& b : tlasInstancesBuffers) destroyBuffer(ctx->allocator(), b);
             destroyBuffer(ctx->allocator(), tlasRefitScratch_);
-            destroyBuffer(ctx->allocator(), geometryDescsBuffer);
+            for (auto& b : geometryDescsBuffers) destroyBuffer(ctx->allocator(), b);
             for (auto& b : materialDescsBuffers) destroyBuffer(ctx->allocator(), b);
             destroyBuffer(ctx->allocator(), sceneCaptureBuf_);
             destroyBuffer(ctx->allocator(), eventLumaBuf_);
@@ -3601,6 +3608,9 @@ namespace threepp {
         // retired, so the memcpy races nothing. Replaces the old shared-buffer
         // path that called vkDeviceWaitIdle on every animated-pbr update.
         void flushMaterialDescsIfDirty(uint32_t frame);
+        // Same fence-gated ring flush for GeometryDescs (auto-LOD level
+        // switches repoint indexAddress/indexed — see geomDescsCached_).
+        void flushGeometryDescsIfDirty(uint32_t frame);
 
         // Per-frame frustum cull: tag every entry with `inFrustum` so raster
         // passes (gbuf prepass, overlay depth prepass) can skip off-screen

--- a/src/threepp/renderers/vulkan/VulkanCoreIndirect.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreIndirect.cpp
@@ -87,13 +87,16 @@ namespace threepp {
             const BlasRecord* rec = resolveBlasForEntry(en);
             if (!rec || rec->vertex.handle == VK_NULL_HANDLE) continue;
 
-            const bool indexed = (rec->index.handle != VK_NULL_HANDLE);
             // Auto-LOD: en.lodLevel==0 for every non-eligible entry (the
             // selection pass in ensureSceneBuilt only sets it >0 on plain
-            // indexed static geometry), so this passthrough is a no-op
-            // everywhere else. Must resolve identically to the TLAS instance
-            // fill in ensureSceneBuilt — both read en.lodLevel verbatim.
+            // static geometry), so this passthrough is a no-op everywhere
+            // else. Must resolve identically to the TLAS instance fill in
+            // ensureSceneBuilt — both read en.lodLevel verbatim. Indexed-ness
+            // is PER SELECTION, not per record: a level of a non-indexed soup
+            // record is an indexed draw (welded canonical indices) against
+            // the same soup vertex buffer.
             const auto lodSel = selectLodGeom(*rec, en.lodLevel);
+            const bool indexed = lodSel.indexed;
             const uint32_t vcount = indexed ? lodSel.indexCount : rec->vertexCount;
             if (vcount == 0u) continue;
 

--- a/src/threepp/renderers/vulkan/VulkanCoreIndirect.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreIndirect.cpp
@@ -88,7 +88,13 @@ namespace threepp {
             if (!rec || rec->vertex.handle == VK_NULL_HANDLE) continue;
 
             const bool indexed = (rec->index.handle != VK_NULL_HANDLE);
-            const uint32_t vcount = indexed ? rec->indexCount : rec->vertexCount;
+            // Auto-LOD: en.lodLevel==0 for every non-eligible entry (the
+            // selection pass in ensureSceneBuilt only sets it >0 on plain
+            // indexed static geometry), so this passthrough is a no-op
+            // everywhere else. Must resolve identically to the TLAS instance
+            // fill in ensureSceneBuilt — both read en.lodLevel verbatim.
+            const auto lodSel = selectLodGeom(*rec, en.lodLevel);
+            const uint32_t vcount = indexed ? lodSel.indexCount : rec->vertexCount;
             if (vcount == 0u) continue;
 
             const VkCullModeFlags wantCull =
@@ -120,7 +126,7 @@ namespace threepp {
             di.prevPosAddr = (rec->prevVertex.handle != VK_NULL_HANDLE && !warpReproject)
                                      ? rec->prevVertex.address
                                      : rec->vertex.address;
-            di.indexAddr   = indexed ? rec->index.address : 0ull;
+            di.indexAddr   = indexed ? lodSel.indexAddress : 0ull;
             // Per-vertex color: only when the material opts in (vertexColors)
             // and the geometry uploaded a color buffer — matches the
             // GeometryDesc::colorAddress gate. gbuffer.frag multiplies albedo

--- a/src/threepp/renderers/vulkan/VulkanCoreIndirect.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreIndirect.cpp
@@ -1,5 +1,7 @@
 #include "VulkanCoreImpl.hpp"
 
+#include "threepp/renderers/vulkan/shaders/vulkan_shared.h"// kInstFlag* bit layout
+
 // debug_resolve.comp's embedded SPIR-V array (kDebugResolveCompSpv) is only
 // referenced by createDebugResolvePipeline below — moved out of the header
 // with the rest of this file's methods.
@@ -130,14 +132,12 @@ namespace threepp {
                                        : 0ull;
             }
             di.instanceCustomIndex = static_cast<uint32_t>(i);
-            // Flag bits match the old gbuffer.vert push-constant layout:
-            //   bit 0 = is_water (DisplacedMesh), bit 3 = is_skinned,
-            //   bit 4 = double-sided material (Side::Double),
-            //   bit 5 = persistent per-frame deformer (tet-skinned soft body),
-            //   bit 6 = per-frame texture animation (Material::textureAnimatedHint).
+            // Per-instance flag word — canonical bit layout in
+            // vulkan_shared.h (kInstFlag*); shaders read it back from the
+            // gbuffer IDs .z via the instance_flags.glsl accessors.
             uint32_t flags = 0u;
-            if (en.isDisplaced) flags |= 1u;
-            if (en.isSkinned)   flags |= 8u;
+            if (en.isDisplaced) flags |= kInstFlagWater;
+            if (en.isSkinned)   flags |= kInstFlagSkinned;
             {
                 const auto sm = en.mesh->material();
                 // DOUBLE_SIDED: gbuffer.frag flips N toward the viewer, so on
@@ -147,21 +147,21 @@ namespace threepp {
                 // consumed in deferred_shade.comp / deferred_denoise.comp) or
                 // the GI history cold-starts every frame — measured as 8× the
                 // frame-to-frame flicker on a procedural tree canopy.
-                if (sm && sm->side == Side::Double) flags |= 16u;
+                if (sm && sm->side == Side::Double) flags |= kInstFlagDoubleSided;
                 // TEXTURE-ANIMATED (scrolling UVs, video/live textures): the
                 // pattern moves with NO geometric motion vectors, so the TAA
                 // resolve must hold a short history (α floor) instead of
                 // smearing it. TAA-only — the GI history accumulates
                 // DEMODULATED irradiance, which a texture animation doesn't
                 // change, so bit 6 deliberately does NOT shorten the GI cap.
-                if (sm && sm->textureAnimatedHint) flags |= 64u;
+                if (sm && sm->textureAnimatedHint) flags |= kInstFlagTexAnim;
             }
             // PERSISTENT DEFORMER: a PhysX soft body deforms EVERY frame, so
             // the GI temporal cap in deferred_shade.comp must not chase its
             // oscillating per-pixel motion magnitude (visible pumping on the
             // wobble). The shader pins a constant history cap on this bit;
             // the TAA resolve floors its blend α (shading changes per frame).
-            if (en.isTet) flags |= 32u;
+            if (en.isTet) flags |= kInstFlagDeformer;
             // Semantic CLASS id (0..255) packed into bits 8..15 — inert to
             // every flag bit-test (they mask the low byte) and carried
             // through the MSAA resolve. Read back via outIds.z >> 8.

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -192,6 +192,10 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
             std::vector<MeshEntry> built;
             std::vector<LineEntry> builtLines;
             sceneSnapshot_.clear();
+            // Rebuilt below as the walk visits each threepp::LOD node — a
+            // mesh entry whose parent chain hits one of these is exempt from
+            // auto-LOD (see the selection pass just after this expansion).
+            manualLodRoots_.clear();
             // traverseVisible (not traverse) so an invisible parent hides its
             // whole subtree — matches three.js / GLRenderer convention. Plain
             // `traverse` walks every node regardless of visibility, leaking
@@ -212,6 +216,10 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                     sn.lod   = lod;
                     sn.flags = kSnapKindOther | kSnapLod;
                     sceneSnapshot_.push_back(sn);
+                    // Auto-LOD exemption: every level object under a manual
+                    // LOD node is author-selected already; don't let auto-LOD
+                    // swap index buffers underneath that choice.
+                    for (Object3D* child : lod->children) manualLodRoots_.insert(child);
                     return;
                 }
                 // Line / LineSegments: never part of the traced/rasterized
@@ -367,6 +375,163 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
             lastVisibleLines_   = std::move(builtLines);
             probeGridDirty_     = true;// scene structure changed → re-fit the probe grid
             }// !snapLean
+
+            // ── Automatic mesh LOD selection (setAutoLod; default off) ──────
+            // Runs UNCONDITIONALLY every frame — camera motion alone can flip
+            // a level even when nothing else about the scene changed — right
+            // after entries got fresh world matrices from WHICHEVER path
+            // produced them above (lean in-place diff or full re-expansion),
+            // so this one spot covers both. Writes only MeshEntry::lodLevel +
+            // lodChangedThisFrame_/autoLodStats_; the BLAS-address/index-
+            // buffer swap itself happens later in this function (the lean
+            // TLAS-refit instance loop) and in the full-rebuild instance loop
+            // further down — both read en.lodLevel verbatim, never re-deriving.
+            lodChangedThisFrame_ = false;
+            if (autoLod_) drainLodResults();// budget: one geometry finalized per frame
+            {
+                VulkanRendererCore::AutoLodStats stats{};
+                stats.indexBytes   = lodIndexBytes_;
+                stats.blasBytes    = lodBlasBytes_;
+                stats.chainsReady  = lodChainsReadyCount_;
+                stats.chainsQueued = lodChainsQueuedCount_;
+                if (autoLod_) {
+                    auto* persp = dynamic_cast<PerspectiveCamera*>(&camera);
+                    Vector3 camPos;
+                    if (persp) camPos.setFromMatrixPosition(*camera.matrixWorld);
+                    const float renderHeightPx = static_cast<float>(renderExtent().height);
+                    const float tanHalfFovY = persp
+                            ? std::tan(math::degToRad(persp->getEffectiveFOV()) * 0.5f)
+                            : 0.f;
+
+                    for (auto& en : entries) {
+                        if (en.isOverlay || en.isParticle) continue;// not scene geometry — no LOD concept
+                        if (en.isSkinned || en.isDisplaced || en.isGrass || en.isMorphed || en.isTet) {
+                            en.lodLevel = 0;// deformers: local AABB is stale, never simplify
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+                        if (!persp) {
+                            en.lodLevel = 0;// non-perspective camera reached here — be defensive
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+                        Mesh* m = en.mesh;
+                        bool underManualLod = false;
+                        for (Object3D* p = m->parent; p; p = p->parent) {
+                            if (manualLodRoots_.count(p)) { underManualLod = true; break; }
+                        }
+                        if (underManualLod) {
+                            en.lodLevel = 0;// author already picked discrete levels here
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+                        if (auto matSp = m->material()) {
+                            if (auto* em = dynamic_cast<MaterialWithEmissive*>(matSp.get())) {
+                                const bool nonBlack = em->emissive.r > 0.f || em->emissive.g > 0.f || em->emissive.b > 0.f;
+                                if (nonBlack || em->emissiveMap) {
+                                    // Emissive NEE's per-tri CDF (buildAndUploadEmissiveTris)
+                                    // caches world-space triangle positions and would not
+                                    // notice a silent index-buffer swap underneath it.
+                                    en.lodLevel = 0;
+                                    ++stats.entriesPerLevel[0];
+                                    continue;
+                                }
+                            }
+                        }
+
+                        auto geom = m->geometry();
+                        if (!geom || !geom->getIndex()) {
+                            en.lodLevel = 0;// unindexed geometry — LOD needs an index buffer to swap
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+                        auto blasIt = blasCache.find(geom.get());
+                        if (blasIt == blasCache.end()) {
+                            en.lodLevel = 0;// brand-new geometry this frame — no LOD0 record to chain off yet
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+                        BlasRecord& rec = *blasIt->second;
+
+                        const uint32_t triCount = rec.indexCount / 3u;
+                        const bool eligible = triCount >= 4096u;
+                        if (eligible && rec.lodState == BlasRecord::LodState::None) {
+                            if ((lodIndexBytes_ + lodBlasBytes_) <= kLodByteBudget) {
+                                enqueueLodJob(geom.get(), rec.geomVersion, *geom);
+                                rec.lodState = BlasRecord::LodState::Queued;
+                            } else if (!lodBudgetWarned_) {
+                                std::cerr << "[VulkanRenderer] auto-LOD: 256 MiB byte budget reached — "
+                                             "no further chains will be generated this session\n";
+                                lodBudgetWarned_ = true;
+                            }
+                        }
+
+                        if (rec.lodState != BlasRecord::LodState::Ready || rec.lodLevels.empty()) {
+                            en.lodLevel = 0;
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+
+                        if (!geom->boundingBox) geom->computeBoundingBox();
+                        if (!geom->boundingBox) {
+                            en.lodLevel = 0;
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+
+                        Matrix4 world;
+                        std::memcpy(world.elements.data(), en.worldMatrix.data(), 64);
+                        Vector3 worldCenter = geom->boundingBox->getCenter();
+                        worldCenter.applyMatrix4(world);
+                        const float objRadius   = geom->boundingBox->getSize().length() * 0.5f;
+                        const float worldScale  = world.getMaxScaleOnAxis();
+                        const float worldRadius = objRadius * worldScale;
+                        const float distToCenter = camPos.distanceTo(worldCenter);
+
+                        uint8_t selected = 0;// camera-inside-sphere (or degenerate FOV) default: full detail
+                        if (distToCenter > worldRadius && tanHalfFovY > 1e-6f) {
+                            const float dist = distToCenter - worldRadius;
+                            const float pxPerUnit = renderHeightPx / (2.f * tanHalfFovY * dist);
+                            auto projErrorOf = [&](uint8_t lvl) -> float {
+                                if (lvl == 0) return 0.f;
+                                return rec.lodLevels[lvl - 1].errorBound * worldScale * pxPerUnit;
+                            };
+                            // Coarsest level whose projected error still fits under τ=0.75px.
+                            for (uint8_t i = static_cast<uint8_t>(rec.lodLevels.size()); i >= 1; --i) {
+                                if (projErrorOf(i) <= 0.75f) { selected = i; break; }
+                            }
+                            // Hysteresis around the entry's CURRENT level (carried across
+                            // lean frames via lastVisibleEntries_) — prevents a level right
+                            // at the threshold from flip-flopping every frame.
+                            const uint8_t cur = (en.lodLevel <= rec.lodLevels.size()) ? en.lodLevel : uint8_t{0};
+                            uint8_t next = cur;
+                            if (selected > cur && projErrorOf(selected) <= 0.6f) next = selected;
+                            else if (selected < cur && projErrorOf(cur) > 0.75f) next = selected;
+                            selected = next;
+                        }
+
+                        if (selected != en.lodLevel) lodChangedThisFrame_ = true;
+                        en.lodLevel = selected;
+                        ++stats.entriesPerLevel[std::min<uint8_t>(selected, 5)];
+                    }
+                } else {
+                    // Feature off (or just turned off this frame): every
+                    // entry snaps straight back to LOD0. Cheap even on huge
+                    // scenes (one field compare/write per entry) and matters
+                    // for correctness — without it, an entry's level from a
+                    // prior setAutoLod(true) session would persist forever
+                    // (MeshEntry::lodLevel survives across lean frames).
+                    uint32_t nonOverlay = 0;
+                    for (auto& en : entries) {
+                        if (en.isOverlay || en.isParticle) continue;
+                        if (en.lodLevel != 0) lodChangedThisFrame_ = true;
+                        en.lodLevel = 0;
+                        ++nonOverlay;
+                    }
+                    stats.entriesPerLevel[0] = nonOverlay;
+                }
+                autoLodStats_ = stats;
+            }
 
             // Change flags shared by the LEAN in-place diff and the generic
             // compare loop below — exactly one of the two fills them.
@@ -863,6 +1028,23 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                                 break;
                             }
 
+                            // An in-place vertex rewrite invalidates any auto-LOD
+                            // chain: the level BLASes BAKE positions (a stale level
+                            // would ray-trace the pre-edit shape) and the chain's
+                            // error bounds measured the old surface. The device-wide
+                            // drain above makes the destroy safe. lodState=None ⇒
+                            // the selection pass re-enqueues against the new
+                            // geomVersion; selectLodGeom falls back to LOD0 for
+                            // every consumer meanwhile. lodChangedThisFrame_ must be
+                            // forced: selection already ran this frame and may have
+                            // left en.lodLevel > 0 — the EFFECTIVE level changes to
+                            // 0 right here, and without the flag the geomDescs GPU
+                            // patch would skip while the TLAS falls back, leaving a
+                            // stale per-level index address behind.
+                            if (rec.lodState != BlasRecord::LodState::None) {
+                                destroyBlasLodLevels(rec);
+                                lodChangedThisFrame_ = true;
+                            }
                             refreshOps.push_back({entries[i].mesh->geometry().get(), &rec});
                             refreshedGeoms.insert(geomKey);
                         }
@@ -919,7 +1101,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         }
                     }
 
-                    if (!matricesSame || bonesDirtyAny || displacedDirtyAny || grassDirtyAny || tetDirtyAny || geomDirtyAny || morphDirtyAny) {
+                    if (!matricesSame || bonesDirtyAny || displacedDirtyAny || grassDirtyAny || tetDirtyAny || geomDirtyAny || morphDirtyAny || lodChangedThisFrame_) {
                         // TLAS refit: needed when instance transforms change
                         // (matricesSame=false) AND when any skinned BLAS was
                         // just rebuilt — the TLAS's per-instance wrapped AABB
@@ -929,6 +1111,10 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         // BLAS handles + buffer addresses are unchanged so
                         // geomDescs / matDescs stay valid; we just rewrite the
                         // tlasInstancesBuffer in place and call MODE_UPDATE.
+                        // EXCEPT auto-LOD: a level switch DOES change which
+                        // BLAS (and which index buffer) an entry's instance
+                        // references — see the plain-geometry branch below
+                        // and the geomDescsCached_ patch after this loop.
                         std::vector<VkAccelerationStructureInstanceKHR> instances;
                         instances.reserve(entries.size());
                         // instanceCustomIndex == entry index (matches the entries-
@@ -967,7 +1153,18 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                                 const BufferGeometry* geomKey = en.mesh->geometry().get();
                                 auto it = blasCache.find(geomKey);
                                 if (it == blasCache.end()) continue;// shouldn't happen on transform-only
-                                blasAddr = it->second->address;
+                                const auto lodSel = selectLodGeom(*it->second, en.lodLevel);
+                                blasAddr = lodSel.asAddress;
+                                // RT secondary hits (reflections/GI/lidar/probe update)
+                                // read GeometryDesc::indexAddress keyed by gl_PrimitiveID
+                                // from whichever BLAS this instance references — it must
+                                // track the SAME level, or a hit against a coarser BLAS
+                                // misindexes the still-LOD0 index buffer. Patched into the
+                                // buffer itself (vkDeviceWaitIdle-gated) below, only on a
+                                // frame where a level actually changed.
+                                if (i < geomDescsCached_.size()) {
+                                    geomDescsCached_[i].indexAddress = lodSel.indexAddress;
+                                }
                             }
                             VkAccelerationStructureInstanceKHR inst{};
                             const auto& e = en.worldMatrix;
@@ -991,7 +1188,22 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                             inst.accelerationStructureReference = blasAddr;
                             instances.push_back(inst);
                         }
-                        const bool blasDeformed = bonesDirtyAny || displacedDirtyAny || grassDirtyAny || tetDirtyAny || morphDirtyAny || geomDirtyAny;
+                        if (lodChangedThisFrame_ && !geomDescsCached_.empty()) {
+                            // geometryDescsBuffer is a SINGLE buffer (not per-
+                            // frame-in-flight — prior frames' in-flight compute
+                            // may still be reading it), unlike matDescsCached_'s
+                            // per-slot ring. Same drain-then-mutate pattern the
+                            // geomDirtyAny path above already uses for shared
+                            // BLAS buffers. Rare (LOD switches are hysteresis-
+                            // gated), so the stall is acceptable.
+                            check(vkDeviceWaitIdle(ctx->device()), "vkDeviceWaitIdle (pre-geomDescs LOD patch)");
+                            void* mapped = nullptr;
+                            vmaMapMemory(ctx->allocator(), geometryDescsBuffer.alloc, &mapped);
+                            std::memcpy(mapped, geomDescsCached_.data(),
+                                        geomDescsCached_.size() * sizeof(GeometryDesc));
+                            vmaUnmapMemory(ctx->allocator(), geometryDescsBuffer.alloc);
+                        }
+                        const bool blasDeformed = bonesDirtyAny || displacedDirtyAny || grassDirtyAny || tetDirtyAny || morphDirtyAny || geomDirtyAny || lodChangedThisFrame_;
                         // Stage the refit; recordCommandBuffer records it into the
                         // frame cb after the deformable BLAS rebuilds (no drain).
                         pendingTlasInstances_ = std::move(instances);
@@ -1134,6 +1346,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                 for (auto it = blasCache.begin(); it != blasCache.end(); ) {
                     if (it->second->liveCheck.expired()) {
                         auto& rec = it->second;
+                        destroyBlasLodLevels(*rec);
                         if (rec->as) ctx->rt().destroyAccelerationStructure(ctx->device(), rec->as, nullptr);
                         destroyBuffer(ctx->allocator(), rec->storage);
                         destroyBuffer(ctx->allocator(), rec->vertex);
@@ -1373,6 +1586,13 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         const unsigned int curVer = geomVersionOf(*m->geometry());
                         if (it->second->geomVersion != curVer) {
                             auto& old = it->second;
+                            // Topology/positions changed under this geometry
+                            // pointer — any existing LOD chain simplified the
+                            // OLD data and no longer matches. Destroy it; the
+                            // fresh BlasRecord created below starts at
+                            // LodState::None and the selection pass re-
+                            // enqueues a new chain next time it's eligible.
+                            destroyBlasLodLevels(*old);
                             if (old->as) ctx->rt().destroyAccelerationStructure(ctx->device(), old->as, nullptr);
                             destroyBuffer(ctx->allocator(), old->storage);
                             destroyBuffer(ctx->allocator(), old->vertex);
@@ -1420,13 +1640,24 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                 inst.mask = kRayMaskOpaque;// placeholder; set to Opaque/Alpha once md is built below
                 inst.instanceShaderBindingTableRecordOffset = 0;
                 inst.flags = VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR;
-                inst.accelerationStructureReference = recPtr->address;
+                // en.lodLevel==0 for every deformer/exempt entry (auto-LOD
+                // selection above only ever sets it on plain cached
+                // geometry), so this passthrough is a no-op for them —
+                // recPtr may point at a SkinnedMeshState/DisplacedMeshState/
+                // etc.'s own BlasRecord, which selectLodGeom treats
+                // identically to a LOD0 blasCache record.
+                const auto lodSel = selectLodGeom(*recPtr, en.lodLevel);
+                inst.accelerationStructureReference = lodSel.asAddress;
                 instances.push_back(inst);
 
                 GeometryDesc gdesc{};
                 gdesc.vertexAddress = recPtr->vertex.address;
                 gdesc.normalAddress = recPtr->normal.address;
-                gdesc.indexAddress  = recPtr->index.address;
+                // Must reference the SAME index buffer the selected BLAS
+                // level was built from — RT secondary hits (reflections/GI/
+                // lidar/probe update) read this keyed by gl_PrimitiveID,
+                // which only lines up against that exact index array.
+                gdesc.indexAddress  = lodSel.indexAddress;
                 gdesc.uvAddress     = recPtr->uv.address;// 0 if no UV attribute
                 gdesc.foamAddress   = recPtr->isOceanSurface ? 1ull : 0ull;// 0/1 flag (not an address); 1 == FFT-displaced ocean surface
                 // prevVertexAddress: skinned + displaced meshes have a real
@@ -1522,6 +1753,13 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
 
             buildTlas(instances);
             uploadDescBuffer(geometryDescsBuffer, geomDescs);
+            // Host mirror for the lean-path auto-LOD patch above. geomDescs
+            // just built already reflects each entry's CURRENT en.lodLevel
+            // (the selection pass runs before this heavy rebuild, so an
+            // entry whose geometry/BLAS wasn't touched by this particular
+            // rebuild can still carry a >0 level from before) — this is
+            // just the persistent copy the lean path patches in place.
+            geomDescsCached_ = geomDescs;
             // Seed every per-frame slot with the fresh matDescs so the first
             // few frames don't try to flush against a half-initialised ring.
             // matDescsCached_ stays in sync as the host-side authoritative

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -104,6 +104,18 @@ void VulkanRendererCore::CoreImpl::flushMaterialDescsIfDirty(uint32_t frame) {
             vmaUnmapMemory(ctx->allocator(), materialDescsBuffers[frame].alloc);
         }
 
+void VulkanRendererCore::CoreImpl::flushGeometryDescsIfDirty(uint32_t frame) {
+            if (!geomDescsDirty_[frame]) return;
+            geomDescsDirty_[frame] = false;
+            if (geomDescsCached_.empty()) return;
+            if (geometryDescsBuffers[frame].handle == VK_NULL_HANDLE) return;
+            void* mapped = nullptr;
+            vmaMapMemory(ctx->allocator(), geometryDescsBuffers[frame].alloc, &mapped);
+            std::memcpy(mapped, geomDescsCached_.data(),
+                        geomDescsCached_.size() * sizeof(GeometryDesc));
+            vmaUnmapMemory(ctx->allocator(), geometryDescsBuffers[frame].alloc);
+        }
+
 void VulkanRendererCore::CoreImpl::cullEntriesAgainstFrustum(Camera& camera) {
             if (lastVisibleEntries_.empty()) return;
             // Combine projection * matrixWorldInverse to extract the world-
@@ -1248,19 +1260,16 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                             instances.push_back(inst);
                         }
                         if (lodChangedThisFrame_ && !geomDescsCached_.empty()) {
-                            // geometryDescsBuffer is a SINGLE buffer (not per-
-                            // frame-in-flight — prior frames' in-flight compute
-                            // may still be reading it), unlike matDescsCached_'s
-                            // per-slot ring. Same drain-then-mutate pattern the
-                            // geomDirtyAny path above already uses for shared
-                            // BLAS buffers. Rare (LOD switches are hysteresis-
-                            // gated), so the stall is acceptable.
-                            check(vkDeviceWaitIdle(ctx->device()), "vkDeviceWaitIdle (pre-geomDescs LOD patch)");
-                            void* mapped = nullptr;
-                            vmaMapMemory(ctx->allocator(), geometryDescsBuffer.alloc, &mapped);
-                            std::memcpy(mapped, geomDescsCached_.data(),
-                                        geomDescsCached_.size() * sizeof(GeometryDesc));
-                            vmaUnmapMemory(ctx->allocator(), geometryDescsBuffer.alloc);
+                            // geomDescsCached_ was patched in place above; the
+                            // per-frame-in-flight ring carries it to the GPU
+                            // stall-free — renderFrame flushes THIS frame's
+                            // slot right after its fence signals (before any
+                            // recording that consumes it), the other slot when
+                            // its frame comes around. Same model as matDescs;
+                            // this replaced a vkDeviceWaitIdle per switch
+                            // frame, which hitched exactly when the camera
+                            // was moving.
+                            for (auto& d : geomDescsDirty_) d = true;
                         }
                         const bool blasDeformed = bonesDirtyAny || displacedDirtyAny || grassDirtyAny || tetDirtyAny || morphDirtyAny || geomDirtyAny || lodChangedThisFrame_;
                         // Stage the refit; recordCommandBuffer records it into the
@@ -1389,13 +1398,15 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                 }
                 destroyBuffer(ctx->allocator(), tlasBuffer);
                 for (auto& b : tlasInstancesBuffers) { destroyBuffer(ctx->allocator(), b); b = {}; }
-                destroyBuffer(ctx->allocator(), geometryDescsBuffer);
+                for (auto& b : geometryDescsBuffers) {
+                    destroyBuffer(ctx->allocator(), b);
+                    b = {};
+                }
                 for (auto& b : materialDescsBuffers) {
                     destroyBuffer(ctx->allocator(), b);
                     b = {};
                 }
                 tlasBuffer = {};
-                geometryDescsBuffer = {};
 
                 // Prune stale cache entries whose underlying objects have been
                 // destroyed (typical on model swap). Keeping them risks an
@@ -1813,7 +1824,14 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
             }
 
             buildTlas(instances);
-            uploadDescBuffer(geometryDescsBuffer, geomDescs);
+            // Every per-frame GeometryDesc slot seeded fresh — same ring
+            // model as the matDescs loop below; the lean auto-LOD patch
+            // flips geomDescsDirty_ and flushGeometryDescsIfDirty carries
+            // deltas per slot from then on.
+            for (uint32_t f = 0; f < kFramesInFlight; ++f) {
+                uploadDescBuffer(geometryDescsBuffers[f], geomDescs);
+            }
+            for (auto& d : geomDescsDirty_) d = false;
             // Host mirror for the lean-path auto-LOD patch above. geomDescs
             // just built already reflects each entry's CURRENT en.lodLevel
             // (the selection pass runs before this heavy rebuild, so an

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -20,7 +20,7 @@ uint32_t VulkanRendererCore::CoreImpl::snapMeshFlags(Mesh& m, const MaterialWith
             return fl;
         }
 
-bool VulkanRendererCore::CoreImpl::sceneSnapshotMatches(Object3D& scene) {
+bool VulkanRendererCore::CoreImpl::sceneSnapshotMatches(Object3D& scene, Camera& camera) {
             if (!sceneBuilt_ || sceneSnapshot_.empty()) return false;
             if (prevSceneFingerprint.size() != lastVisibleEntries_.size()) return false;
             size_t cur = 0;
@@ -33,7 +33,16 @@ bool VulkanRendererCore::CoreImpl::sceneSnapshotMatches(Object3D& scene) {
                 }
                 const SnapNode& sn = sceneSnapshot_[cur++];
                 const uint32_t kind = sn.flags & kSnapKindMask;
-                if (kind == kSnapKindOther) return;// pointer identity is all we need
+                if (kind == kSnapKindOther) {
+                    // LOD parity (see the full pass): re-run level selection
+                    // every frame. Pre-order walk ⇒ the mutation lands before
+                    // this LOD's children are visited, so a level switch makes
+                    // the node sequence diverge from the snapshot at the
+                    // swapped subtree ⇒ ok=false ⇒ full re-expansion picks up
+                    // the new level's meshes.
+                    if ((sn.flags & kSnapLod) != 0u && sn.lod->autoUpdate) sn.lod->update(camera);
+                    return;// otherwise pointer identity is all we need
+                }
                 // Same object at the same address ⇒ same dynamic type — the
                 // typed pointers recorded by the full pass are still valid, so
                 // the walk pays zero dynamic_casts. attributesVersion()
@@ -125,13 +134,18 @@ void VulkanRendererCore::CoreImpl::cullEntriesAgainstFrustum(Camera& camera) {
             }
         }
 
-void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene) {
+void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& camera) {
             // force=false (matching GLRenderer/WgpuRenderer): with
             // updateMatrix()'s change-detection early-out, only subtrees whose
             // transforms actually moved pay the world-matrix multiplies — a
             // forced pass re-multiplied every node every frame (several
             // ms/frame on Bistro's node count, static or not).
             scene.updateMatrixWorld();
+            // A parentless camera (the common case — not add()ed to the scene)
+            // is untouched by the scene's updateMatrixWorld, but the LOD level
+            // selection below reads camera.matrixWorld. Same guard as
+            // GLRenderer::render; change-detected early-out ⇒ ~free.
+            if (!camera.parent) camera.updateMatrixWorld();
 
             // Honour live edits to already-uploaded material textures (e.g. a
             // DataTexture re-baked via setData + needsUpdate). Cheap version
@@ -150,7 +164,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene) {
             // caught: matrices by the memcmp diff, material/geometry edits by
             // their version reads, structure/visibility/texture-routing
             // changes by the snapshot walk itself (mismatch ⇒ full path).
-            const bool snapLean = sceneSnapshotMatches(scene);
+            const bool snapLean = sceneSnapshotMatches(scene, camera);
             std::vector<MeshEntry>& entries = lastVisibleEntries_;// canonical list, cached across frames
             std::vector<MeshFingerprint> currFp;
             if (snapLean) {
@@ -185,6 +199,21 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene) {
             scene.traverseVisible([&](Object3D& o) {
                 SnapNode sn{};
                 sn.obj = &o;
+                // three.js parity — LOD level selection (GLRenderer::
+                // projectObject runs lod.update(camera) as it projects).
+                // traverseVisible is PRE-ORDER: this LOD's children are
+                // visited after this callback, so the rest of this walk
+                // already sees the level picked for this frame's camera.
+                // Recorded with a typed view + kSnapLod so the replay walk
+                // re-runs the selection cast-free (Object3D is a virtual
+                // base — the replay cannot static_cast down).
+                if (auto* lod = dynamic_cast<LOD*>(&o)) {
+                    if (lod->autoUpdate) lod->update(camera);
+                    sn.lod   = lod;
+                    sn.flags = kSnapKindOther | kSnapLod;
+                    sceneSnapshot_.push_back(sn);
+                    return;
+                }
                 // Line / LineSegments: never part of the traced/rasterized
                 // scene, always overlay.
                 // Collected before the Mesh dispatch so subclasses don't

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -440,8 +440,8 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         }
 
                         auto geom = m->geometry();
-                        if (!geom || !geom->getIndex()) {
-                            en.lodLevel = 0;// unindexed geometry — LOD needs an index buffer to swap
+                        if (!geom) {
+                            en.lodLevel = 0;
                             ++stats.entriesPerLevel[0];
                             continue;
                         }
@@ -453,12 +453,23 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         }
                         BlasRecord& rec = *blasIt->second;
 
-                        const uint32_t triCount = rec.indexCount / 3u;
-                        const bool eligible = triCount >= 4096u;
+                        // NON-indexed soup (FBX-style loaders never call
+                        // setIndex) is eligible too: the chain generator welds
+                        // it into canonical indices, and the levels drive
+                        // INDEXED draws against the unchanged soup vertex
+                        // buffer (selectLodGeom reports the indexed-ness).
+                        const uint32_t triCount =
+                                (rec.indexCount != 0u ? rec.indexCount : rec.vertexCount) / 3u;
+                        const bool eligible = triCount >= 1024u;
                         if (eligible && rec.lodState == BlasRecord::LodState::None) {
                             if ((lodIndexBytes_ + lodBlasBytes_) <= kLodByteBudget) {
-                                enqueueLodJob(geom.get(), rec.geomVersion, *geom);
-                                rec.lodState = BlasRecord::LodState::Queued;
+                                // Failed enqueue (no position attribute — can't
+                                // happen for a live BlasRecord, but be defensive)
+                                // marks Failed, not Queued: no result is coming,
+                                // so Queued would strand the record forever.
+                                rec.lodState = enqueueLodJob(geom.get(), rec.geomVersion, *geom)
+                                        ? BlasRecord::LodState::Queued
+                                        : BlasRecord::LodState::Failed;
                             } else if (!lodBudgetWarned_) {
                                 std::cerr << "[VulkanRenderer] auto-LOD: 256 MiB byte budget reached — "
                                              "no further chains will be generated this session\n";
@@ -1159,11 +1170,14 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                                 // read GeometryDesc::indexAddress keyed by gl_PrimitiveID
                                 // from whichever BLAS this instance references — it must
                                 // track the SAME level, or a hit against a coarser BLAS
-                                // misindexes the still-LOD0 index buffer. Patched into the
-                                // buffer itself (vkDeviceWaitIdle-gated) below, only on a
-                                // frame where a level actually changed.
+                                // misindexes the still-LOD0 index buffer. `indexed` rides
+                                // along: a level of a non-indexed soup record IS an
+                                // indexed fetch. Patched into the buffer itself
+                                // (vkDeviceWaitIdle-gated) below, only on a frame where a
+                                // level actually changed.
                                 if (i < geomDescsCached_.size()) {
                                     geomDescsCached_[i].indexAddress = lodSel.indexAddress;
+                                    geomDescsCached_[i].indexed = lodSel.indexed ? 1u : 0u;
                                 }
                             }
                             VkAccelerationStructureInstanceKHR inst{};
@@ -1680,7 +1694,9 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         (recPtr->prevVertex.handle != VK_NULL_HANDLE && !warpReproject)
                                 ? recPtr->prevVertex.address
                                 : recPtr->vertex.address;
-                gdesc.indexed = recPtr->index.handle != VK_NULL_HANDLE ? 1u : 0u;
+                // Per SELECTION, not per record: a level of a non-indexed
+                // soup record IS indexed (welded canonical indices).
+                gdesc.indexed = lodSel.indexed ? 1u : 0u;
                 // Per-vertex color only when the material opts in (three.js
                 // semantics: vertexColors == true) AND the geometry uploaded a
                 // color buffer. 0 otherwise → chit skips the modulation.

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -207,7 +207,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
             // Rebuilt below as the walk visits each threepp::LOD node — a
             // mesh entry whose parent chain hits one of these is exempt from
             // auto-LOD (see the selection pass just after this expansion).
-            manualLodRoots_.clear();
+            manualLodLevelRoots_.clear();
             // traverseVisible (not traverse) so an invisible parent hides its
             // whole subtree — matches three.js / GLRenderer convention. Plain
             // `traverse` walks every node regardless of visibility, leaking
@@ -231,7 +231,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                     // Auto-LOD exemption: every level object under a manual
                     // LOD node is author-selected already; don't let auto-LOD
                     // swap index buffers underneath that choice.
-                    for (Object3D* child : lod->children) manualLodRoots_.insert(child);
+                    for (Object3D* child : lod->children) manualLodLevelRoots_.insert(child);
                     return;
                 }
                 // Line / LineSegments: never part of the traced/rasterized
@@ -349,13 +349,13 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                                    m->material() && m->material()->tetSkinning &&
                                    m->material()->tetTexture != nullptr;
                 // Auto-LOD selection caches — once per Mesh, shared by every
-                // instance entry (see the MeshEntry field doc). manualLodRoots_
+                // instance entry (see the MeshEntry field doc). manualLodLevelRoots_
                 // is complete for this mesh's ancestors: traverseVisible is
                 // pre-order, so an enclosing LOD node registered its level
                 // objects before we got here.
                 bool lodExempt = !m->autoLod;// per-object opt-out (self-managed LOD, e.g. terrain tiles)
                 for (Object3D* p = m->parent; !lodExempt && p; p = p->parent) {
-                    if (manualLodRoots_.count(p)) lodExempt = true;
+                    if (manualLodLevelRoots_.count(p)) lodExempt = true;
                 }
                 const MaterialWithEmissive* lodEmissive = nullptr;
                 if (auto mat = m->material()) {
@@ -419,7 +419,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
             probeGridDirty_     = true;// scene structure changed → re-fit the probe grid
             }// !snapLean
 
-            // ── Automatic mesh LOD selection (setAutoLod; default off) ──────
+            // ── Automatic mesh LOD selection (setAutoLod; ON by default) ────
             // Runs UNCONDITIONALLY every frame — camera motion alone can flip
             // a level even when nothing else about the scene changed — right
             // after entries got fresh world matrices from WHICHEVER path
@@ -445,6 +445,13 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                     auto* persp = dynamic_cast<PerspectiveCamera*>(&camera);
                     Vector3 camPos;
                     if (persp) camPos.setFromMatrixPosition(*camera.matrixWorld);
+                    // renderExtent() is the INTERNAL (render-scale-applied)
+                    // resolution the G-buffer rasterizes at — τ below is in
+                    // G-buffer pixels, i.e. the resolution the geometric error
+                    // is actually sampled at. (Post-TAA upscale can stretch a
+                    // render pixel to ~1.3 display pixels at scale 0.75; the
+                    // fjord/harness visual gates validated the threshold at
+                    // that operating point.)
                     const float renderHeightPx = static_cast<float>(renderExtent().height);
                     const float tanHalfFovY = persp
                             ? std::tan(math::degToRad(persp->getEffectiveFOV()) * 0.5f)

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -336,6 +336,35 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                 const bool isTet = !isSkinned && !isDisplaced && !isGrass && !isMorphed &&
                                    m->material() && m->material()->tetSkinning &&
                                    m->material()->tetTexture != nullptr;
+                // Auto-LOD selection caches — once per Mesh, shared by every
+                // instance entry (see the MeshEntry field doc). manualLodRoots_
+                // is complete for this mesh's ancestors: traverseVisible is
+                // pre-order, so an enclosing LOD node registered its level
+                // objects before we got here.
+                bool lodUnderManual = false;
+                for (Object3D* p = m->parent; p; p = p->parent) {
+                    if (manualLodRoots_.count(p)) { lodUnderManual = true; break; }
+                }
+                const MaterialWithEmissive* lodEmissive = nullptr;
+                if (auto mat = m->material()) {
+                    lodEmissive = dynamic_cast<MaterialWithEmissive*>(mat.get());
+                }
+                if (!geom->boundingBox) geom->computeBoundingBox();
+                Vector3 lodCenter;
+                float lodRadius = 0.f;
+                if (geom->boundingBox) {
+                    lodCenter = geom->boundingBox->getCenter();
+                    lodRadius = geom->boundingBox->getSize().length() * 0.5f;
+                }
+                auto setLodCaches = [&](MeshEntry& e) {
+                    e.lodUnderManualLod = lodUnderManual;
+                    e.lodEmissive       = lodEmissive;
+                    e.lodGeomKey        = geom.get();
+                    e.lodCenter[0]      = lodCenter.x;
+                    e.lodCenter[1]      = lodCenter.y;
+                    e.lodCenter[2]      = lodCenter.z;
+                    e.lodRadius         = lodRadius;
+                };
                 if (inst && inst->count() > 0) {
                     Matrix4 instMat;
                     Matrix4 world;
@@ -353,6 +382,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         e.isMorphed    = isMorphed;
                         e.isTet        = isTet;
                         e.isInstanced  = true;
+                        setLodCaches(e);
                         std::memcpy(e.worldMatrix.data(), world.elements.data(), 64);
                         built.push_back(e);
                     }
@@ -367,6 +397,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                     e.isGrass      = isGrass;
                     e.isMorphed    = isMorphed;
                     e.isTet        = isTet;
+                    setLodCaches(e);
                     std::memcpy(e.worldMatrix.data(), m->matrixWorld->elements.data(), 64);
                     built.push_back(e);
                 }
@@ -395,6 +426,10 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                 stats.chainsReady  = lodChainsReadyCount_;
                 stats.chainsQueued = lodChainsQueuedCount_;
                 if (autoLod_) {
+                    // Hot path by design: everything type- or structure-derived
+                    // was cached on the entry at expansion (see MeshEntry doc) —
+                    // this loop is float math + one blasCache hash per entry.
+                    // The uncached version cost 2-4 ms/frame at 4k entries.
                     auto* persp = dynamic_cast<PerspectiveCamera*>(&camera);
                     Vector3 camPos;
                     if (persp) camPos.setFromMatrixPosition(*camera.matrixWorld);
@@ -405,47 +440,32 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
 
                     for (auto& en : entries) {
                         if (en.isOverlay || en.isParticle) continue;// not scene geometry — no LOD concept
-                        if (en.isSkinned || en.isDisplaced || en.isGrass || en.isMorphed || en.isTet) {
-                            en.lodLevel = 0;// deformers: local AABB is stale, never simplify
-                            ++stats.entriesPerLevel[0];
-                            continue;
-                        }
-                        if (!persp) {
-                            en.lodLevel = 0;// non-perspective camera reached here — be defensive
-                            ++stats.entriesPerLevel[0];
-                            continue;
-                        }
-                        Mesh* m = en.mesh;
-                        bool underManualLod = false;
-                        for (Object3D* p = m->parent; p; p = p->parent) {
-                            if (manualLodRoots_.count(p)) { underManualLod = true; break; }
-                        }
-                        if (underManualLod) {
-                            en.lodLevel = 0;// author already picked discrete levels here
-                            ++stats.entriesPerLevel[0];
-                            continue;
-                        }
-                        if (auto matSp = m->material()) {
-                            if (auto* em = dynamic_cast<MaterialWithEmissive*>(matSp.get())) {
-                                const bool nonBlack = em->emissive.r > 0.f || em->emissive.g > 0.f || em->emissive.b > 0.f;
-                                if (nonBlack || em->emissiveMap) {
-                                    // Emissive NEE's per-tri CDF (buildAndUploadEmissiveTris)
-                                    // caches world-space triangle positions and would not
-                                    // notice a silent index-buffer swap underneath it.
-                                    en.lodLevel = 0;
-                                    ++stats.entriesPerLevel[0];
-                                    continue;
-                                }
-                            }
-                        }
-
-                        auto geom = m->geometry();
-                        if (!geom) {
+                        // Deformers (stale local AABB), authored manual-LOD
+                        // subtrees, and non-perspective cameras (SSE needs a
+                        // pinhole model): full detail.
+                        if (en.isSkinned || en.isDisplaced || en.isGrass || en.isMorphed || en.isTet ||
+                            en.lodUnderManualLod || !persp) {
+                            if (en.lodLevel != 0) lodChangedThisFrame_ = true;
                             en.lodLevel = 0;
                             ++stats.entriesPerLevel[0];
                             continue;
                         }
-                        auto blasIt = blasCache.find(geom.get());
+                        // Emissive VALUES read live off the expansion-cached
+                        // cast — NEE's per-tri CDF (buildAndUploadEmissiveTris)
+                        // caches world-space triangles and would not notice a
+                        // silent index-buffer swap underneath it. Live values
+                        // (not a cached verdict) so a lantern whose intensity
+                        // ramps up at dusk exempts the moment it turns on.
+                        if (en.lodEmissive &&
+                            (en.lodEmissive->emissive.r > 0.f || en.lodEmissive->emissive.g > 0.f ||
+                             en.lodEmissive->emissive.b > 0.f || en.lodEmissive->emissiveMap)) {
+                            if (en.lodLevel != 0) lodChangedThisFrame_ = true;
+                            en.lodLevel = 0;
+                            ++stats.entriesPerLevel[0];
+                            continue;
+                        }
+
+                        auto blasIt = blasCache.find(en.lodGeomKey);
                         if (blasIt == blasCache.end()) {
                             en.lodLevel = 0;// brand-new geometry this frame — no LOD0 record to chain off yet
                             ++stats.entriesPerLevel[0];
@@ -463,11 +483,14 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                         const bool eligible = triCount >= 1024u;
                         if (eligible && rec.lodState == BlasRecord::LodState::None) {
                             if ((lodIndexBytes_ + lodBlasBytes_) <= kLodByteBudget) {
-                                // Failed enqueue (no position attribute — can't
-                                // happen for a live BlasRecord, but be defensive)
+                                // The enqueue snapshots attribute data, so it needs
+                                // the live geometry — the ONLY shared_ptr deref
+                                // left in this loop, paid once per geometry
+                                // lifetime. Failed enqueue (no position attribute)
                                 // marks Failed, not Queued: no result is coming,
                                 // so Queued would strand the record forever.
-                                rec.lodState = enqueueLodJob(geom.get(), rec.geomVersion, *geom)
+                                auto geomSp = en.mesh->geometry();
+                                rec.lodState = (geomSp && enqueueLodJob(en.lodGeomKey, rec.geomVersion, *geomSp))
                                         ? BlasRecord::LodState::Queued
                                         : BlasRecord::LodState::Failed;
                             } else if (!lodBudgetWarned_) {
@@ -483,21 +506,41 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                             continue;
                         }
 
-                        if (!geom->boundingBox) geom->computeBoundingBox();
-                        if (!geom->boundingBox) {
-                            en.lodLevel = 0;
+                        // Re-derive the cached object-space sphere after an
+                        // in-place geometry edit (flagged by the geom-dirty
+                        // detection; boundingBox was invalidated there too).
+                        if (en.lodSphereDirty) {
+                            en.lodSphereDirty = false;
+                            if (auto g = en.mesh->geometry()) {
+                                if (!g->boundingBox) g->computeBoundingBox();
+                                if (g->boundingBox) {
+                                    const Vector3 c = g->boundingBox->getCenter();
+                                    en.lodCenter[0] = c.x;
+                                    en.lodCenter[1] = c.y;
+                                    en.lodCenter[2] = c.z;
+                                    en.lodRadius = g->boundingBox->getSize().length() * 0.5f;
+                                }
+                            }
+                        }
+                        if (en.lodRadius <= 0.f) {
+                            en.lodLevel = 0;// unknown bounds — stay at full detail
                             ++stats.entriesPerLevel[0];
                             continue;
                         }
 
-                        Matrix4 world;
-                        std::memcpy(world.elements.data(), en.worldMatrix.data(), 64);
-                        Vector3 worldCenter = geom->boundingBox->getCenter();
-                        worldCenter.applyMatrix4(world);
-                        const float objRadius   = geom->boundingBox->getSize().length() * 0.5f;
-                        const float worldScale  = world.getMaxScaleOnAxis();
-                        const float worldRadius = objRadius * worldScale;
-                        const float distToCenter = camPos.distanceTo(worldCenter);
+                        // World bounding sphere straight off the entry's
+                        // column-major world matrix — no Matrix4 round-trip.
+                        const float* M = en.worldMatrix.data();
+                        const float cx = M[0] * en.lodCenter[0] + M[4] * en.lodCenter[1] + M[8] * en.lodCenter[2] + M[12];
+                        const float cy = M[1] * en.lodCenter[0] + M[5] * en.lodCenter[1] + M[9] * en.lodCenter[2] + M[13];
+                        const float cz = M[2] * en.lodCenter[0] + M[6] * en.lodCenter[1] + M[10] * en.lodCenter[2] + M[14];
+                        const float s0 = M[0] * M[0] + M[1] * M[1] + M[2] * M[2];
+                        const float s1 = M[4] * M[4] + M[5] * M[5] + M[6] * M[6];
+                        const float s2 = M[8] * M[8] + M[9] * M[9] + M[10] * M[10];
+                        const float worldScale = std::sqrt(std::max(s0, std::max(s1, s2)));
+                        const float worldRadius = en.lodRadius * worldScale;
+                        const float dx = camPos.x - cx, dy = camPos.y - cy, dz = camPos.z - cz;
+                        const float distToCenter = std::sqrt(dx * dx + dy * dy + dz * dz);
 
                         uint8_t selected = 0;// camera-inside-sphere (or degenerate FOV) default: full detail
                         if (distToCenter > worldRadius && tanHalfFovY > 1e-6f) {
@@ -639,6 +682,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                             entryGeomDirty[i] = true;
                             // boundingBox invalidation — mirrors the generic loop.
                             if (auto gg = en.mesh->geometry()) gg->boundingBox.reset();
+                            entries[i].lodSphereDirty = true;// auto-LOD's cached sphere follows
                         }
                     }
                     if (xfmChanged) {
@@ -887,6 +931,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                     if (geomChanged && !entries[i].isParticle) {
                         geomDirtyAny = true;
                         entryGeomDirty[i] = true;
+                        entries[i].lodSphereDirty = true;// auto-LOD's cached sphere follows
                         // Invalidate the cached boundingBox so the next
                         // cullEntriesAgainstFrustum recomputes it from the
                         // current positions. Without this, plain meshes with

--- a/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreScene.cpp
@@ -353,9 +353,9 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                 // is complete for this mesh's ancestors: traverseVisible is
                 // pre-order, so an enclosing LOD node registered its level
                 // objects before we got here.
-                bool lodUnderManual = false;
-                for (Object3D* p = m->parent; p; p = p->parent) {
-                    if (manualLodRoots_.count(p)) { lodUnderManual = true; break; }
+                bool lodExempt = !m->autoLod;// per-object opt-out (self-managed LOD, e.g. terrain tiles)
+                for (Object3D* p = m->parent; !lodExempt && p; p = p->parent) {
+                    if (manualLodRoots_.count(p)) lodExempt = true;
                 }
                 const MaterialWithEmissive* lodEmissive = nullptr;
                 if (auto mat = m->material()) {
@@ -369,7 +369,7 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
                     lodRadius = geom->boundingBox->getSize().length() * 0.5f;
                 }
                 auto setLodCaches = [&](MeshEntry& e) {
-                    e.lodUnderManualLod = lodUnderManual;
+                    e.lodExemptStatic = lodExempt;
                     e.lodEmissive       = lodEmissive;
                     e.lodGeomKey        = geom.get();
                     e.lodCenter[0]      = lodCenter.x;
@@ -452,11 +452,13 @@ void VulkanRendererCore::CoreImpl::ensureSceneBuilt(Object3D& scene, Camera& cam
 
                     for (auto& en : entries) {
                         if (en.isOverlay || en.isParticle) continue;// not scene geometry — no LOD concept
-                        // Deformers (stale local AABB), authored manual-LOD
-                        // subtrees, and non-perspective cameras (SSE needs a
-                        // pinhole model): full detail.
+                        // Deformers (stale local AABB), opted-out meshes
+                        // (Object3D::autoLod == false — self-managed LOD like
+                        // terrain tiles), authored manual-LOD subtrees, and
+                        // non-perspective cameras (SSE needs a pinhole model):
+                        // full detail.
                         if (en.isSkinned || en.isDisplaced || en.isGrass || en.isMorphed || en.isTet ||
-                            en.lodUnderManualLod || !persp) {
+                            en.lodExemptStatic || !persp) {
                             if (en.lodLevel != 0) lodChangedThisFrame_ = true;
                             en.lodLevel = 0;
                             ++stats.entriesPerLevel[0];

--- a/src/threepp/renderers/vulkan/shaders/deferred_denoise.comp
+++ b/src/threepp/renderers/vulkan/shaders/deferred_denoise.comp
@@ -1,5 +1,8 @@
 #version 460
 #extension GL_EXT_scalar_block_layout : require
+#extension GL_GOOGLE_include_directive : enable
+
+#include "instance_flags.glsl"// per-instance flag accessors
 
 // SVGF variance-guided MULTI-PASS à-trous wavelet denoiser for the RasterFirst
 // deferred GI. Dispatched as N passes with WIDENING step (1,2,4,8): each pass is a
@@ -364,7 +367,7 @@ void main() {
     // so neighbouring texels of one cutout card can carry OPPOSITE normals —
     // a signed pow-48 stop then refuses the card's own neighbours and the
     // 1-spp GI noise survives unfiltered. ±N is the same surface there.
-    const bool dsided = (texelFetch(gbufIdsTex, px, 0).z & 16u) != 0u;
+    const bool dsided = ifDoubleSided(texelFetch(gbufIdsTex, px, 0).z);
 
     vec4  cC   = readSrc(px);
     float lumC = dot(cC.rgb, LUMA);

--- a/src/threepp/renderers/vulkan/shaders/deferred_shade.comp
+++ b/src/threepp/renderers/vulkan/shaders/deferred_shade.comp
@@ -13,7 +13,8 @@
 // material diversity). Requires shaderSampledImageArrayNonUniformIndexing.
 #extension GL_EXT_nonuniform_qualifier : require
 
-#include "vulkan_shared.h"// MaterialDesc
+#include "vulkan_shared.h"  // MaterialDesc
+#include "instance_flags.glsl"// per-instance flag accessors + reactivity channels
 
 // Raster-first deferred shading. Shades the material G-buffer
 // from the raster prepass into a clean, analytic base + adds ray-traced
@@ -1116,7 +1117,7 @@ void main() {
             // surface for irradiance-history purposes, so compare
             // orientation-agnostically. Single-sided geometry keeps the
             // signed test (a wall's two faces ARE different surfaces).
-            const bool dsided = (giFlagsZ & 16u) != 0u;
+            const bool dsided = ifDoubleSided(giFlagsZ);
             bool found = false;
             for (int dy = -1; dy <= 1; ++dy) {
                 for (int dx = -1; dx <= 1; ++dx) {
@@ -1178,7 +1179,8 @@ void main() {
         // camera world flow so it tracks. Collapses to length(motionGL) when the
         // camera is still.
         const float giCamNdc = pc.camRot * 1.7 + 1.7 * pc.camDelta / max(length(worldPos - camPos), 0.25);
-        // PERSISTENT DEFORMER (flags bit 5 — tet-skinned soft bodies): the
+        // IRRADIANCE-REACTIVE content (sources + channel semantics:
+        // instance_flags.glsl — today: persistent per-frame deformers): the
         // surface deforms EVERY frame, so |motionGL| swings across the
         // smoothstep window with the wobble and the motion-scaled cap
         // oscillates with it — dragging the blend alpha, the despeckle gate
@@ -1190,10 +1192,10 @@ void main() {
         // deforming 1-spp surface sheds isolated GI sparks every frame and
         // NEEDS it (pinning at 10 disabled it: visible white speckle on soft
         // bodies) — while staying above the spatial variance fallback (4).
-        const bool  giDeformer = (giFlagsZ & 32u) != 0u;
-        const float capF = giDeformer
-                ? 6.0
-                : mix(48.0, 6.0, smoothstep(0.002, 0.03, max(length(motionGL), giCamNdc)));
+        // mix() on the [0..1] reactivity: exact motion-scaled cap at 0; at 1
+        // the pin may sit an ULP off 6.0 — both gates have miles of margin.
+        const float capF = mix(mix(48.0, 6.0, smoothstep(0.002, 0.03, max(length(motionGL), giCamNdc))),
+                               6.0, ifIrradianceReactivity(giFlagsZ));
         // Skip frames carry the history UNCHANGED (no new sample → no histLen
         // increment, no blend); trace frames accumulate as before.
         const float histLen = giSkip ? max(prevT.a, 1.0)
@@ -1279,7 +1281,7 @@ void main() {
                 // Re-derive dsided locally — the GI 3×3 pass above scopes its own
                 // copy inside its `if (valid)` block; giFlagsZ (the source flag) is
                 // still in scope here so this is the same bit test, not a new heuristic.
-                const bool  dsided  = (giFlagsZ & 16u) != 0u;
+                const bool  dsided  = ifDoubleSided(giFlagsZ);
                 const float surfD   = texture(gbufMotionTex, uv).b;// this surface's prev NDC depth (shared by all 4 taps)
                 const vec4  svh     = cam.projInverse * vec4(prevNDC, surfD, 1.0);
                 const float svz     = svh.z / svh.w;

--- a/src/threepp/renderers/vulkan/shaders/gbuffer.frag
+++ b/src/threepp/renderers/vulkan/shaders/gbuffer.frag
@@ -73,9 +73,9 @@ layout(location = 1) out vec4 outMotion;
 //   .y = STABLE per-object instance id (host-assigned, persists across frames
 //        and visible-set changes; 0 = sky). The recoverable label for
 //        instance segmentation — see VulkanRendererCore::setObjectInstanceId.
-//   .z = flags in bits 0..7 (bit 0 is_water, bit 1 transmissive, bit 2
-//        thinWalled, bit 3 skinned, bit 4 double, bit 5 deformer, bit 6
-//        tex-anim) | semantic CLASS id in bits 8..15 (0 = unset). Consumers
+//   .z = per-instance flags in bits 0..7 | semantic CLASS id in bits 8..15
+//        (0 = unset). Canonical bit layout: vulkan_shared.h (kInstFlag*);
+//        shader consumers use the instance_flags.glsl accessors. Consumers
 //        bit-test the low byte, so the class byte is inert to them; the MSAA
 //        resolve carries the dominant sample's .z through unchanged.
 //   .w = reserved (repacked with MSAA coverage metadata by gbuf_resolve.comp)

--- a/src/threepp/renderers/vulkan/shaders/instance_flags.glsl
+++ b/src/threepp/renderers/vulkan/shaders/instance_flags.glsl
@@ -1,0 +1,50 @@
+// Accessors for the per-instance flag word (gbuffer IDs .z — bit layout in
+// vulkan_shared.h). Consumers ask for MEANING, not bit positions, so a new
+// source of an existing meaning (a new flag, a material hint) touches only
+// this file.
+//
+// TEMPORAL REACTIVITY — the consolidated "how little should temporal
+// accumulation trust history on this surface" signal. Two channels, because
+// shading and irradiance decorrelate from motion vectors differently:
+//
+//   ifShadingReactivity — the shaded APPEARANCE changes every frame in a way
+//     motion vectors cannot express: a persistent deformer's normals /
+//     stretch / contact shadowing swing in place (near-zero screen motion,
+//     full shading change), and animated textures move their pattern with
+//     ZERO geometric motion. The TAA resolve floors its blend α toward the
+//     current frame on this signal. Scoping the deformer term to persistent
+//     deformers rather than all skinned meshes is deliberate: the old
+//     is_skinned force-high-α hack paid every walking character's temporal
+//     AA for a per-frame-shading problem skinned meshes don't inherently
+//     have.
+//
+//   ifIrradianceReactivity — the demodulated GI INTEGRAND itself is
+//     non-stationary: a deformer re-orients the gather hemisphere every
+//     frame, so a long history displays a lagged average. The GI accumulator
+//     pins a short CONSTANT history cap on this signal. Animated textures
+//     deliberately contribute 0 here — GI accumulates DEMODULATED
+//     irradiance, which a scrolling albedo does not change.
+//
+// Both channels are binary today (flag-driven) but typed float [0..1] and
+// consumed via mix()/scale, so graded sources (material reactivity hints,
+// shading-change detection) plug in here without touching consumers.
+
+#ifndef THREEPP_INSTANCE_FLAGS_GLSL
+#define THREEPP_INSTANCE_FLAGS_GLSL
+
+#include "vulkan_shared.h"
+
+bool ifWater(uint z)       { return (z & kInstFlagWater) != 0u; }
+bool ifSkinned(uint z)     { return (z & kInstFlagSkinned) != 0u; }
+bool ifDoubleSided(uint z) { return (z & kInstFlagDoubleSided) != 0u; }
+uint ifClassId(uint z)     { return (z >> 8) & 0xFFu; }
+
+float ifShadingReactivity(uint z) {
+    return ((z & (kInstFlagDeformer | kInstFlagTexAnim)) != 0u) ? 1.0 : 0.0;
+}
+
+float ifIrradianceReactivity(uint z) {
+    return ((z & kInstFlagDeformer) != 0u) ? 1.0 : 0.0;
+}
+
+#endif// THREEPP_INSTANCE_FLAGS_GLSL

--- a/src/threepp/renderers/vulkan/shaders/taa_resolve.comp
+++ b/src/threepp/renderers/vulkan/shaders/taa_resolve.comp
@@ -1,4 +1,7 @@
 #version 460
+#extension GL_GOOGLE_include_directive : enable
+
+#include "instance_flags.glsl"// per-instance flag accessors + reactivity channels
 
 // Raster TAA resolve / temporal upsampler. Inputs:
 //   binding 0: taaInputTex        — current frame, post-denoise (RENDER extent)
@@ -312,12 +315,12 @@ void main() {
 
     // Mesh-ID rejection + skinned-mesh detection. Read both at once.
     //   ids.x = instanceCustomIndex+1 (0 = sky/miss)
-    //   ids.z = flags  (bit 0 is_water, bit 3 is_skinned)
+    //   ids.z = per-instance flags (layout: vulkan_shared.h)
     const uvec4 currIds = texture(gbufIdsCurrTex, uvIn);
     const uvec4 prevIds = reprojValid
             ? texture(gbufIdsPrevTex, prevUv * inScale)
             : uvec4(0u);
-    const bool isSkinned = (currIds.z & 8u) != 0u;
+    const bool isSkinned = ifSkinned(currIds.z);
     // NO hard mesh-ID disocclusion reject. Under jitter a silhouette pixel's
     // coverage (hence its mesh-ID) flips EVERY frame, so an ID-mismatch reject
     // fires at every edge every frame → history never accumulates → edges
@@ -542,26 +545,19 @@ void main() {
     // history above is at best the neighbourhood mean, but a freshly revealed
     // surface should read its own current sample, not a clip of stale colour.
     float a = max(clamp((pc.blendAlpha + velocityBump) * antiFlicker, 0.01, 1.0), depthDisocc);
-    // PER-FRAME-CHANGING CONTENT — α floor for two flag classes:
-    //   bit 5 (32u): persistent GEOMETRY deformer (tet-skinned soft bodies).
-    //     Reprojection aligns the geometry, but the shading itself (normals
-    //     swinging, stretch, contact shadowing) changes every frame — an EMA
-    //     at α≈0.1-0.25 displays a 3-8-frame-lagged average of it, read as
-    //     "frames of history dragging behind the fish" (GL, no TAA, is
-    //     crisp). The velocity bump cannot catch this: a body wobbling in
-    //     place has near-zero screen motion yet full shading change — screen
-    //     velocity and shading-change rate are decoupled exactly here (the
-    //     reason the old is_skinned force-high-alpha hack was wrong is the
-    //     reason this flag-scoped floor is right).
-    //   bit 6 (64u): per-frame TEXTURE animation (Material::textureAnimatedHint
-    //     — scrolling conveyor-belt UVs, video textures). The pattern moves
-    //     with ZERO motion vectors, so history blending smears/lags it at any
-    //     reprojection quality.
-    // 0.75 leaves a ~1/3-frame mean shading lag (0.5 still read as a visible
-    // one-frame echo on high-contrast fish texture); the variance clip (and
-    // setGbufferMsaa for edges) covers the reduced temporal AA.
-    const bool perFrameContent = (currIds.z & 96u) != 0u;
-    if (perFrameContent) a = max(a, 0.75);
+    // SHADING-REACTIVE content — α floor toward the current frame. Sources +
+    // channel semantics: instance_flags.glsl (today: persistent deformers +
+    // animated textures — shading changes every frame in ways motion vectors
+    // can't express, so an EMA at α≈0.1-0.25 displays a 3-8-frame-lagged
+    // average of it, read as "frames of history dragging behind" the
+    // content; the velocity bump can't catch it because screen velocity and
+    // shading-change rate are decoupled exactly there). Floor 0.75 leaves a
+    // ~1/3-frame mean shading lag (0.5 still read as a visible one-frame
+    // echo on high-contrast per-frame content); the variance clip (and
+    // setGbufferMsaa for edges) covers the reduced temporal AA. Scaling the
+    // floor by the [0..1] reactivity keeps the binary case exact and lets a
+    // graded source soften it.
+    a = max(a, 0.75 * ifShadingReactivity(currIds.z));
     // `result` is still WORKING space here (companded in HDR mode) — decompand
     // back to true linear right before it leaves the shader. LDR mode: no-op
     // (decompand is only ever called under `hdr`), byte-identical to before.

--- a/src/threepp/renderers/vulkan/shaders/vulkan_shared.h
+++ b/src/threepp/renderers/vulkan/shaders/vulkan_shared.h
@@ -29,6 +29,20 @@
 #define kRayMaskOpaque 0x01u
 #define kRayMaskAlpha  0x02u
 
+// Per-instance flag word — packed host-side (VulkanCoreIndirect.cpp) into
+// DrawInfo.flags, carried through gbuffer.vert into the gbuffer IDs
+// attachment's .z channel (rgba16ui — truncates to 16 bits, so flags live in
+// bits 0..7 and the semantic CLASS id in bits 8..15). THE canonical bit
+// layout; shader consumers go through the instance_flags.glsl accessors
+// instead of raw masks. Bits 1..2 are reserved (documented for transmissive/
+// thin-walled in an earlier design, never packed — kept so re-introducing
+// them can't silently collide).
+#define kInstFlagWater       0x01u// DisplacedMesh (FFT water / displaced surface)
+#define kInstFlagSkinned     0x08u// GPU-skinned mesh
+#define kInstFlagDoubleSided 0x10u// Side::Double material (±N = same surface)
+#define kInstFlagDeformer    0x20u// persistent per-frame deformer (tet soft body)
+#define kInstFlagTexAnim     0x40u// per-frame texture animation (Material::textureAnimatedHint)
+
 #ifdef __cplusplus
 
 #include <cstdint>

--- a/src/threepp/utils/GeometryLod.cpp
+++ b/src/threepp/utils/GeometryLod.cpp
@@ -14,7 +14,8 @@ namespace threepp::geometrylod {
     }// namespace
 
     std::vector<Level> generateChain(const float* positions, size_t vertexCount,
-                                      const uint32_t* indices, size_t indexCount) {
+                                      const uint32_t* indices, size_t indexCount,
+                                      bool sparse) {
         std::vector<Level> chain;
         if (!positions || !indices || vertexCount < 3 || indexCount < kMinIndices) return chain;
 
@@ -25,7 +26,11 @@ namespace threepp::geometrylod {
 
         std::vector<uint32_t> src(indices, indices + indexCount);
         float prevErrorAbs = 0.f;
-        constexpr unsigned options = meshopt_SimplifyLockBorder;
+        // Sparse applies to EVERY level of a soup chain — the referenced
+        // subset stays sparse relative to the original vertex buffer all the
+        // way down (see the header's parameter doc for why it's required).
+        const unsigned options = meshopt_SimplifyLockBorder |
+                                 (sparse ? meshopt_SimplifySparse : 0u);
 
         for (size_t level = 0; level < kMaxLevels; ++level) {
             const size_t targetCount = (src.size() / 2) / 3 * 3;// ~50% of previous, tri-aligned
@@ -59,6 +64,39 @@ namespace threepp::geometrylod {
         }
 
         return chain;
+    }
+
+    std::vector<uint32_t> buildCanonicalIndices(const float* positions,
+                                                 const float* normals,
+                                                 const float* uvs,
+                                                 size_t vertexCount) {
+        std::vector<uint32_t> out;
+        const size_t indexCount = vertexCount / 3 * 3;// whole triangles only
+        if (!positions || indexCount < 3) return out;
+
+        meshopt_Stream streams[3];
+        size_t streamCount = 0;
+        streams[streamCount++] = {positions, 3 * sizeof(float), 3 * sizeof(float)};
+        if (normals) streams[streamCount++] = {normals, 3 * sizeof(float), 3 * sizeof(float)};
+        if (uvs) streams[streamCount++] = {uvs, 2 * sizeof(float), 2 * sizeof(float)};
+
+        // NULL indices = unindexed input (per meshopt's doc); remap[v] is the
+        // dense unique-slot id every binary-identical vertex shares.
+        std::vector<uint32_t> remap(vertexCount);
+        meshopt_generateVertexRemapMulti(remap.data(), nullptr, vertexCount,
+                                         vertexCount, streams, streamCount);
+
+        // One representative ORIGINAL vid per unique slot (first occurrence),
+        // so the output indexes the caller's untouched soup vertex buffer —
+        // no compacted/remapped vertex stream is ever materialized.
+        std::vector<uint32_t> representative(vertexCount, ~0u);
+        out.resize(indexCount);
+        for (size_t i = 0; i < indexCount; ++i) {
+            const uint32_t slot = remap[i];
+            if (representative[slot] == ~0u) representative[slot] = static_cast<uint32_t>(i);
+            out[i] = representative[slot];
+        }
+        return out;
     }
 
 }// namespace threepp::geometrylod

--- a/src/threepp/utils/GeometryLod.cpp
+++ b/src/threepp/utils/GeometryLod.cpp
@@ -1,0 +1,64 @@
+#include "threepp/utils/GeometryLod.hpp"
+
+#include <meshoptimizer.h>
+
+#include <algorithm>
+
+namespace threepp::geometrylod {
+
+    namespace {
+        constexpr size_t kMaxLevels = 4;
+        constexpr size_t kMinIndices = 384;// 128 triangles
+        constexpr float kTargetErrorRel = 0.05f;
+        constexpr size_t kRefuseNumerator = 85;// stop if new count > 85% of previous
+    }// namespace
+
+    std::vector<Level> generateChain(const float* positions, size_t vertexCount,
+                                      const uint32_t* indices, size_t indexCount) {
+        std::vector<Level> chain;
+        if (!positions || !indices || vertexCount < 3 || indexCount < kMinIndices) return chain;
+
+        // Converts meshopt's mesh-extent-relative error into absolute
+        // object-space units once; every level's result_error is scaled by
+        // the same factor (see meshopt_simplifyScale's doc comment).
+        const float scale = meshopt_simplifyScale(positions, vertexCount, 3 * sizeof(float));
+
+        std::vector<uint32_t> src(indices, indices + indexCount);
+        float prevErrorAbs = 0.f;
+        constexpr unsigned options = meshopt_SimplifyLockBorder;
+
+        for (size_t level = 0; level < kMaxLevels; ++level) {
+            const size_t targetCount = (src.size() / 2) / 3 * 3;// ~50% of previous, tri-aligned
+            if (targetCount < kMinIndices) break;
+
+            // destination must hold up to src.size() elements (meshopt's
+            // worst case is the INPUT count, not the target).
+            std::vector<uint32_t> dst(src.size());
+            float resultErrorRel = 0.f;
+            const size_t newCount = meshopt_simplify(
+                    dst.data(), src.data(), src.size(),
+                    positions, vertexCount, 3 * sizeof(float),
+                    targetCount, kTargetErrorRel, options, &resultErrorRel);
+
+            if (newCount == 0) break;// degenerate result — stop the chain here
+            if (newCount * 100 > src.size() * kRefuseNumerator) break;// refuses to reduce meaningfully
+
+            dst.resize(newCount);
+            // meshopt's result_error is measured against THIS call's input —
+            // i.e. against the PREVIOUS level, not the original mesh. Chained
+            // deviations compound, so the honest bound vs LOD0 is the running
+            // SUM (a max() clamp under-reports deep levels ~N× and silently
+            // breaks the sub-pixel-switch guarantee the selection threshold
+            // assumes). Additive is conservative — it can only make selection
+            // pick finer levels sooner, never admit a visible pop.
+            const float errorAbs = prevErrorAbs + resultErrorRel * scale;
+            prevErrorAbs = errorAbs;
+
+            chain.push_back(Level{std::move(dst), errorAbs});
+            src = chain.back().indices;// next level simplifies further from here
+        }
+
+        return chain;
+    }
+
+}// namespace threepp::geometrylod


### PR DESCRIPTION
## What

Automatic, zero-configuration mesh LOD for the Vulkan renderer. Eligible geometry
gets a chain of simplified **index buffers** generated in the background with the
bundled meshoptimizer (vertex/normal/UV buffers are shared across all levels —
index-only), and each frame every entry selects the coarsest level whose projected
screen-space error stays under **0.75 px**, with hysteresis. The selected level is
consumed **identically by the raster G-buffer and the ray-tracing TLAS/GeometryDescs**,
so the rasterized and ray-traced views of an entry can never disagree about which
triangles exist.

**On by default.** `setAutoLod(false)` is the manual override; transitions are
sub-pixel by construction and measured below the test scenes' own animation noise.

## Why

This is a **performance feature for geometry-bound scenes**. Measured
(interleaved same-process A/B/A, off→on→off drift-controlled):

| scene / phase | off | on | delta |
|---|---|---|---|
| fjord cinematic flight | 16.3 ms (61 fps) | 12.7 ms (79 fps) | **+29 % FPS** |
| fjord flight, G-buffer GPU | 3.2 ms | 2.0 ms | −38 % |
| fjord flight, worst frame | 137 ms | 94 ms | better |
| fjord static vista | 13.5 ms | 13.6 ms | tied |
| Bistro (per-pixel-bound worst case) | 27.1 ms | 26.8 ms | neutral |

The fjord win comes almost entirely from instanced vegetation: 7 chains covering
~2 500 instanced entries at **3.2 MB** of resident LOD memory.

Explicit non-goal: this does **not** reduce TAA edge shimmer (measured ~5 % at
best on Bistro — that flicker is sub-pixel coverage plus the 1-spp shading floor,
not triangle density).

## How it works

- **Eligibility:** plain static meshes ≥ 1024 triangles. Unindexed triangle soup
  (FBX-style loaders never index) is welded into canonical indices via
  `meshopt_generateVertexRemapMulti` + `meshopt_SimplifySparse`; levels become
  indexed draws against the untouched soup vertex buffer.
- **Generation:** one background worker, jobs snapshot their data (no lifetime
  races); results finalize at up to 16 geometries / 8 MiB per frame in a single
  one-shot submit. Chain errors accumulate additively across levels (meshopt's
  `result_error` is relative to each call's input). 256 MiB resident cap.
- **Consistency:** each level owns its BLAS; level switches force the full TLAS
  build path (`MODE_UPDATE` with a changed AS reference is legally murky) and
  `GeometryDesc::indexAddress/indexed` ride a per-frame-in-flight ring (same
  fence-gated model as MaterialDescs) — **no device stalls on switch frames**.
- **Selection cost:** everything type/structure-derived is cached on the entry at
  scene expansion; the per-frame pass is float math + one hash lookup per entry
  (~0 measured overhead at 4 k entries).
- **Exempt (always full detail):** deformers (skinned/displaced/grass/morphed/tet),
  emissive materials (the NEE triangle CDF can't see index swaps), manual
  `threepp::LOD` subtrees, overlays/particles, and the new **`Object3D::autoLod = false`**
  opt-out for meshes that manage their own detail — `TileTerrain` sets it on its
  quadtree tiles (auto-simplification on top of system LOD flattened shading and
  spotlighted tile seams; positional error bounds position, not lighting response).

## API surface

- `Object3D::autoLod` (default `true`) — per-mesh opt-out, `frustumCulled` family.
- `VulkanRendererCore::setAutoLod(bool)` / `autoLod()` — global override.
- `VulkanRendererCore::autoLodStats()` — entries per level, chains, resident bytes.
- `threepp::geometrylod::generateChain()` / `buildCanonicalIndices()` — renderer-
  agnostic chain generator in `threepp/utils`.
- The fjord demo shows live LOD stats + an on/off toggle in its perf panel.
