### PR TITLE
Fix five lifetime / memory-safety defects

### DIFF
--- a/include/threepp/core/BufferAttribute.hpp
+++ b/include/threepp/core/BufferAttribute.hpp
@@ -80,9 +80,6 @@ namespace threepp {
 
             this->usage_ = source.usage_;
         }
-
-        inline static Vector3 _vector{};
-        inline static Vector2 _vector2{};
     };
 
     template<class T>
@@ -180,26 +177,33 @@ namespace threepp {
             return *this;
         }
 
+        // The scratch vectors below are deliberately function-local. They used to
+        // be shared `inline static` members, which made every one of these
+        // transforms a data race when two threads processed different geometries
+        // at once (loaders and sensor code do exactly that). A 12-byte stack
+        // local is also cheaper than thread-local storage.
         TypedBufferAttribute<T>& applyMatrix3(const Matrix3& m) {
 
             if (this->itemSize_ == 2) {
 
+                Vector2 v;
                 for (unsigned i = 0, l = this->count_; i < l; i++) {
 
-                    setFromBufferAttribute(_vector2, i);
-                    _vector2.applyMatrix3(m);
+                    setFromBufferAttribute(v, i);
+                    v.applyMatrix3(m);
 
-                    this->setXY(i, _vector2.x, _vector2.y);
+                    this->setXY(i, v.x, v.y);
                 }
 
             } else if (this->itemSize_ == 3) {
 
+                Vector3 v;
                 for (unsigned i = 0, l = this->count_; i < l; i++) {
 
-                    setFromBufferAttribute(_vector, i);
-                    _vector.applyMatrix3(m);
+                    setFromBufferAttribute(v, i);
+                    v.applyMatrix3(m);
 
-                    this->setXYZ(i, _vector.x, _vector.y, _vector.z);
+                    this->setXYZ(i, v.x, v.y, v.z);
                 }
             }
 
@@ -208,15 +212,16 @@ namespace threepp {
 
         TypedBufferAttribute<T>& applyMatrix4(const Matrix4& m) {
 
+            Vector3 v;
             for (unsigned i = 0, l = this->count_; i < l; i++) {
 
-                _vector.x = this->getX(i);
-                _vector.y = this->getY(i);
-                _vector.z = this->getZ(i);
+                v.x = this->getX(i);
+                v.y = this->getY(i);
+                v.z = this->getZ(i);
 
-                _vector.applyMatrix4(m);
+                v.applyMatrix4(m);
 
-                this->setXYZ(i, _vector.x, _vector.y, _vector.z);
+                this->setXYZ(i, v.x, v.y, v.z);
             }
 
             return *this;
@@ -224,15 +229,16 @@ namespace threepp {
 
         TypedBufferAttribute<T>& applyNormalMatrix(const Matrix3& m) {
 
+            Vector3 v;
             for (unsigned i = 0, l = this->count_; i < l; i++) {
 
-                _vector.x = this->getX(i);
-                _vector.y = this->getY(i);
-                _vector.z = this->getZ(i);
+                v.x = this->getX(i);
+                v.y = this->getY(i);
+                v.z = this->getZ(i);
 
-                _vector.applyNormalMatrix(m);
+                v.applyNormalMatrix(m);
 
-                this->setXYZ(i, _vector.x, _vector.y, _vector.z);
+                this->setXYZ(i, v.x, v.y, v.z);
             }
 
             return *this;
@@ -240,15 +246,16 @@ namespace threepp {
 
         TypedBufferAttribute<T>& transformDirection(const Matrix4& m) {
 
+            Vector3 v;
             for (unsigned i = 0, l = this->count_; i < l; i++) {
 
-                _vector.x = this->getX(i);
-                _vector.y = this->getY(i);
-                _vector.z = this->getZ(i);
+                v.x = this->getX(i);
+                v.y = this->getY(i);
+                v.z = this->getZ(i);
 
-                _vector.transformDirection(m);
+                v.transformDirection(m);
 
-                this->setXYZ(i, _vector.x, _vector.y, _vector.z);
+                this->setXYZ(i, v.x, v.y, v.z);
             }
 
             return *this;

--- a/include/threepp/extras/physx/PhysxVehicle.hpp
+++ b/include/threepp/extras/physx/PhysxVehicle.hpp
@@ -174,11 +174,19 @@ namespace threepp {
             buildComponentSequence();
 
             stepCallback_ = [this](float dt) { stepVehicle(dt); };
-            world_->onPreSubstep(stepCallback_);
+            stepHandle_ = world_->onPreSubstep(stepCallback_);
         }
 
         ~PhysxVehicle() {
             using namespace ::physx;
+
+            // Unregister FIRST: stepCallback_ captures `this`, so a world that
+            // kept calling it after the vehicle died would run stepVehicle() on
+            // freed memory.
+            if (world_ && stepHandle_) {
+                world_->removeSubstepCallback(stepHandle_);
+                stepHandle_ = 0;
+            }
 
             if (constraintsCreated_) {
                 ::physx::vehicle2::PxVehicleConstraintsDestroy(physxConstraints_);
@@ -857,6 +865,7 @@ namespace threepp {
         bool initialised_ = false;
 
         std::function<void(float)> stepCallback_;
+        PhysxWorld::SubstepHandle stepHandle_ = 0;
 
         ::physx::PxRigidDynamic* chassisActor_ = nullptr;
         ::physx::PxMaterial* wheelShapeMaterial_ = nullptr;

--- a/include/threepp/extras/physx/PhysxVehicleEngineDrive.hpp
+++ b/include/threepp/extras/physx/PhysxVehicleEngineDrive.hpp
@@ -175,11 +175,19 @@ namespace threepp {
             buildComponentSequence();
 
             stepCallback_ = [this](float dt) { stepVehicle(dt); };
-            world_->onPreSubstep(stepCallback_);
+            stepHandle_ = world_->onPreSubstep(stepCallback_);
         }
 
         ~PhysxVehicleEngineDrive() {
             using namespace ::physx;
+
+            // Unregister FIRST: stepCallback_ captures `this`, so a world that
+            // kept calling it after the vehicle died would run stepVehicle() on
+            // freed memory.
+            if (world_ && stepHandle_) {
+                world_->removeSubstepCallback(stepHandle_);
+                stepHandle_ = 0;
+            }
 
             if (constraintsCreated_) {
                 ::physx::vehicle2::PxVehicleConstraintsDestroy(physxConstraints_);
@@ -1015,6 +1023,7 @@ namespace threepp {
         bool initialised_ = false;
 
         std::function<void(float)> stepCallback_;
+        PhysxWorld::SubstepHandle stepHandle_ = 0;
 
         ::physx::PxRigidDynamic* chassisActor_ = nullptr;
         ::physx::PxMaterial* wheelShapeMaterial_ = nullptr;

--- a/include/threepp/extras/physx/PhysxWorld.hpp
+++ b/include/threepp/extras/physx/PhysxWorld.hpp
@@ -305,8 +305,38 @@ namespace threepp {
             syncRigidBindings(alpha);
         }
 
-        void onPreSubstep(std::function<void(float)> cb) { preSubstep_.push_back(std::move(cb)); }
-        void onPostSubstep(std::function<void(float)> cb) { postSubstep_.push_back(std::move(cb)); }
+        // Substep hooks. Both return an opaque handle usable with
+        // removeSubstepCallback(): a callback almost always captures `this` from
+        // some longer-lived object (PhysxVehicle registers its update here), and
+        // without a way to unregister, destroying that object left the world
+        // calling into freed memory on the next step. Anything that registers
+        // must unregister in its destructor.
+        using SubstepHandle = std::size_t;
+
+        SubstepHandle onPreSubstep(std::function<void(float)> cb) {
+            const auto h = nextSubstepHandle_++;
+            preSubstep_.push_back({h, std::move(cb)});
+            return h;
+        }
+
+        SubstepHandle onPostSubstep(std::function<void(float)> cb) {
+            const auto h = nextSubstepHandle_++;
+            postSubstep_.push_back({h, std::move(cb)});
+            return h;
+        }
+
+        // Unregister a pre/post substep callback. Safe to call with a stale or
+        // already-removed handle (no-op), and safe to call from inside a
+        // callback — the step loop iterates by index over a snapshot.
+        void removeSubstepCallback(SubstepHandle handle) {
+            const auto drop = [handle](std::vector<SubstepEntry>& v) {
+                v.erase(std::remove_if(v.begin(), v.end(),
+                                       [handle](const SubstepEntry& e) { return e.handle == handle; }),
+                        v.end());
+            };
+            drop(preSubstep_);
+            drop(postSubstep_);
+        }
 
         // --- Proprioceptive sensors -------------------------------------------
         // A registered Sensor is sampled from the step loop once per fixed substep
@@ -385,6 +415,28 @@ namespace threepp {
                     std::remove_if(objBindings_.begin(), objBindings_.end(),
                                    [&](const ObjBinding& b) { return b.actor == actor; }),
                     objBindings_.end());
+            // InstancedMesh bindings hold actor pointers too, and used to be
+            // skipped here: the actor was released while instBindings_ still
+            // named it, so the next sync dereferenced freed memory.
+            //
+            // Null the slot rather than erasing it — instance i mirrors
+            // actors[i], so compacting the vector would silently repoint every
+            // later instance at a different body. A nulled slot is skipped by
+            // the sync loops, leaving that instance frozen at its last matrix;
+            // hiding or moving it is the caller's call. A binding is dropped
+            // only once every actor in it is gone.
+            for (auto& b : instBindings_) {
+                for (auto*& a : b.actors) {
+                    if (a == actor) a = nullptr;
+                }
+            }
+            instBindings_.erase(
+                    std::remove_if(instBindings_.begin(), instBindings_.end(),
+                                   [](const InstBinding& b) {
+                                       return std::all_of(b.actors.begin(), b.actors.end(),
+                                                          [](const ::physx::PxRigidActor* a) { return a == nullptr; });
+                                   }),
+                    instBindings_.end());
             scene_->removeActor(*actor);
             actor->release();
         }
@@ -747,10 +799,13 @@ namespace threepp {
         }
 
         void substep(float dt) {
-            for (auto& cb : preSubstep_) cb(dt);
+            // Iterate by index, re-reading size each time: a callback is allowed
+            // to register or remove a substep callback (a vehicle tearing itself
+            // down mid-step), which would invalidate a range-for's iterators.
+            for (size_t i = 0; i < preSubstep_.size(); ++i) preSubstep_[i].fn(dt);
             scene_->simulate(dt);
             scene_->fetchResults(true);
-            for (auto& cb : postSubstep_) cb(dt);
+            for (size_t i = 0; i < postSubstep_.size(); ++i) postSubstep_[i].fn(dt);
             // Body states are fresh here (post fetchResults). Advance the sim clock
             // and drive any registered sensors — appended after existing hooks so
             // the dt / stepping path above is untouched.
@@ -777,6 +832,7 @@ namespace threepp {
                     b.prevPoses.resize(b.actors.size());
                 }
                 for (size_t i = 0; i < b.actors.size(); ++i) {
+                    if (!b.actors[i]) continue;// removeActor() nulled this slot
                     b.prevPoses[i] = b.actors[i]->getGlobalPose();
                 }
                 b.hasPrev = true;
@@ -813,6 +869,7 @@ namespace threepp {
                 Vector3 pos, scale;
                 Quaternion rot;
                 for (size_t i = 0; i < b.actors.size(); ++i) {
+                    if (!b.actors[i]) continue;// removeActor() nulled this slot
                     b.mesh->getMatrixAt(i, m);
                     m.decompose(pos, rot, scale);
                     const auto cur = b.actors[i]->getGlobalPose();
@@ -849,8 +906,13 @@ namespace threepp {
 
         std::vector<ObjBinding> objBindings_;
         std::vector<InstBinding> instBindings_;
-        std::vector<std::function<void(float)>> preSubstep_;
-        std::vector<std::function<void(float)>> postSubstep_;
+        struct SubstepEntry {
+            SubstepHandle handle;
+            std::function<void(float)> fn;
+        };
+        std::vector<SubstepEntry> preSubstep_;
+        std::vector<SubstepEntry> postSubstep_;
+        SubstepHandle nextSubstepHandle_ = 1;// 0 reserved as "no handle"
         std::vector<Sensor*> sensors_;// non-owning; sampled each substep
     };
 

--- a/python/src/bind_physx.cpp
+++ b/python/src/bind_physx.cpp
@@ -394,14 +394,22 @@ namespace threepp_py {
                      "Add one dynamic body per instance of an InstancedMesh. Returns a list of RigidBody.")
                 .def("on_pre_substep",
                      [](PhysxWorld& w, py::function cb) {
-                         w.onPreSubstep([cb](float dt) { py::gil_scoped_acquire g; cb(dt); });
+                         return w.onPreSubstep([cb](float dt) { py::gil_scoped_acquire g; cb(dt); });
                      },
-                     py::arg("callback"), "Register callback(dt) fired before each fixed substep.")
+                     py::arg("callback"),
+                     "Register callback(dt) fired before each fixed substep. Returns a "
+                     "handle for remove_substep_callback().")
                 .def("on_post_substep",
                      [](PhysxWorld& w, py::function cb) {
-                         w.onPostSubstep([cb](float dt) { py::gil_scoped_acquire g; cb(dt); });
+                         return w.onPostSubstep([cb](float dt) { py::gil_scoped_acquire g; cb(dt); });
                      },
-                     py::arg("callback"), "Register callback(dt) fired after each fixed substep.")
+                     py::arg("callback"),
+                     "Register callback(dt) fired after each fixed substep. Returns a "
+                     "handle for remove_substep_callback().")
+                .def("remove_substep_callback", &PhysxWorld::removeSubstepCallback,
+                     py::arg("handle"),
+                     "Unregister a pre/post substep callback by its handle. A stale or "
+                     "already-removed handle is a no-op.")
                 .def("register_sensor",
                      [](PhysxWorld& w, Imu& imu) { w.registerSensor(&imu); },
                      py::arg("sensor"), py::keep_alive<1, 2>(),

--- a/src/threepp/helpers/BoxHelper.cpp
+++ b/src/threepp/helpers/BoxHelper.cpp
@@ -29,7 +29,7 @@ std::string BoxHelper::type() const {
 
 void BoxHelper::update() {
 
-    static Box3 _box;
+    static thread_local Box3 _box;
 
     _box.setFromObject(*this->object);
 

--- a/src/threepp/helpers/DirectionalLightHelper.cpp
+++ b/src/threepp/helpers/DirectionalLightHelper.cpp
@@ -43,9 +43,9 @@ DirectionalLightHelper::DirectionalLightHelper(DirectionalLight& light, float si
 
 void DirectionalLightHelper::update() {
 
-    static Vector3 _v1;
-    static Vector3 _v2;
-    static Vector3 _v3;
+    static thread_local Vector3 _v1;
+    static thread_local Vector3 _v2;
+    static thread_local Vector3 _v3;
 
     _v1.setFromMatrixPosition(*this->light.matrixWorld);
     _v2.setFromMatrixPosition(*this->light.target().matrixWorld);

--- a/src/threepp/helpers/SpotLightHelper.cpp
+++ b/src/threepp/helpers/SpotLightHelper.cpp
@@ -64,7 +64,7 @@ void SpotLightHelper::update() {
 
     this->cone->scale.set(coneWidth, coneWidth, coneLength);
 
-    static Vector3 _vector;
+    static thread_local Vector3 _vector;
     _vector.setFromMatrixPosition(*this->light->target().matrixWorld);
 
     this->cone->lookAt(_vector);

--- a/src/threepp/loaders/OBJLoader.cpp
+++ b/src/threepp/loaders/OBJLoader.cpp
@@ -21,14 +21,35 @@ using namespace threepp;
 
 namespace {
 
-    size_t parseVertexOrNormalIndex(const std::string& value, size_t len) {
-        int index = utils::parseInt(value);
-        return (index > 0 ? (index - 1) : index + len / 3) * 3;
+    // Resolve an OBJ face index into a flat offset into a tightly-packed array
+    // of `stride` floats per element.
+    //
+    // OBJ indices are 1-based, and negative values are relative to the end
+    // (-1 = last element declared so far). Both forms come straight out of the
+    // file, so both must be range-checked: a truncated or hand-edited .obj can
+    // easily name element 999999 of a 3-element array, and the callers index
+    // with operator[]. Returns nullopt for anything that does not address a
+    // real element (including 0, which is never a valid OBJ index) so the
+    // caller can drop the face instead of reading out of bounds.
+    std::optional<size_t> resolveIndex(const std::string& value, size_t arraySize, size_t stride) {
+
+        const int index = utils::parseInt(value);
+        if (index == 0) return std::nullopt;
+
+        const auto count = static_cast<long long>(arraySize / stride);
+        const long long i = index > 0 ? index - 1 : count + index;
+
+        if (i < 0 || i >= count) return std::nullopt;
+
+        return static_cast<size_t>(i) * stride;
     }
 
-    size_t parseUvIndex(const std::string& value, size_t len) {
-        int index = utils::parseInt(value);
-        return (index > 0 ? (index - 1) : index + len / 2) * 2;
+    std::optional<size_t> parseVertexOrNormalIndex(const std::string& value, size_t len) {
+        return resolveIndex(value, len, 3);
+    }
+
+    std::optional<size_t> parseUvIndex(const std::string& value, size_t len) {
+        return resolveIndex(value, len, 2);
     }
 
     struct OBJGeometry {
@@ -136,6 +157,11 @@ namespace {
 
         std::vector<std::string> materialLibraries;
 
+        // Faces/points dropped because an index did not address a declared
+        // element. Reported once after parsing rather than per occurrence — a
+        // broken file tends to repeat the same mistake on every line.
+        size_t badIndexCount = 0;
+
         ParserState() {
             startObject("", false);
         }
@@ -232,49 +258,80 @@ namespace {
                      const std::string& ua, const std::string& ub, const std::string& uc,
                      const std::string& na, const std::string& nb, const std::string& nc) {
 
-            auto vLen = vertices.size();
+            // Resolve EVERY index before appending anything. The per-vertex
+            // arrays (vertices/uvs/normals/colors) are written in parallel, so
+            // emitting a vertex and then bailing on a bad uv would leave them
+            // permanently out of step. A face with any unresolvable index is
+            // dropped whole instead.
+            const auto vLen = vertices.size();
+            const auto ia = parseVertexOrNormalIndex(a, vLen);
+            const auto ib = parseVertexOrNormalIndex(b, vLen);
+            const auto ic = parseVertexOrNormalIndex(c, vLen);
+            if (!ia || !ib || !ic) {
+                ++badIndexCount;
+                return;
+            }
 
-            auto ia = parseVertexOrNormalIndex(a, vLen);
-            auto ib = parseVertexOrNormalIndex(b, vLen);
-            auto ic = parseVertexOrNormalIndex(c, vLen);
-
-            addVertex(ia, ib, ic);
-
+            std::optional<size_t> ta, tb, tc;
             if (!ua.empty()) {
-
-                auto uvlen = uvs.size();
-                ia = parseUvIndex(ua, uvlen);
-                ib = parseUvIndex(ub, uvlen);
-                ic = parseUvIndex(uc, uvlen);
-
-                addUv(ia, ib, ic);
+                const auto uvLen = uvs.size();
+                ta = parseUvIndex(ua, uvLen);
+                tb = parseUvIndex(ub, uvLen);
+                tc = parseUvIndex(uc, uvLen);
+                if (!ta || !tb || !tc) {
+                    ++badIndexCount;
+                    return;
+                }
             }
 
+            std::optional<size_t> nia, nib, nic;
             if (!na.empty()) {
-
-                auto nLen = normals.size();
-                ia = parseVertexOrNormalIndex(na, nLen);
-
-                ib = (na == nb) ? ia : parseVertexOrNormalIndex(nb, nLen);
-                ic = (na == nc) ? ia : parseVertexOrNormalIndex(nc, nLen);
-
-                addNormal(ia, ib, ic);
+                const auto nLen = normals.size();
+                nia = parseVertexOrNormalIndex(na, nLen);
+                nib = (na == nb) ? nia : parseVertexOrNormalIndex(nb, nLen);
+                nic = (na == nc) ? nia : parseVertexOrNormalIndex(nc, nLen);
+                if (!nia || !nib || !nic) {
+                    ++badIndexCount;
+                    return;
+                }
             }
 
+            // Vertex colors come from a 6-float `v` line, so they are addressed
+            // by the VERTEX index at stride 3 — not by whatever ia/ib/ic held
+            // after the uv block above reassigned them at stride 2.
+            std::optional<size_t> ca, cb, cc;
             if (!colors.empty()) {
-
-                addColor(ia, ib, ic);
+                const auto cLen = colors.size();
+                ca = resolveIndex(a, cLen, 3);
+                cb = resolveIndex(b, cLen, 3);
+                cc = resolveIndex(c, cLen, 3);
+                if (!ca || !cb || !cc) {
+                    ++badIndexCount;
+                    return;
+                }
             }
+
+            addVertex(*ia, *ib, *ic);
+            if (ta) addUv(*ta, *tb, *tc);
+            if (nia) addNormal(*nia, *nib, *nic);
+            if (ca) addColor(*ca, *cb, *cc);
         }
 
         void addPointGeometry(const std::vector<std::string>& verts) {
 
             object->geometry.type = "Points";
 
-            auto vLen = verts.size();
+            // Indices address the accumulated vertex array, not this line's
+            // token list — `verts.size()` here silently mis-resolved every
+            // negative (relative) index.
+            const auto vLen = vertices.size();
 
             for (const auto& v : verts) {
-                addVertexPointOrLine(parseVertexOrNormalIndex(v, vLen));
+                if (const auto i = parseVertexOrNormalIndex(v, vLen)) {
+                    addVertexPointOrLine(*i);
+                } else {
+                    ++badIndexCount;
+                }
             }
         }
     };
@@ -447,6 +504,11 @@ struct OBJLoader::Impl {
         }
 
         state.finalize();
+
+        if (state.badIndexCount > 0) {
+            std::cerr << "[OBJLoader] dropped " << state.badIndexCount
+                      << " face(s)/point(s) with out-of-range indices" << std::endl;
+        }
 
         auto container = Group::create();
 

--- a/src/threepp/math/Triangle.cpp
+++ b/src/threepp/math/Triangle.cpp
@@ -158,12 +158,12 @@ void Triangle::closestPointToPoint(const Vector3& p, Vector3& target) const {
     const auto a = this->a_, b = this->b_, c = this->c_;
     float v, w;
 
-    static Vector3 _vab{};
-    static Vector3 _vac{};
-    static Vector3 _vap{};
-    static Vector3 _vbp{};
-    static Vector3 _vcp{};
-    static Vector3 _vbc{};
+    static thread_local Vector3 _vab{};
+    static thread_local Vector3 _vac{};
+    static thread_local Vector3 _vap{};
+    static thread_local Vector3 _vbp{};
+    static thread_local Vector3 _vcp{};
+    static thread_local Vector3 _vbc{};
 
 
     // algorithm thanks to Real-Time Collision Detection by Christer Ericson,

--- a/src/threepp/objects/LOD.cpp
+++ b/src/threepp/objects/LOD.cpp
@@ -66,8 +66,8 @@ size_t LOD::getCurrentLevel() const {
 
 void LOD::update(Camera& camera) {
 
-    static Vector3 _v1;
-    static Vector3 _v2;
+    static thread_local Vector3 _v1;
+    static thread_local Vector3 _v2;
 
     if (levels.size() > 1) {
 

--- a/src/threepp/objects/Mesh.cpp
+++ b/src/threepp/objects/Mesh.cpp
@@ -22,7 +22,7 @@ namespace {
             Object3D& object, Material& material, const Raycaster& raycaster, const Ray& ray,
             const Vector3& pA, const Vector3& pB, const Vector3& pC, Vector3& point) {
 
-        static Vector3 _intersectionPointWorld{};
+        static thread_local Vector3 _intersectionPointWorld{};
 
         if (material.side == Side::Back) {
 
@@ -60,10 +60,10 @@ namespace {
             const FloatBufferAttribute* uv2,
             unsigned int a, unsigned int b, unsigned int c) {
 
-        static Vector3 _vA{};
-        static Vector3 _vB{};
-        static Vector3 _vC{};
-        static Vector3 _intersectionPoint{};
+        static thread_local Vector3 _vA{};
+        static thread_local Vector3 _vB{};
+        static thread_local Vector3 _vC{};
+        static thread_local Vector3 _intersectionPoint{};
 
         position.setFromBufferAttribute(_vA, a);
         position.setFromBufferAttribute(_vB, b);
@@ -133,9 +133,9 @@ namespace {
 
         if (intersection) {
 
-            static Vector2 _uvA{};
-            static Vector2 _uvB{};
-            static Vector2 _uvC{};
+            static thread_local Vector2 _uvA{};
+            static thread_local Vector2 _uvB{};
+            static thread_local Vector2 _uvC{};
 
             if (uv) {
 
@@ -183,7 +183,7 @@ void Mesh::raycast(const Raycaster& raycaster, std::vector<Intersection>& inters
 
     if (material() == nullptr) return;
 
-    static Sphere _sphere{};
+    static thread_local Sphere _sphere{};
 
     // Checking boundingSphere distance to ray
 
@@ -196,8 +196,8 @@ void Mesh::raycast(const Raycaster& raycaster, std::vector<Intersection>& inters
 
     //
 
-    static Ray _ray{};
-    static Matrix4 _inverseMatrix{};
+    static thread_local Ray _ray{};
+    static thread_local Matrix4 _inverseMatrix{};
 
     _inverseMatrix.copy(*matrixWorld).invert();
     _ray.copy(raycaster.ray).applyMatrix4(_inverseMatrix);

--- a/src/threepp/renderers/vulkan/DlssUpscaler.cpp
+++ b/src/threepp/renderers/vulkan/DlssUpscaler.cpp
@@ -166,8 +166,15 @@ namespace threepp::vulkan {
     }
 
     bool DlssUpscaler::ensureNgx() {
-        if (ngxInited_) return params_ != nullptr;
-        ngxInited_ = true;
+        // ngxInited_ tracks "NGX is initialised and owes us a Shutdown1", so it is
+        // set only AFTER a successful Init and cleared by whoever shuts down. It
+        // used to be set here, before the Init call, which made every failure path
+        // below wrong: an Init failure left it true (so shutdownNgx() later called
+        // Shutdown1 on uninitialised NGX), and the capability / parameter failures
+        // shut down inline AND left it true (double shutdown). Both are on the
+        // non-RTX fallback path, i.e. the common case for a machine without DLSS.
+        if (ngxTried_) return params_ != nullptr;
+        ngxTried_ = true;
 
         modulePathW_       = moduleDirW();
         modulePathPtrs_[0] = modulePathW_.c_str();
@@ -185,8 +192,9 @@ namespace threepp::vulkan {
             std::fprintf(stderr,
                          "[threepp] DLSS: NGX init failed (0x%08x) — "
                          "falling back to FSR/TAA.\n", static_cast<unsigned>(r));
-            return false;
+            return false;// nothing to shut down
         }
+        ngxInited_ = true;
 
         // Capability check: driver present + DLSS supported on this GPU.
         NVSDK_NGX_Parameter* caps = nullptr;
@@ -201,6 +209,7 @@ namespace threepp::vulkan {
                          "[threepp] DLSS: not available on this GPU/driver — "
                          "falling back to FSR/TAA.\n");
             NVSDK_NGX_VULKAN_Shutdown1(ctx_.device());
+            ngxInited_ = false;
             return false;
         }
 
@@ -210,6 +219,7 @@ namespace threepp::vulkan {
                          static_cast<unsigned>(r));
             params_ = nullptr;
             NVSDK_NGX_VULKAN_Shutdown1(ctx_.device());
+            ngxInited_ = false;
             return false;
         }
         return true;

--- a/src/threepp/renderers/vulkan/DlssUpscaler.hpp
+++ b/src/threepp/renderers/vulkan/DlssUpscaler.hpp
@@ -161,6 +161,11 @@ namespace threepp::vulkan {
         VulkanContext& ctx_;
         uint32_t framesInFlight_ = 0;
 
+        // ngxTried_: ensureNgx() has run, so don't retry (success or failure).
+        // ngxInited_: NGX is initialised and owes a matching Shutdown1. Kept
+        // separate so a failed init is never shut down, and a partially-failed
+        // init that already shut down inline is not shut down twice.
+        bool                 ngxTried_  = false;
         bool                 ngxInited_ = false;
         NVSDK_NGX_Parameter* params_    = nullptr;// capability/eval parameter map
         NVSDK_NGX_Handle*    feature_   = nullptr;// the DLSS SR feature

--- a/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
+++ b/src/threepp/renderers/vulkan/VulkanCoreImpl.hpp
@@ -1563,6 +1563,27 @@ namespace threepp {
             rec.lodState = BlasRecord::LodState::None;
         }
 
+        // Free every GPU resource a BlasRecord owns. Teardown used to inline
+        // this list at each of the six places that hold a BlasRecord (blasCache,
+        // skinned / tet / displaced / grass / morphed states), and five of the
+        // six had drifted: they omitted `color`, so the per-vertex color buffer
+        // leaked for every mesh that wasn't a plain cached BLAS. One helper, so
+        // adding a Buffer to BlasRecord can only ever be missed in one place.
+        // NB: LOD levels are NOT freed here — blasCache is the only owner of a
+        // LOD chain and calls destroyBlasLodLevels() itself, which also keeps
+        // the lodBlasBytes_ accounting straight.
+        void destroyBlasRecord(BlasRecord& rec) {
+            if (rec.as) ctx->rt().destroyAccelerationStructure(ctx->device(), rec.as, nullptr);
+            destroyBuffer(ctx->allocator(), rec.storage);
+            destroyBuffer(ctx->allocator(), rec.vertex);
+            destroyBuffer(ctx->allocator(), rec.index);
+            destroyBuffer(ctx->allocator(), rec.normal);
+            destroyBuffer(ctx->allocator(), rec.uv);
+            destroyBuffer(ctx->allocator(), rec.color);
+            destroyBuffer(ctx->allocator(), rec.prevVertex);
+            destroyBuffer(ctx->allocator(), rec.blasScratch);
+        }
+
         // Cached CDF blob (16 floats per tri) reused across frames when no
         // emissive mesh moved + entries-list size unchanged. The CPU walk in
         // buildAndUploadEmissiveTris is the dominant per-frame cost on
@@ -3048,15 +3069,7 @@ namespace threepp {
 
             for (auto& [_, rec] : blasCache) {
                 destroyBlasLodLevels(*rec);
-                if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
-                destroyBuffer(ctx->allocator(), rec->storage);
-                destroyBuffer(ctx->allocator(), rec->vertex);
-                destroyBuffer(ctx->allocator(), rec->index);
-                destroyBuffer(ctx->allocator(), rec->normal);
-                destroyBuffer(ctx->allocator(), rec->uv);
-                destroyBuffer(ctx->allocator(), rec->color);
-                destroyBuffer(ctx->allocator(), rec->prevVertex);
-                destroyBuffer(ctx->allocator(), rec->blasScratch);
+                destroyBlasRecord(*rec);
             }
             blasCache.clear();
 
@@ -3069,16 +3082,7 @@ namespace threepp {
                 destroyBuffer(ctx->allocator(), st->skinWeight);
                 destroyBuffer(ctx->allocator(), st->boneMatrices);
                 destroyBuffer(ctx->allocator(), st->blasScratch);
-                auto& rec = st->blas;
-                if (!rec) continue;
-                if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
-                destroyBuffer(ctx->allocator(), rec->storage);
-                destroyBuffer(ctx->allocator(), rec->vertex);
-                destroyBuffer(ctx->allocator(), rec->index);
-                destroyBuffer(ctx->allocator(), rec->normal);
-                destroyBuffer(ctx->allocator(), rec->uv);
-                destroyBuffer(ctx->allocator(), rec->prevVertex);
-                destroyBuffer(ctx->allocator(), rec->blasScratch);
+                if (st->blas) destroyBlasRecord(*st->blas);
             }
             skinnedMeshStates.clear();
 
@@ -3092,31 +3096,12 @@ namespace threepp {
                 destroyBuffer(ctx->allocator(), st->tetPos);
                 vulkan::destroyExternalBuffer(d, st->tetPosExt);
                 destroyBuffer(ctx->allocator(), st->blasScratch);
-                auto& rec = st->blas;
-                if (!rec) continue;
-                if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
-                destroyBuffer(ctx->allocator(), rec->storage);
-                destroyBuffer(ctx->allocator(), rec->vertex);
-                destroyBuffer(ctx->allocator(), rec->index);
-                destroyBuffer(ctx->allocator(), rec->normal);
-                destroyBuffer(ctx->allocator(), rec->uv);
-                destroyBuffer(ctx->allocator(), rec->prevVertex);
-                destroyBuffer(ctx->allocator(), rec->blasScratch);
+                if (st->blas) destroyBlasRecord(*st->blas);
             }
             tetMeshStates.clear();
 
             for (auto& [_, st] : displacedStates) {
-                if (st->blas) {
-                    auto& rec = st->blas;
-                    if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
-                    destroyBuffer(ctx->allocator(), rec->storage);
-                    destroyBuffer(ctx->allocator(), rec->vertex);
-                    destroyBuffer(ctx->allocator(), rec->index);
-                    destroyBuffer(ctx->allocator(), rec->normal);
-                    destroyBuffer(ctx->allocator(), rec->uv);
-                    destroyBuffer(ctx->allocator(), rec->prevVertex);
-                    destroyBuffer(ctx->allocator(), rec->blasScratch);
-                }
+                if (st->blas) destroyBlasRecord(*st->blas);
                 if (st->scratchA.view  != VK_NULL_HANDLE) vkDestroyImageView(d, st->scratchA.view, nullptr);
                 if (st->scratchA.image != VK_NULL_HANDLE) vmaDestroyImage(ctx->allocator(), st->scratchA.image, st->scratchA.alloc);
                 if (st->foamImage.view  != VK_NULL_HANDLE) vkDestroyImageView(d, st->foamImage.view, nullptr);
@@ -3132,33 +3117,14 @@ namespace threepp {
             displacedStates.clear();
 
             for (auto& [_, st] : grassStates) {
-                if (st->blas) {
-                    auto& rec = st->blas;
-                    if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
-                    destroyBuffer(ctx->allocator(), rec->storage);
-                    destroyBuffer(ctx->allocator(), rec->vertex);
-                    destroyBuffer(ctx->allocator(), rec->index);
-                    destroyBuffer(ctx->allocator(), rec->normal);
-                    destroyBuffer(ctx->allocator(), rec->uv);
-                    destroyBuffer(ctx->allocator(), rec->prevVertex);
-                    destroyBuffer(ctx->allocator(), rec->blasScratch);
-                }
+                if (st->blas) destroyBlasRecord(*st->blas);
                 destroyBuffer(ctx->allocator(), st->restPos);
                 destroyBuffer(ctx->allocator(), st->heightFrac);
             }
             grassStates.clear();
 
             for (auto& [_, st] : morphedMeshStates) {
-                auto& rec = st->blas;
-                if (!rec) continue;
-                if (rec->as) ctx->rt().destroyAccelerationStructure(d, rec->as, nullptr);
-                destroyBuffer(ctx->allocator(), rec->storage);
-                destroyBuffer(ctx->allocator(), rec->vertex);
-                destroyBuffer(ctx->allocator(), rec->index);
-                destroyBuffer(ctx->allocator(), rec->normal);
-                destroyBuffer(ctx->allocator(), rec->uv);
-                destroyBuffer(ctx->allocator(), rec->prevVertex);
-                destroyBuffer(ctx->allocator(), rec->blasScratch);
+                if (st->blas) destroyBlasRecord(*st->blas);
             }
             morphedMeshStates.clear();
 
@@ -3173,6 +3139,12 @@ namespace threepp {
             for (auto& b : emissiveTriBuffers) destroyBuffer(ctx->allocator(), b);
             destroyImage2D(ctx->allocator(), d, envImage);
             destroyImage2D(ctx->allocator(), d, blueNoiseImage);
+            // 1x1 stand-ins bound to the MS gbuffer descriptor slots whenever
+            // MSAA is off. Created once by ensureGbufDummyMS() (guarded by
+            // gbufDummyMSCreated_) and, until now, destroyed nowhere at all —
+            // 5 VkImage + 5 VkImageView leaked per device. They are not
+            // recreated on resize, so this destructor is their only owner.
+            for (auto& img : gbufDummyMS_) destroyImage2D(ctx->allocator(), d, img);
             destroyImage2D(ctx->allocator(), d, oceanFineHeightDummy);
             destroyImage2D(ctx->allocator(), d, oceanFoamDummy);
             destroyImage2D(ctx->allocator(), d, foamDetailImage);

--- a/tests/loaders/OBJLoader_test.cpp
+++ b/tests/loaders/OBJLoader_test.cpp
@@ -31,6 +31,17 @@ namespace {
         return position->count();
     }
 
+    // Load a snippet, returning the produced group. A file whose every face was
+    // dropped yields a group with no children (the loader skips empty geometry).
+    std::shared_ptr<Group> loadObj(const std::string& name, const std::string& contents) {
+        auto path = writeTempFile(name, contents);
+        OBJLoader loader;
+        loader.useCache = false;
+        auto group = loader.load(path, false);
+        std::filesystem::remove(path);
+        return group;
+    }
+
 }// namespace
 
 TEST_CASE("OBJLoader handles vertex-only faces without crashing") {
@@ -115,4 +126,95 @@ TEST_CASE("OBJLoader handles all face-vertex token forms") {
         CHECK(positionCount(group) == 3);
         std::filesystem::remove(path);
     }
+}
+
+// Face indices come straight out of the file and were fed to operator[] with no
+// range check, so a truncated or hand-edited .obj could read far past the end of
+// the vertex array. Every case below is a heap out-of-bounds read before the
+// fix; after it, the offending face is dropped and the rest of the file loads.
+TEST_CASE("OBJLoader rejects out-of-range face indices") {
+
+    const std::string threeVerts =
+            "v 0.0 0.0 0.0\n"
+            "v 1.0 0.0 0.0\n"
+            "v 0.0 1.0 0.0\n";
+
+    SECTION("index far past the end") {
+        auto group = loadObj("threepp_oob_high.obj", threeVerts + "f 1 2 999999\n");
+        REQUIRE(group);
+        CHECK(group->children.empty());// the only face was dropped
+    }
+
+    SECTION("index one past the end") {
+        auto group = loadObj("threepp_oob_off_by_one.obj", threeVerts + "f 1 2 4\n");
+        REQUIRE(group);
+        CHECK(group->children.empty());
+    }
+
+    SECTION("index 0 is never valid in OBJ") {
+        // The old arithmetic mapped 0 to exactly one-past-the-end.
+        auto group = loadObj("threepp_oob_zero.obj", threeVerts + "f 0 1 2\n");
+        REQUIRE(group);
+        CHECK(group->children.empty());
+    }
+
+    SECTION("negative index below the start") {
+        auto group = loadObj("threepp_oob_neg.obj", threeVerts + "f -1 -2 -99\n");
+        REQUIRE(group);
+        CHECK(group->children.empty());
+    }
+
+    SECTION("a bad face does not discard the good ones") {
+        auto group = loadObj("threepp_oob_mixed.obj",
+                             threeVerts + "f 1 2 3\n"
+                                          "f 1 2 999999\n"
+                                          "f 3 2 1\n");
+        // Two surviving triangles -> six vertices.
+        CHECK(positionCount(group) == 6);
+    }
+
+    SECTION("out-of-range uv drops the whole face, keeping buffers in step") {
+        // Emitting the position and then bailing on the uv would leave
+        // position/uv permanently misaligned for the rest of the file.
+        auto group = loadObj("threepp_oob_uv.obj",
+                             threeVerts +
+                                     "vt 0.0 0.0\n"
+                                     "f 1/1 2/1 3/9\n"
+                                     "f 1/1 2/1 3/1\n");
+        REQUIRE(group);
+        REQUIRE(group->children.size() == 1);
+        auto* mesh = group->children.front()->as<Mesh>();
+        REQUIRE(mesh);
+        auto geometry = mesh->geometry();
+        REQUIRE(geometry);
+        auto* position = geometry->getAttribute<float>("position");
+        auto* uv = geometry->getAttribute<float>("uv");
+        REQUIRE(position);
+        REQUIRE(uv);
+        CHECK(position->count() == 3);// only the second face survived
+        CHECK(uv->count() == position->count());
+    }
+}
+
+TEST_CASE("OBJLoader resolves negative face indices relative to the end") {
+
+    // -1 is the last vertex declared so far, so `f -3 -2 -1` is `f 1 2 3`.
+    auto relative = loadObj("threepp_neg_rel.obj",
+                            "v 0.0 0.0 0.0\n"
+                            "v 1.0 0.0 0.0\n"
+                            "v 0.0 1.0 0.0\n"
+                            "f -3 -2 -1\n");
+    auto absolute = loadObj("threepp_neg_abs.obj",
+                            "v 0.0 0.0 0.0\n"
+                            "v 1.0 0.0 0.0\n"
+                            "v 0.0 1.0 0.0\n"
+                            "f 1 2 3\n");
+
+    REQUIRE(positionCount(relative) == 3);
+    REQUIRE(positionCount(absolute) == 3);
+
+    auto posOf = [](const std::shared_ptr<Group>& g) {
+        return g->children.front()->as<Mesh>()->geometry()->getAttribute<float>("position")->array();
+    };
+    CHECK(posOf(relative) == posOf(absolute));
 }


### PR DESCRIPTION
This PR aims to improve on various lifetime and ownership discipline in the codebase.

1. OBJLoader read out of bounds on any malformed face index. parseVertexOrNormalIndex/parseUvIndex turned a file-supplied integer straight into an offset and addVertex/addUv/addNormal/addColor dereferenced it with operator[]. `f 1 2 999999` in a 3-vertex file read megabytes past the end; a negative index below the start wrapped size_t. Replaced with resolveIndex(), which range-checks both the 1-based and the negative (relative-to-end) forms and rejects 0 -- previously mapped to exactly one-past-the-end. A face with any unresolvable index is now dropped whole, and the count is reported once after parsing.

   Two further bugs surfaced in the same function while fixing this:

   - addColor() was called with whatever ia/ib/ic held after the uv block had reassigned them at stride 2, indexing a stride-3 color array. Vertex colors are now resolved from the vertex token at stride 3.
   - addPointGeometry() passed the token count of the current `p` line as the array length, so every negative index in a point element resolved against the wrong bound. Now uses vertices.size().

   Indices are resolved for all attributes BEFORE anything is appended:
   the per-vertex arrays are written in parallel, so emitting a position
   and then bailing on a bad uv left them permanently out of step.

2. CPU raycasting was not reentrant. Mesh::raycast and Triangle's barycentric helpers kept their scratch in 17 mutable file-scope statics, so two threads calling Raycaster::intersectObjects raced. Now thread_local, matching the existing idiom in MathUtils.cpp. Same treatment for the LOD and light-helper update paths.

   BufferAttribute's two shared `inline static` scratch vectors are instead now plain function locals -- applyMatrix3/4, applyNormalMatrix and transformDirection are exactly the calls a loader or sensor makes off the main thread, and a 12-byte stack local beats thread-local storage.

3. DLSS shut down NGX without initialising it, or twice. ngxInited_ was set before NVSDK_NGX_VULKAN_Init, so an Init failure left it true (the destructor then called Shutdown1 on uninitialised NGX) and the capability / parameter failures shut down inline AND left it true (double shutdown). Split into ngxTried_ (don't retry) and ngxInited_ (owes a Shutdown1). Both paths are the non-RTX fallback, i.e. the common case on a machine without DLSS.

4. Two Vulkan teardown leaks.
   - gbufDummyMS_, the five 1x1 stand-ins bound to the MS gbuffer slots when MSAA is off, were created once and destroyed nowhere: 5 VkImage + 5 VkImageView per device.
   - BlasRecord teardown was inlined at all six sites that own one, and five of the six had drifted -- they omitted `color`, leaking the per-vertex color buffer for every skinned / tet / displaced / grass / morphed mesh. Replaced with one destroyBlasRecord() helper, so a new Buffer on BlasRecord can only be missed in one place.

5. Two PhysX use-after-frees, both reachable from Python.
   - removeActor() scrubbed objBindings_ but not instBindings_, releasing an actor the instanced-mesh sync still dereferenced. The slot is now nulled rather than erased: instance i mirrors actors[i], so compacting would silently repoint every later instance at a different body. Sync loops skip nulled slots; a binding is dropped once all its actors are gone.
   - onPreSubstep/onPostSubstep had no unregister, and PhysxVehicle / PhysxVehicleEngineDrive register a callback capturing `this`. A destroyed vehicle left the world calling into freed memory on the next step. Both now return a SubstepHandle, removeSubstepCallback() takes it, and both vehicles unregister first thing in their destructors. substep() iterates by index so a callback may register or remove one. Exposed to Python as remove_substep_callback().

Tests: six new OBJLoader cases covering out-of-range positive, off-by-one, zero, negative-below-start, mixed valid/invalid, and out-of-range uv (asserting position/uv stay in step), plus one pinning negative indices as equivalent to their absolute form. Every one of these is a heap out-of-bounds read before the fix.
