### PR TITLE
Fix four Object3D / BufferAttribute API footguns

### DIFF
--- a/include/threepp/core/BufferAttribute.hpp
+++ b/include/threepp/core/BufferAttribute.hpp
@@ -101,6 +101,10 @@ namespace threepp {
             return array_;
         }
 
+        // Copy one element from `attribute` into this attribute.
+        // NB: this used to `return &this;` — taking the address of a prvalue,
+        // which is ill-formed. It only ever compiled because nothing instantiated
+        // it; the first caller would have been a hard error.
         TypedBufferAttribute<T>& copyAt(unsigned int index1, const TypedBufferAttribute<T>& attribute, unsigned int index2) {
 
             index1 *= this->itemSize_;
@@ -111,7 +115,7 @@ namespace threepp {
                 this->array_[index1 + i] = attribute.array_[index2 + i];
             }
 
-            return &this;
+            return *this;
         }
 
         TypedBufferAttribute<T>& copyArray(const std::vector<T>& array) {

--- a/include/threepp/core/Object3D.hpp
+++ b/include/threepp/core/Object3D.hpp
@@ -108,7 +108,9 @@ namespace threepp {
         bool autoLod = true;
         // This value allows the default rendering order of scene graph objects to be overridden although opaque and transparent objects remain sorted independently.
         // When this property is set for an instance of Group, all descendants objects will be sorted and rendered together. Sorting is from lowest to highest renderOrder. Default value is 0.
-        unsigned int renderOrder = 0;
+        // Signed, as in three.js: a negative value pushes an object behind the
+        // default-ordered ones (the usual way to pin a skybox or backdrop).
+        int renderOrder = 0;
 
         std::unordered_map<std::string, std::any> userData;
 
@@ -183,25 +185,37 @@ namespace threepp {
         virtual void remove(Object3D& object);
 
         // Removes this object from its current parent.
-        void removeFromParent();
+        //
+        // Returns the owning reference if the parent held one, so a caller can
+        // keep the object alive across the call:
+        //     auto kept = obj->removeFromParent();   // obj stays valid
+        // Discarding the result on an object the parent owned destroys it — the
+        // return value is the only thing keeping it alive. Returns nullptr when
+        // the object was attached with addRef() (parent never owned it) or had
+        // no parent.
+        std::shared_ptr<Object3D> removeFromParent();
 
         // Removes all child objects.
         void clear();
 
         // Searches through an object and its children, starting with the object itself, and returns the first with a matching name.
         // Note that for most objects the name is an empty string by default. You will have to set it manually to make use of this method.
+        //
+        // When T is given, the search is for the first node matching BOTH the name
+        // and the type. It used to resolve the first node matching the name only
+        // and then cast it, so getObjectByName<Mesh>("wheel") returned nullptr
+        // whenever any non-Mesh node named "wheel" (a Group, a Bone) came first in
+        // traversal order — a silent miss on a name that really was present.
         template<class T = Object3D>
         T* getObjectByName(const std::string& name) {
-            if (this->name == name) return dynamic_cast<T*>(this);
+
+            if (this->name == name) {
+                if (auto* self = dynamic_cast<T*>(this)) return self;
+            }
 
             for (const auto& child : this->children) {
 
-                auto object = child->getObjectByName(name);
-
-                if (object) {
-
-                    return dynamic_cast<T*>(object);
-                }
+                if (auto* found = child->getObjectByName<T>(name)) return found;
             }
 
             return nullptr;
@@ -331,6 +345,13 @@ namespace threepp {
 
     private:
         inline static unsigned int _object3Did{0};
+
+        // Unlink `object` from this node: drop it from `children`, clear its
+        // parent, fire "remove", and hand back the owning reference if this node
+        // held one. The caller decides whether that reference dies (destroying
+        // the object) or is kept. Shared by remove() and removeFromParent() so
+        // detach order is defined in exactly one place.
+        std::shared_ptr<Object3D> detachChild(Object3D& object);
 
         std::vector<std::shared_ptr<Object3D>> children_;
 

--- a/src/threepp/controls/TransformControlsGizmo.hpp
+++ b/src/threepp/controls/TransformControlsGizmo.hpp
@@ -423,7 +423,11 @@ public:
                     throw std::runtime_error("GizmoObject::setupGizmo: invalid type");
                 }
 
-                object->renderOrder = std::numeric_limits<int>::infinity();
+                // Draw the gizmo last so it is never occluded by the scene.
+                // This read `numeric_limits<int>::infinity()`, which for an
+                // integral type is not infinity at all — it returns int{}, i.e.
+                // 0 — so the gizmo was silently left at the DEFAULT render order.
+                object->renderOrder = std::numeric_limits<int>::max();
 
                 object->position.set(0, 0, 0);
                 object->rotation.set(0, 0, 0);

--- a/src/threepp/core/Object3D.cpp
+++ b/src/threepp/core/Object3D.cpp
@@ -231,37 +231,57 @@ void Object3D::addRef(Object3D& object) {
     object.dispatchEvent("added");
 }
 
-void Object3D::remove(Object3D& object) {
+std::shared_ptr<Object3D> Object3D::detachChild(Object3D& object) {
+
+    // Take the owning reference out of children_ FIRST, into a local. Erasing it
+    // in place would run the shared_ptr destructor right here — destroying the
+    // object while we still have to clear its parent and fire "remove", and while
+    // the caller still holds the reference it passed in. Moving it out keeps the
+    // object alive until the caller drops what we return.
+    std::shared_ptr<Object3D> owned;
+    if (const auto it = std::ranges::find_if(children_, [&object](const auto& obj) {
+            return obj.get() == &object;
+        });
+        it != children_.end()) {
+
+        owned = std::move(*it);
+        children_.erase(it);
+    }
 
     // non-owning (all children should be represented here)
-    if (const auto find = std::ranges::find_if(children, [&object](const auto& obj) {
+    if (const auto it = std::ranges::find_if(children, [&object](const auto& obj) {
             return obj == &object;
         });
-        find != children.end()) {
+        it != children.end()) {
 
-        Object3D* child = *find;
-        children.erase(find);
+        Object3D* child = *it;
+        children.erase(it);
 
         child->parent = nullptr;
         child->dispatchEvent("remove", child);
     }
 
-    // owning
-    if (const auto find = std::ranges::find_if(children_, [&object](const auto& obj) {
-            return obj.get() == &object;
-        });
-        find != children_.end()) {
-
-        children_.erase(find);
-    }
+    return owned;
 }
 
-void Object3D::removeFromParent() {
+void Object3D::remove(Object3D& object) {
 
-    if (parent) {
+    // The returned reference dies at the end of this statement, so an object the
+    // parent solely owned is destroyed here — but only after it has been fully
+    // unlinked and its listeners have run against a live object.
+    detachChild(object);
+}
 
-        parent->remove(*this);
-    }
+std::shared_ptr<Object3D> Object3D::removeFromParent() {
+
+    if (!parent) return nullptr;
+
+    // Hand the owning reference to the caller rather than dropping it inside
+    // this call: `parent->remove(*this)` used to free `this` while this frame was
+    // still executing, which is UB even though nothing touched a member
+    // afterwards. Now self-removal is safe, and `auto kept = o->removeFromParent()`
+    // is the way to detach without destroying.
+    return parent->detachChild(*this);
 }
 
 void Object3D::clear() {
@@ -541,4 +561,33 @@ Object3D::Object3D(Object3D&& source) noexcept: Object3D() {
     }
 }
 
-Object3D::~Object3D() = default;
+Object3D::~Object3D() {
+
+    // Leave no dangling references to this node.
+    //
+    // `children` is a vector of raw, non-owning pointers, and addRef() puts
+    // objects there that the parent does NOT own. Such a child can easily die
+    // first — a stack local, or a unique_ptr the caller holds — and until now the
+    // parent kept a dangling entry, so the next traverse() was a use-after-free:
+    //
+    //     { Mesh m{geo, mat}; scene->addRef(m); }   // m dies here
+    //     scene->traverse(...);                     // read of freed memory
+    //
+    // Detaching in the destructor makes that safe without changing addRef()'s
+    // non-owning contract.
+    if (parent) {
+        auto& siblings = parent->children;
+        siblings.erase(std::remove(siblings.begin(), siblings.end(), this), siblings.end());
+        parent = nullptr;
+    }
+
+    // Symmetrically: any child we do not own outlives us, so clear its parent
+    // before it can point at freed memory. Doing this in the destructor BODY also
+    // means the owned children_ (destroyed after the body, in reverse member
+    // order) already see parent == nullptr and skip the erase above — so they
+    // never reach back into a half-destroyed parent.
+    for (auto* child : children) {
+        if (child->parent == this) child->parent = nullptr;
+    }
+    children.clear();
+}

--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -507,7 +507,7 @@ struct GLRenderer::Impl {
         }
     }
 
-    void projectObject(Object3D* object, Camera* camera, unsigned int groupOrder, bool sortObjects) {
+    void projectObject(Object3D* object, Camera* camera, int groupOrder, bool sortObjects) {
         if (!object->visible) return;
 
         bool visible = object->layers.test(camera->layers);

--- a/src/threepp/renderers/common/RenderLists.cpp
+++ b/src/threepp/renderers/common/RenderLists.cpp
@@ -61,7 +61,7 @@ RenderItem* RenderList::getNextRenderItem(
         Object3D* object,
         BufferGeometry* geometry,
         Material* material,
-        unsigned int groupOrder, float z, std::optional<GeometryGroup> group) {
+        int groupOrder, float z, std::optional<GeometryGroup> group) {
 
     uint64_t progId = resolver_ ? resolver_(material) : 0;
 
@@ -104,7 +104,7 @@ void RenderList::push(
         Object3D* object,
         BufferGeometry* geometry,
         Material* material,
-        unsigned int groupOrder, float z, std::optional<GeometryGroup> group) {
+        int groupOrder, float z, std::optional<GeometryGroup> group) {
 
     auto renderItem = getNextRenderItem(object, geometry, material, groupOrder, z, group);
 
@@ -127,7 +127,7 @@ void RenderList::unshift(
         Object3D* object,
         BufferGeometry* geometry,
         Material* material,
-        unsigned int groupOrder, float z, std::optional<GeometryGroup> group) {
+        int groupOrder, float z, std::optional<GeometryGroup> group) {
 
     auto renderItem = getNextRenderItem(object, geometry, material, groupOrder, z, group);
 

--- a/src/threepp/renderers/common/RenderLists.hpp
+++ b/src/threepp/renderers/common/RenderLists.hpp
@@ -23,8 +23,11 @@ namespace threepp {
         BufferGeometry* geometry = nullptr;
         Material* material = nullptr;
         uint64_t programId = 0;  // Opaque program identifier for sort ordering
-        unsigned int groupOrder = 0;
-        unsigned int renderOrder = 0;
+        // Both signed: groupOrder is copied from Object3D::renderOrder, so an
+        // unsigned type wrapped a negative order into a huge value and sorted the
+        // object LAST instead of first.
+        int groupOrder = 0;
+        int renderOrder = 0;
         float z = 0;
         std::optional<GeometryGroup> group;
     };
@@ -50,19 +53,19 @@ namespace threepp {
                 Object3D* object,
                 BufferGeometry* geometry,
                 Material* material,
-                unsigned int groupOrder, float z, std::optional<GeometryGroup> group);
+                int groupOrder, float z, std::optional<GeometryGroup> group);
 
         void push(
                 Object3D* object,
                 BufferGeometry* geometry,
                 Material* material,
-                unsigned int groupOrder, float z, std::optional<GeometryGroup> group);
+                int groupOrder, float z, std::optional<GeometryGroup> group);
 
         void unshift(
                 Object3D* object,
                 BufferGeometry* geometry,
                 Material* material,
-                unsigned int groupOrder, float z, std::optional<GeometryGroup> group);
+                int groupOrder, float z, std::optional<GeometryGroup> group);
 
         void sort();
 

--- a/tests/core/BufferAttribute_test.cpp
+++ b/tests/core/BufferAttribute_test.cpp
@@ -1,0 +1,93 @@
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "threepp/core/BufferAttribute.hpp"
+#include "threepp/math/Matrix4.hpp"
+
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace threepp;
+
+TEST_CASE("BufferAttribute reports count from array size and itemSize") {
+
+    auto attr = FloatBufferAttribute::create(std::vector<float>{0, 1, 2, 3, 4, 5}, 3);
+
+    CHECK(attr->itemSize() == 3);
+    CHECK(attr->count() == 2);
+}
+
+TEST_CASE("BufferAttribute accessors address elements by itemSize") {
+
+    auto attr = FloatBufferAttribute::create(std::vector<float>{1, 2, 3, 4, 5, 6}, 3);
+
+    CHECK(attr->getX(0) == 1);
+    CHECK(attr->getY(0) == 2);
+    CHECK(attr->getZ(0) == 3);
+    CHECK(attr->getX(1) == 4);
+    CHECK(attr->getZ(1) == 6);
+
+    attr->setXYZ(0, 7, 8, 9);
+    CHECK(attr->getX(0) == 7);
+    CHECK(attr->getZ(0) == 9);
+    // Writing element 0 must not disturb element 1.
+    CHECK(attr->getX(1) == 4);
+}
+
+// copyAt was never instantiated, and its body ended in `return &this;` — taking
+// the address of a prvalue, which is ill-formed. The first caller would have been
+// a hard compile error, so this test is as much a compile check as a behaviour one.
+TEST_CASE("BufferAttribute copyAt copies one element between attributes") {
+
+    auto dst = FloatBufferAttribute::create(std::vector<float>{0, 0, 0, 0, 0, 0}, 3);
+    auto src = FloatBufferAttribute::create(std::vector<float>{1, 2, 3, 4, 5, 6}, 3);
+
+    auto& returned = dst->copyAt(1, *src, 0);
+
+    CHECK(&returned == dst.get());// returns *this, not the address of `this`
+
+    // Element 1 of dst now holds element 0 of src; element 0 is untouched.
+    CHECK(dst->getX(0) == 0);
+    CHECK(dst->getX(1) == 1);
+    CHECK(dst->getY(1) == 2);
+    CHECK(dst->getZ(1) == 3);
+}
+
+// applyMatrix4 and friends used to write through two shared `inline static`
+// scratch vectors, so transforming two attributes concurrently produced
+// interleaved garbage. The scratch is function-local now; this pins that.
+TEST_CASE("BufferAttribute transforms are safe on concurrent attributes") {
+
+    constexpr int kVerts = 512;
+    constexpr int kThreads = 4;
+
+    std::vector<std::unique_ptr<FloatBufferAttribute>> attrs;
+    for (int t = 0; t < kThreads; ++t) {
+        std::vector<float> data;
+        data.reserve(kVerts * 3);
+        for (int i = 0; i < kVerts; ++i) {
+            data.insert(data.end(), {static_cast<float>(t), static_cast<float>(t), static_cast<float>(t)});
+        }
+        attrs.push_back(FloatBufferAttribute::create(std::move(data), 3));
+    }
+
+    // Each thread translates its own attribute by a distinct offset.
+    std::vector<std::thread> threads;
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&attrs, t] {
+            Matrix4 m;
+            m.setPosition(static_cast<float>(100 * t), 0, 0);
+            attrs[t]->applyMatrix4(m);
+        });
+    }
+    for (auto& th : threads) th.join();
+
+    for (int t = 0; t < kThreads; ++t) {
+        const float expectedX = static_cast<float>(t) + static_cast<float>(100 * t);
+        for (int i = 0; i < kVerts; ++i) {
+            REQUIRE(attrs[t]->getX(i) == expectedX);
+            REQUIRE(attrs[t]->getY(i) == static_cast<float>(t));
+        }
+    }
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_test_executable(BufferAttribute_test)
 add_test_executable(EventDispatcher_test)
 add_test_executable(Layers_test)
 add_test_executable(Object3D_test)

--- a/tests/core/Object3D_test.cpp
+++ b/tests/core/Object3D_test.cpp
@@ -501,3 +501,139 @@ TEST_CASE("updateWorldMatrix") {
 
     REQUIRE(object->matrixWorld->elements == m.setPosition(parent->position).elements);
 }
+
+
+// ---------------------------------------------------------------------------
+// Ownership / lifetime of the scene-graph links
+// ---------------------------------------------------------------------------
+
+TEST_CASE("addRef'd child unlinks itself on destruction") {
+
+    auto parent = Object3D::create();
+
+    {
+        Object3D child;
+        parent->addRef(child);
+        REQUIRE(parent->children.size() == 1);
+    }// child dies here; it was never owned by parent
+
+    // Before the destructor unlinked itself, `children` kept a dangling raw
+    // pointer and the traverse below was a use-after-free.
+    CHECK(parent->children.empty());
+
+    int visited = 0;
+    parent->traverse([&](Object3D&) { ++visited; });
+    CHECK(visited == 1);// just the parent
+}
+
+TEST_CASE("destroying a parent clears its children's parent pointer") {
+
+    Object3D child;
+
+    {
+        auto parent = Object3D::create();
+        parent->addRef(child);
+        REQUIRE(child.parent != nullptr);
+    }// parent dies; child (not owned) outlives it
+
+    CHECK(child.parent == nullptr);
+}
+
+TEST_CASE("removeFromParent hands back ownership") {
+
+    auto parent = Object3D::create();
+    auto child = Object3D::create();
+    parent->add(child);
+
+    Object3D* raw = child.get();
+    child.reset();// the parent is now the only owner
+
+    SECTION("keeping the returned reference keeps the object alive") {
+        auto kept = raw->removeFromParent();
+        REQUIRE(kept);
+        CHECK(kept.get() == raw);
+        CHECK(kept->parent == nullptr);
+        CHECK(parent->children.empty());
+    }
+
+    SECTION("an addRef'd child reports no ownership to hand back") {
+        auto other = Object3D::create();
+        Object3D loose;
+        other->addRef(loose);
+        CHECK(loose.removeFromParent() == nullptr);
+        CHECK(other->children.empty());
+    }
+}
+
+TEST_CASE("remove fires its event against a live object") {
+
+    auto parent = Object3D::create();
+    auto child = Object3D::create();
+    parent->add(child);
+    child.reset();// parent solely owns it
+
+    Object3D* raw = parent->children.front();
+
+    bool sawEvent = false;
+    unsigned int idDuringEvent = 0;
+    LambdaEventListener listener([&](Event&) {
+        sawEvent = true;
+        idDuringEvent = raw->id;// must not be a read of freed memory
+    });
+    raw->addEventListener("remove", listener);
+
+    const unsigned int expectedId = raw->id;
+    parent->remove(*raw);
+
+    CHECK(sawEvent);
+    CHECK(idDuringEvent == expectedId);
+    CHECK(parent->children.empty());
+}
+
+// ---------------------------------------------------------------------------
+// getObjectByName
+// ---------------------------------------------------------------------------
+
+TEST_CASE("getObjectByName matches on name and type together") {
+
+    auto scene = Object3D::create();
+
+    // A non-Camera node with the wanted name comes FIRST in traversal order.
+    auto decoy = Object3D::create();
+    decoy->name = "target";
+    scene->add(decoy);
+
+    auto wanted = PerspectiveCamera::create();
+    wanted->name = "target";
+    scene->add(wanted);
+
+    // Untyped lookup finds the first name match, as before.
+    CHECK(scene->getObjectByName("target") == decoy.get());
+
+    // Typed lookup used to resolve the decoy and then fail the cast, returning
+    // nullptr even though a matching Camera was present.
+    CHECK(scene->getObjectByName<PerspectiveCamera>("target") == wanted.get());
+}
+
+TEST_CASE("getObjectByName returns null when no node matches the type") {
+
+    auto scene = Object3D::create();
+    auto child = Object3D::create();
+    child->name = "plain";
+    scene->add(child);
+
+    CHECK(scene->getObjectByName("plain") == child.get());
+    CHECK(scene->getObjectByName<PerspectiveCamera>("plain") == nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// renderOrder
+// ---------------------------------------------------------------------------
+
+TEST_CASE("renderOrder accepts negative values") {
+
+    auto object = Object3D::create();
+    object->renderOrder = -1;
+    CHECK(object->renderOrder == -1);
+    CHECK(object->renderOrder < 0);// would have wrapped huge when unsigned
+}


### PR DESCRIPTION
All four change observable behaviour, so they are split out from the mechanical memory-safety batch and land with tests.

1. ~Object3D() left dangling pointers to itself.

   `children` is a vector of raw, non-owning pointers and addRef() puts objects there that the parent does not own. Such a child can easily die first -- a stack local, a unique_ptr the caller holds -- and the destructor was `= default`, so the parent kept a dangling entry and the next traverse() was a use-after-free:

       { Mesh m{geo, mat}; scene->addRef(m); }   // m dies here
       scene->traverse(...);                     // read of freed memory

   The destructor now unlinks itself from its parent, and clears the parent pointer of every child it does not own (which would otherwise point at freed memory once the parent goes). Both happen in the destructor BODY, so the owned children_ -- destroyed afterwards in reverse member order -- already see parent == nullptr and never reach back into a half-destroyed parent.

   addRef()'s non-owning contract is unchanged; it just stops being a lifetime trap.

2. remove() destroyed the object mid-call, and removeFromParent() freed `this` while its own frame was live.

   remove() erased the owning shared_ptr in place, which ran the destructor right there -- before the child's parent was cleared and before the "remove" listeners ran, and while the caller still held the reference it had passed in. And removeFromParent() called parent->remove(*this), freeing `this` mid-method: UB, benign only because nothing touched a member afterwards.

   Both now go through one private detachChild(), which moves the owning reference out to a local before doing anything else, so unlinking and event dispatch always run against a live object.

   removeFromParent() returns that reference instead of dropping it, so self-removal is safe and detach-without-destroy is expressible:

       auto kept = obj->removeFromParent();   // obj stays valid

   Returns nullptr for an addRef()'d child (parent never owned it) or no parent. void -> shared_ptr is source-compatible: callers that ignore the result still compile, and for an object the parent solely owned, ignoring it destroys the object exactly as before.

3. getObjectByName<T> missed matches it should have found.

   It resolved the first node matching the NAME and then cast, so getObjectByName<Mesh>("wheel") returned nullptr whenever any non-Mesh node named "wheel" -- a Group, a Bone -- came first in traversal order. It now searches for the first node matching both name and type. Untyped lookup is unchanged.

4. renderOrder could not express a negative order.

   `unsigned int` in three.js's signed slot, so the standard way to pin a skybox behind everything wrapped to a huge value and sorted it LAST. Now int, along with RenderItem::renderOrder, RenderItem::groupOrder and the RenderList::push/unshift/getNextRenderItem chain -- groupOrder is copied straight from renderOrder, so leaving it unsigned would have reintroduced the wrap one layer down.

   Fixing the type surfaced a live bug at the one place that wanted an extreme value: TransformControlsGizmo set

       object->renderOrder = std::numeric_limits<int>::infinity();

   which for an integral type is not infinity -- numeric_limits<int> has has_infinity == false and infinity() returns int{}, i.e. 0. The gizmo asking to draw last was silently left at the DEFAULT render order. Now numeric_limits<int>::max().

5. TypedBufferAttribute::copyAt was ill-formed.

   Its body ended in `return &this;` -- taking the address of a prvalue -- against a `TypedBufferAttribute<T>&` return type. It compiled only because nothing ever instantiated it; the first caller would have been a hard error. Now `return *this;`.

Tests: six new Object3D cases (addRef'd child unlinks on destruction; parent destruction clears a non-owned child's parent; removeFromParent hands back ownership and reports none for an addRef'd child; "remove" fires against a live object; getObjectByName matches name AND type, and returns null when no node matches the type; renderOrder holds a negative value). Plus a new BufferAttribute_test: count/itemSize, element accessors, copyAt (a compile check as much as a behaviour one), and a threaded transform that pins the function-local scratch introduced in the previous batch.