### PR TITLE
GL: make runtime shadow-map reconfiguration actually work

### DIFF
--- a/src/threepp/renderers/GLRenderer.cpp
+++ b/src/threepp/renderers/GLRenderer.cpp
@@ -867,6 +867,8 @@ struct GLRenderer::Impl {
         materialProperties->numClippingPlanes = parameters.numClippingPlanes;
         materialProperties->numIntersection = parameters.numClipIntersection;
         materialProperties->vertexAlphas = parameters.vertexAlphas;
+        materialProperties->shadowMapEnabled = parameters.shadowMapEnabled;
+        materialProperties->shadowMapType = parameters.shadowMapType;
     }
 
     gl::GLProgram* setProgram(Camera* camera, Object3D* _scene, Material* material, Object3D* object) {
@@ -965,6 +967,22 @@ struct GLRenderer::Impl {
 
             } else if (materialProperties->vertexAlphas != vertexAlphas) {
 
+                needsProgramChange = true;
+
+            } else if (materialProperties->shadowMapEnabled !=
+                       (shadowMap.enabled && !currentRenderState->getShadowsArray().empty())) {
+
+                // USE_SHADOWMAP is a compile-time define, so toggling
+                // Renderer::shadowMap().enabled has to rebuild the program.
+                // Without this the shadow pass stopped running but the material
+                // kept sampling the shadow map, leaving the last-rendered
+                // shadows frozen on screen instead of disappearing.
+                needsProgramChange = true;
+
+            } else if (materialProperties->shadowMapEnabled && materialProperties->shadowMapType != shadowMap.type) {
+
+                // Likewise SHADOWMAP_TYPE_* — switching Basic/PCF/PCF-soft/VSM
+                // changes the sampling code, not a uniform.
                 needsProgramChange = true;
             }
 

--- a/src/threepp/renderers/gl/GLProperties.hpp
+++ b/src/threepp/renderers/gl/GLProperties.hpp
@@ -3,6 +3,7 @@
 #ifndef THREEPP_GLPROPERTIES_HPP
 #define THREEPP_GLPROPERTIES_HPP
 
+#include "threepp/constants.hpp"
 #include "threepp/scenes/Scene.hpp"
 
 #include "GLUniforms.hpp"
@@ -57,6 +58,14 @@ namespace threepp::gl {
 
         bool needsLights{};
         bool receiveShadow{};
+
+        // The shadow configuration the current program was compiled against.
+        // USE_SHADOWMAP and SHADOWMAP_TYPE_* are baked into the shader, so a
+        // runtime change to Renderer::shadowMap() has to invalidate the program —
+        // otherwise the shadow pass stops running while the material keeps
+        // sampling the (now frozen) shadow map.
+        bool shadowMapEnabled{};
+        ShadowMap shadowMapType{};
 
         unsigned int lightsStateVersion{};
 

--- a/src/threepp/renderers/gl/GLShadowMap.cpp
+++ b/src/threepp/renderers/gl/GLShadowMap.cpp
@@ -73,6 +73,12 @@ struct GLShadowMap::Impl {
     }
 
     void VSMPass(GLRenderer& _renderer, LightShadow* shadow, Camera* camera) {
+
+        // Belt and braces: the caller only reaches here for a non-point shadow
+        // with type == VSM, and render() guarantees both targets exist for that
+        // combination. Bail rather than dereference if that ever drifts again.
+        if (!shadow->map || !shadow->mapPass) return;
+
         const auto& geometry = _objects.update(fullScreenMesh.get());
 
         // vertical pass
@@ -305,30 +311,40 @@ struct GLShadowMap::Impl {
                 }
             }
 
-            if (!shadow->map && !std::dynamic_pointer_cast<PointLightShadow>(shadow) && scope->type == ShadowMap::VSM) {
+            // VSM blurs the depth map through a second target, so it needs
+            // `mapPass` and must sample with Linear; every other type compares
+            // depth directly and must NOT filter across texels. `mapPass` is
+            // therefore also the marker for "these targets were built for VSM".
+            const bool wantVsm = scope->type == ShadowMap::VSM && !std::dynamic_pointer_cast<PointLightShadow>(shadow);
+            const bool haveVsm = shadow->mapPass != nullptr;
 
-                GLRenderTarget::Options pars{};
-                pars.minFilter = Filter::Linear;
-                pars.magFilter = Filter::Linear;
-                pars.format = Format::RGBA;
+            if (shadow->map && wantVsm != haveVsm) {
 
-                shadow->map = GLRenderTarget::create(static_cast<int>(_shadowMapSize.x), static_cast<int>(_shadowMapSize.y), pars);
-                shadow->map->texture->name = light->name + ".shadowMap";
-
-                shadow->mapPass = GLRenderTarget::create(static_cast<int>(_shadowMapSize.x), static_cast<int>(_shadowMapSize.y), pars);
-
-                shadow->camera->updateProjectionMatrix();
+                // The shadow type changed after the targets were allocated.
+                // Previously the allocation was guarded on `!shadow->map` alone,
+                // so switching TO VSM at runtime left mapPass null and VSMPass()
+                // dereferenced it — an outright crash. Switching AWAY from VSM
+                // silently kept the Linear filtering, softening every other type.
+                // Drop both and rebuild for the current type.
+                shadow->dispose();
+                shadow->map.reset();
+                shadow->mapPass.reset();
             }
 
             if (!shadow->map) {
 
                 GLRenderTarget::Options pars{};
-                pars.minFilter = Filter::Nearest;
-                pars.magFilter = Filter::Nearest;
+                pars.minFilter = wantVsm ? Filter::Linear : Filter::Nearest;
+                pars.magFilter = wantVsm ? Filter::Linear : Filter::Nearest;
                 pars.format = Format::RGBA;
 
                 shadow->map = GLRenderTarget::create(static_cast<int>(_shadowMapSize.x), static_cast<int>(_shadowMapSize.y), pars);
                 shadow->map->texture->name = light->name + ".shadowMap";
+
+                if (wantVsm) {
+
+                    shadow->mapPass = GLRenderTarget::create(static_cast<int>(_shadowMapSize.x), static_cast<int>(_shadowMapSize.y), pars);
+                }
 
                 shadow->camera->updateProjectionMatrix();
             }

--- a/tests/renderers/gl/CMakeLists.txt
+++ b/tests/renderers/gl/CMakeLists.txt
@@ -28,4 +28,5 @@ if (THREEPP_WITH_GLFW)
 
     add_gl_render_test(GLRenderer_test)
     add_gl_render_test(GLFurnace_test)
+    add_gl_render_test(GLShadowMap_test)
 endif ()

--- a/tests/renderers/gl/GLShadowMap_test.cpp
+++ b/tests/renderers/gl/GLShadowMap_test.cpp
@@ -1,0 +1,167 @@
+// Shadow-map runtime reconfiguration.
+//
+// Renderer::shadowMap() is mutable at runtime (the ImGui RendererSettings panel
+// exposes it), and both `enabled` and `type` feed compile-time defines
+// (USE_SHADOWMAP, SHADOWMAP_TYPE_*) plus the render-target layout. Changing them
+// after the first frame therefore has to invalidate material programs and, for
+// VSM, reallocate the shadow targets.
+
+#include "gl_test_helpers.hpp"
+
+#include "threepp/lights/AmbientLight.hpp"
+#include "threepp/lights/DirectionalLight.hpp"
+#include "threepp/materials/MeshStandardMaterial.hpp"
+
+namespace {
+
+    // A lit plane with a box floating above it: the box casts a shadow onto the
+    // plane, so "how dark is the darkest region" distinguishes shadowed from
+    // unshadowed rendering.
+    struct ShadowScene {
+        std::shared_ptr<Scene> scene;
+        std::shared_ptr<PerspectiveCamera> camera;
+    };
+
+    ShadowScene makeShadowScene() {
+        auto scene = Scene::create();
+        scene->background = Color(0, 0, 0);
+
+        auto light = DirectionalLight::create(0xffffff, 3.f);
+        light->position.set(2, 6, 2);
+        light->castShadow = true;
+        scene->add(light);
+
+        // A little ambient so the unshadowed floor is clearly brighter than the
+        // shadowed part rather than both being near-black.
+        scene->add(AmbientLight::create(0x202020));
+
+        auto floorMat = MeshStandardMaterial::create();
+        floorMat->color = Color(1, 1, 1);
+        floorMat->roughness = 1.f;
+        floorMat->metalness = 0.f;
+        auto floor = Mesh::create(PlaneGeometry::create(20, 20), floorMat);
+        floor->rotation.x = -math::PI / 2.f;
+        floor->receiveShadow = true;
+        scene->add(floor);
+
+        auto boxMat = MeshStandardMaterial::create();
+        boxMat->color = Color(1, 1, 1);
+        auto box = Mesh::create(BoxGeometry::create(2, 2, 2), boxMat);
+        box->position.set(0, 2, 0);
+        box->castShadow = true;
+        scene->add(box);
+
+        auto camera = PerspectiveCamera::create(50, 1.f, 0.1f, 100.f);
+        camera->position.set(0, 7, 9);
+        camera->lookAt(Vector3{0, 0, 0});
+
+        return {scene, camera};
+    }
+
+    std::vector<unsigned char> renderOnce(GLRenderer& renderer, ShadowScene& s) {
+        renderer.setClearColor(Color(0, 0, 0));
+        renderer.render(*s.scene, *s.camera);
+        return renderer.readRGBPixels();
+    }
+
+}// namespace
+
+TEST_CASE("Shadows disappear when shadowMap.enabled is turned off") {
+
+    auto s = makeShadowScene();
+
+    GLRenderer renderer(glCanvas());
+    renderer.shadowMap().enabled = true;
+    renderer.shadowMap().type = ShadowMap::PFC;
+
+    const auto withShadows = renderOnce(renderer, s);
+    REQUIRE(withShadows.size() == DATA_SIZE);
+    const int darkWithShadows = countDarkPixels(withShadows);
+
+    // Sanity: the scene must actually cast a shadow, or the test below is vacuous.
+    REQUIRE(darkWithShadows > 0);
+
+    // Turn shadows off at runtime, exactly as the settings panel does.
+    renderer.shadowMap().enabled = false;
+    renderer.shadowMap().needsUpdate = true;
+
+    const auto withoutShadows = renderOnce(renderer, s);
+    REQUIRE(withoutShadows.size() == DATA_SIZE);
+    const int darkWithoutShadows = countDarkPixels(withoutShadows);
+
+    INFO("dark pixels: shadows on = " << darkWithShadows
+                                      << ", shadows off = " << darkWithoutShadows);
+
+    // The shadowed region must be gone. Before the fix, `needsProgramChange` did
+    // not consider the shadow config, so the material kept its USE_SHADOWMAP
+    // program and went on sampling the (no longer updated) shadow map — the
+    // shadow stayed on screen, merely frozen, and this count did not drop.
+    CHECK(darkWithoutShadows < darkWithShadows / 2);
+
+    renderer.dispose();
+}
+
+TEST_CASE("Shadows come back when shadowMap.enabled is turned on again") {
+
+    auto s = makeShadowScene();
+
+    GLRenderer renderer(glCanvas());
+    renderer.shadowMap().enabled = false;
+
+    const int darkOff = countDarkPixels(renderOnce(renderer, s));
+
+    renderer.shadowMap().enabled = true;
+    renderer.shadowMap().needsUpdate = true;
+
+    const int darkOn = countDarkPixels(renderOnce(renderer, s));
+
+    INFO("dark pixels: off first = " << darkOff << ", then on = " << darkOn);
+    CHECK(darkOn > darkOff);
+
+    renderer.dispose();
+}
+
+TEST_CASE("Switching shadow type at runtime does not crash") {
+
+    // The render targets are allocated on the first shadow render, and VSM needs
+    // a second target (mapPass) plus Linear filtering. Guarding that allocation
+    // on `!shadow->map` alone meant a type switch after the first frame left
+    // mapPass null, and the VSM blur pass dereferenced it.
+    const ShadowMap order[] = {ShadowMap::PFC, ShadowMap::VSM, ShadowMap::Basic,
+                               ShadowMap::VSM, ShadowMap::PFCSoft, ShadowMap::VSM};
+
+    auto s = makeShadowScene();
+
+    GLRenderer renderer(glCanvas());
+    renderer.shadowMap().enabled = true;
+
+    for (const auto type : order) {
+        renderer.shadowMap().type = type;
+        renderer.shadowMap().needsUpdate = true;
+
+        const auto px = renderOnce(renderer, s);
+        REQUIRE(px.size() == DATA_SIZE);
+        // Something was drawn — a blank frame would mean the shadow pass had
+        // clobbered the scene render.
+        CHECK(countNonBlack(px) > 0);
+    }
+
+    renderer.dispose();
+}
+
+TEST_CASE("VSM as the very first shadow type also works") {
+
+    // Covers the other allocation order: VSM chosen before any shadow render, so
+    // both targets are created by the VSM branch up front.
+    auto s = makeShadowScene();
+
+    GLRenderer renderer(glCanvas());
+    renderer.shadowMap().enabled = true;
+    renderer.shadowMap().type = ShadowMap::VSM;
+
+    const auto px = renderOnce(renderer, s);
+    REQUIRE(px.size() == DATA_SIZE);
+    CHECK(countNonBlack(px) > 0);
+
+    renderer.dispose();
+}


### PR DESCRIPTION
Two bugs reported from the ImGui RendererSettings panel: disabling shadows left them on screen (merely frozen), and switching the type to VSM crashed.

1. Toggling shadowMap.enabled did not rebuild material programs.

   USE_SHADOWMAP and SHADOWMAP_TYPE_* are #defines baked into the shader at compile time, and they ARE part of the program cache key -- but setProgram()'s needsProgramChange chain never looked at the shadow config. It checked material version, lights version, output encoding, instancing, skinning, envMap, fog, clipping planes and vertexAlphas, so getProgram() was never re-entered on a shadow-config change and materialProperties->currentProgram stayed as compiled.

   Turning shadows OFF therefore stopped the shadow pass from running while the material went on sampling the shadow map, leaving the last-rendered shadows frozen in place. Turning them ON from a start-disabled state was equally broken in the other direction: no USE_SHADOWMAP in the program, so no shadows ever appeared.

   MaterialProperties now records the shadowMapEnabled / shadowMapType the current program was built against, and needsProgramChange compares both.

2. Switching shadow type after the first frame crashed on VSM.

   The shadow render targets were allocated on the first shadow render, and the VSM branch -- which additionally allocates shadow->mapPass and needs Linear filtering -- was guarded on `!shadow->map` together with the type check. So with any non-VSM type active on the first frame (PCF is the default), `map` was created and `mapPass` left null; switching to VSM afterwards skipped the allocation entirely because `map` already existed, and VSMPass() then dereferenced the null mapPass at

       shadowMaterialHorizontal->uniforms.at("shadow_pass")
               .setValue(shadow->mapPass->texture.get());

   Switching AWAY from VSM was wrong too, just silently: the targets kept Linear filtering, which softens the depth comparison for Basic/PCF/ PCF-soft.

   mapPass is created only for VSM, so its presence doubles as "these targets were built for VSM". The two allocation blocks are now one: if the wanted mode disagrees with the built mode, dispose and rebuild with the right filtering and the right number of targets. VSMPass() also returns early if either target is missing, rather than dereferencing.

Tests: new tests/renderers/gl/GLShadowMap_test.cpp -- shadows vanish when disabled, come back when re-enabled, a Basic/PCF/PCF-soft/VSM switching sequence does not crash, and VSM chosen up front still works.

