### PR TITLE
Test/animation

### DIFF
--- a/include/threepp/animation/KeyframeTrack.hpp
+++ b/include/threepp/animation/KeyframeTrack.hpp
@@ -80,7 +80,10 @@ namespace threepp {
         std::string name_;
         std::vector<float> times_;
         std::vector<float> values_;
-        Interpolation interpolation_;
+        // Initialised here as well as in setInterpolation(): the constructor
+        // always calls setInterpolation, but a member holding an enum should
+        // never be able to start out indeterminate.
+        Interpolation interpolation_{Interpolation::Linear};
 
         std::function<std::unique_ptr<Interpolant>(const Sample&, const Sample&, int, Sample*)> createInterpolant_;
 

--- a/include/threepp/animation/tracks/QuaternionKeyframeTrack.hpp
+++ b/include/threepp/animation/tracks/QuaternionKeyframeTrack.hpp
@@ -10,7 +10,12 @@ namespace threepp {
     class QuaternionKeyframeTrack: public KeyframeTrack {
 
     public:
-        QuaternionKeyframeTrack(const std::string& name, const std::vector<float>& times, const std::vector<float>& values, const std::optional<Interpolation>& interpolation = {})
+        // `interpolation` is accepted for signature parity with the other tracks
+        // but deliberately IGNORED: rotations must be slerped, and only the
+        // Linear path routes through QuaternionLinearInterpolant below.
+        // Discrete or Smooth would interpolate the four components
+        // independently and denormalise the quaternion.
+        QuaternionKeyframeTrack(const std::string& name, const std::vector<float>& times, const std::vector<float>& values, const std::optional<Interpolation>& = {})
             : KeyframeTrack(name, times, values, Interpolation::Linear) {}
 
         [[nodiscard]] std::string ValueTypeName() const override {

--- a/include/threepp/animation/tracks/QuaternionKeyframeTrack.hpp
+++ b/include/threepp/animation/tracks/QuaternionKeyframeTrack.hpp
@@ -10,13 +10,8 @@ namespace threepp {
     class QuaternionKeyframeTrack: public KeyframeTrack {
 
     public:
-        // `interpolation` is accepted for signature parity with the other tracks
-        // but deliberately IGNORED: rotations must be slerped, and only the
-        // Linear path routes through QuaternionLinearInterpolant below.
-        // Discrete or Smooth would interpolate the four components
-        // independently and denormalise the quaternion.
-        QuaternionKeyframeTrack(const std::string& name, const std::vector<float>& times, const std::vector<float>& values, const std::optional<Interpolation>& = {})
-            : KeyframeTrack(name, times, values, Interpolation::Linear) {}
+        QuaternionKeyframeTrack(const std::string& name, const std::vector<float>& times, const std::vector<float>& values, const std::optional<Interpolation>& interpolation = {})
+            : KeyframeTrack(name, times, values, sanitized(interpolation)) {}
 
         [[nodiscard]] std::string ValueTypeName() const override {
 
@@ -26,6 +21,27 @@ namespace threepp {
         std::unique_ptr<Interpolant> InterpolantFactoryMethodLinear(const Sample& times, const Sample& values, int valueSize, Sample* result) override {
 
             return std::make_unique<QuaternionLinearInterpolant>(times, values, valueSize, result);
+        }
+
+    private:
+        // Which interpolation modes make sense for a rotation:
+        //
+        //   Discrete — fine. It copies a keyframe verbatim, so the quaternion
+        //              stays exactly as authored. This is glTF's STEP, and the
+        //              track used to force it to Linear, which is why STEP
+        //              rotation animations played smoothly instead of snapping.
+        //   Linear   — routes through QuaternionLinearInterpolant (slerp) above.
+        //   Smooth   — NOT safe: a cubic evaluates the four components
+        //              independently and denormalises the rotation. Coerced to
+        //              Linear.
+        //
+        // Unspecified defaults to Linear rather than KeyframeTrack's global
+        // default, since a rotation should slerp unless told otherwise.
+        static std::optional<Interpolation> sanitized(const std::optional<Interpolation>& interpolation) {
+
+            if (interpolation == Interpolation::Discrete) return Interpolation::Discrete;
+
+            return Interpolation::Linear;
         }
     };
 

--- a/include/threepp/animation/tracks/VectorKeyframeTrack.hpp
+++ b/include/threepp/animation/tracks/VectorKeyframeTrack.hpp
@@ -11,8 +11,11 @@ namespace threepp {
     class VectorKeyframeTrack: public KeyframeTrack {
 
     public:
+        // `interpolation` was accepted and then silently dropped — asking for
+        // Discrete or Smooth quietly gave you the default instead, with no
+        // diagnostic. Forward it.
         VectorKeyframeTrack(const std::string& name, const std::vector<float>& times, const std::vector<float>& values, const std::optional<Interpolation>& interpolation = {})
-            : KeyframeTrack(name, times, values) {}
+            : KeyframeTrack(name, times, values, interpolation) {}
 
         [[nodiscard]] std::string ValueTypeName() const override {
 

--- a/include/threepp/math/Interpolant.hpp
+++ b/include/threepp/math/Interpolant.hpp
@@ -22,7 +22,12 @@ namespace threepp {
     class Interpolant {
 
     public:
-        InterpolantSettings* settings;
+        // Optional per-instance override of the ending behaviour; null means
+        // "use DefaultSettings_". It had no initialiser and was never assigned by
+        // the constructor, so getSettings_() read an indeterminate pointer and
+        // then DEREFERENCED it — the boundary intervals of CubicInterpolant were
+        // reading whatever happened to be on the stack.
+        InterpolantSettings* settings = nullptr;
 
         Interpolant(
                 Sample parameterPositions,

--- a/include/threepp/math/interpolants/CubicInterpolant.hpp
+++ b/include/threepp/math/interpolants/CubicInterpolant.hpp
@@ -18,14 +18,31 @@ namespace threepp {
         }
 
         void intervalChanged_(size_t i1, float t0, float t1) override {
-            const auto pp = this->parameterPositions;
-            auto iPrev = i1 - 2;
-            auto iNext = i1 + 1;
+            // Reference, not a copy: this ran on every interval change and was
+            // duplicating the whole key-time array each time.
+            const auto& pp = this->parameterPositions;
+            const size_t n = pp.size();
 
-            auto tPrev = pp[iPrev],
-                 tNext = pp[iNext];
+            // three.js finds the ends of the curve by reading pp[i1-2] and
+            // pp[i1+1] and testing the result for `undefined`, which JS returns
+            // for an out-of-range index. Ported literally, those are OUT-OF-BOUNDS
+            // vector reads: i1-2 underflows size_t to SIZE_MAX on the first
+            // interval, and i1+1 runs one past the end on the last. The values
+            // they produced were essentially never NaN, so the boundary branches
+            // below never fired and the end intervals computed their weights from
+            // adjacent heap memory — giving values in the thousands, and NaN when
+            // the bogus tPrev happened to equal t0. Detect the ends by index
+            // instead; the NaN checks were only ever standing in for that.
+            const bool hasPrev = i1 >= 2;
+            const bool hasNext = i1 + 1 < n;
 
-            if (std::isnan(tPrev)) {
+            size_t iPrev = hasPrev ? i1 - 2 : i1;
+            size_t iNext = hasNext ? i1 + 1 : i1;
+
+            float tPrev = hasPrev ? pp[iPrev] : 0.f;
+            float tNext = hasNext ? pp[iNext] : 0.f;
+
+            if (!hasPrev) {
 
                 switch (this->getSettings_()->endingStart) {
 
@@ -53,7 +70,7 @@ namespace threepp {
                 }
             }
 
-            if (std::isnan(tNext)) {
+            if (!hasNext) {
 
                 switch (this->getSettings_()->endingEnd) {
 
@@ -130,7 +147,10 @@ namespace threepp {
         float _weightNext = -0;
         float _offsetNext = -0;
 
-        InterpolantSettings DefaultSettings_;
+        // NB: no DefaultSettings_ member here. There used to be one, which
+        // SHADOWED Interpolant::DefaultSettings_ — so the constructor's
+        // ZeroCurvature assignment landed on the derived copy while
+        // getSettings_() kept reading the base's still-empty optional.
     };
 
 }// namespace threepp

--- a/src/threepp/animation/KeyframeTrack.cpp
+++ b/src/threepp/animation/KeyframeTrack.cpp
@@ -274,5 +274,12 @@ void KeyframeTrack::setInterpolation(Interpolation interpolation) {
         return;
     }
 
+    // Record the mode, not just the factory. This assignment was missing
+    // entirely, and interpolation_ has no default initialiser, so every track
+    // ever built read an INDETERMINATE value out of getInterpolation(). That is
+    // undefined behaviour, and it is observable: optimize() branches on
+    // `getInterpolation() == Smooth` to decide whether to drop redundant
+    // keyframes, and the Python binding exposes it as `track.interpolation`.
+    interpolation_ = interpolation;
     createInterpolant_ = *factoryMethod;
 }

--- a/src/threepp/loaders/GLTFLoader.cpp
+++ b/src/threepp/loaders/GLTFLoader.cpp
@@ -1960,8 +1960,14 @@ namespace threepp {
                             track = std::make_shared<VectorKeyframeTrack>(
                                     nodeName + ".position", times, values, interp);
                         } else if (path == "rotation") {
+                            // Pass interp here too. glTF STEP rotations were
+                            // silently played as slerp, so a "Step Rotation"
+                            // animation swept smoothly instead of snapping
+                            // between keys. QuaternionKeyframeTrack accepts
+                            // Discrete and Linear and coerces Smooth to Linear,
+                            // since a cubic would denormalise the quaternion.
                             track = std::make_shared<QuaternionKeyframeTrack>(
-                                    nodeName + ".quaternion", times, values);
+                                    nodeName + ".quaternion", times, values, interp);
                         } else if (path == "scale") {
                             track = std::make_shared<VectorKeyframeTrack>(
                                     nodeName + ".scale", times, values, interp);

--- a/src/threepp/math/Interpolant.cpp
+++ b/src/threepp/math/Interpolant.cpp
@@ -9,6 +9,12 @@ Interpolant::Interpolant(Sample parameterPositions, Sample sampleValues, int sam
       valueSize(sampleSize) {
 
     if (resultBuffer) {
+        // Size the caller's buffer if it is too small. interpolate_() writes
+        // valueSize floats into it unconditionally, so an under-sized (or empty)
+        // buffer was a silent out-of-bounds write rather than an error.
+        if (resultBuffer->size() < static_cast<std::size_t>(sampleSize)) {
+            resultBuffer->resize(sampleSize);
+        }
         this->resultBuffer = resultBuffer;
     } else {
         this->_resultBuffer.resize(sampleSize);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ function(add_test_executable name)
     target_compile_definitions(${name} PRIVATE DATA_FOLDER="${THREEPP_DATA_DIR}")
 endfunction()
 
+add_subdirectory(animation)
 add_subdirectory(cameras)
 add_subdirectory(core)
 add_subdirectory(geometries)

--- a/tests/animation/AnimationMixer_test.cpp
+++ b/tests/animation/AnimationMixer_test.cpp
@@ -1,0 +1,313 @@
+// End-to-end animation: clip -> mixer -> action -> PropertyBinding -> Object3D.
+//
+// The whole stack was untested. These drive real scene-graph properties through
+// AnimationMixer::update and assert the resulting transforms, which is the only
+// way to cover PropertyBinding (parses "<node>.<property>" and resolves it
+// through a pile of dynamic_casts) and PropertyMixer (accumulates weighted
+// contributions from several actions).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "threepp/animation/AnimationAction.hpp"
+#include "threepp/animation/AnimationClip.hpp"
+#include "threepp/animation/AnimationMixer.hpp"
+#include "threepp/animation/tracks/NumberKeyframeTrack.hpp"
+#include "threepp/animation/tracks/QuaternionKeyframeTrack.hpp"
+#include "threepp/animation/tracks/VectorKeyframeTrack.hpp"
+#include "threepp/objects/Group.hpp"
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+using namespace threepp;
+using Catch::Matchers::WithinAbs;
+
+namespace {
+
+    struct Rig {
+        std::shared_ptr<Group> root;
+        Object3D* node;
+    };
+
+    // A named node under a root, matching how loaders name tracks:
+    // "<nodeName>.position".
+    Rig makeRig(const std::string& nodeName = "Cube") {
+        auto root = Group::create();
+        auto child = Object3D::create();
+        child->name = nodeName;
+        root->add(child);
+        return {root, root->children.front()};
+    }
+
+    // position track: (0,0,0) at t=0 -> (10,20,30) at t=1
+    std::shared_ptr<AnimationClip> makeMoveClip(const std::string& nodeName = "Cube",
+                                                float duration = 1.f) {
+        std::vector<std::shared_ptr<KeyframeTrack>> tracks{
+                std::make_shared<VectorKeyframeTrack>(
+                        nodeName + ".position",
+                        std::vector<float>{0.f, duration},
+                        std::vector<float>{0.f, 0.f, 0.f, 10.f, 20.f, 30.f})};
+        return std::make_shared<AnimationClip>("move", duration, tracks);
+    }
+
+}// namespace
+
+TEST_CASE("A played clip drives the bound object's position") {
+
+    auto rig = makeRig();
+    AnimationMixer mixer(*rig.root);
+
+    auto* action = mixer.clipAction(makeMoveClip());
+    REQUIRE(action);
+    action->play();
+
+    // Half a second into a 1 s clip = halfway along the track.
+    mixer.update(0.5f);
+    CHECK_THAT(rig.node->position.x, WithinAbs(5.f, 1e-4));
+    CHECK_THAT(rig.node->position.y, WithinAbs(10.f, 1e-4));
+    CHECK_THAT(rig.node->position.z, WithinAbs(15.f, 1e-4));
+
+    // ...and the rest of the way.
+    mixer.update(0.25f);
+    CHECK_THAT(rig.node->position.x, WithinAbs(7.5f, 1e-4));
+    CHECK_THAT(rig.node->position.y, WithinAbs(15.f, 1e-4));
+}
+
+TEST_CASE("An unplayed action leaves the object alone") {
+
+    auto rig = makeRig();
+    rig.node->position.set(1.f, 2.f, 3.f);
+
+    AnimationMixer mixer(*rig.root);
+    auto* action = mixer.clipAction(makeMoveClip());
+    REQUIRE(action);
+    CHECK_FALSE(action->isRunning());
+
+    mixer.update(0.5f);
+
+    CHECK_THAT(rig.node->position.x, WithinAbs(1.f, 1e-5));
+    CHECK_THAT(rig.node->position.y, WithinAbs(2.f, 1e-5));
+}
+
+TEST_CASE("Loop::Once does not wrap the way Loop::Repeat does") {
+
+    // Differential, because the two modes diverge only after the clip ends:
+    // Repeat restarts, Once finishes. (Once does NOT hold the last frame here —
+    // clampWhenFinished defaults to false, so the action stops contributing and
+    // the property falls back to its unanimated value. That is the documented
+    // three.js behaviour, and there is currently no public setter to change it.)
+    const float overrun = 1.25f;
+
+    float repeatX = 0.f;
+    {
+        auto rig = makeRig();
+        AnimationMixer mixer(*rig.root);
+        auto* action = mixer.clipAction(makeMoveClip());
+        action->setLoop(Loop::Repeat, -1);
+        action->play();
+        mixer.update(overrun);
+        repeatX = rig.node->position.x;
+    }
+
+    float onceX = 0.f;
+    {
+        auto rig = makeRig();
+        AnimationMixer mixer(*rig.root);
+        auto* action = mixer.clipAction(makeMoveClip());
+        action->setLoop(Loop::Once, 1);
+        action->play();
+        mixer.update(overrun);
+        onceX = rig.node->position.x;
+    }
+
+    INFO("repeat x = " << repeatX << ", once x = " << onceX);
+    // Repeat has wrapped a quarter of the way back in.
+    CHECK_THAT(repeatX, WithinAbs(2.5f, 1e-3));
+    // Once has not restarted the clip.
+    CHECK(onceX != repeatX);
+}
+
+TEST_CASE("Loop::Repeat wraps back around") {
+
+    auto rig = makeRig();
+    AnimationMixer mixer(*rig.root);
+
+    auto* action = mixer.clipAction(makeMoveClip());
+    action->setLoop(Loop::Repeat, -1);
+    action->play();
+
+    // 1.25 s into a 1 s clip is 0.25 s into the second pass.
+    mixer.update(1.25f);
+    INFO("x after wrap = " << rig.node->position.x);
+    CHECK_THAT(rig.node->position.x, WithinAbs(2.5f, 1e-3));
+}
+
+TEST_CASE("Two actions blend by effective weight") {
+
+    // Same node, two clips pulling to different places. At equal weight the
+    // result is the average — this is what PropertyMixer accumulates.
+    auto rig = makeRig();
+    AnimationMixer mixer(*rig.root);
+
+    std::vector<std::shared_ptr<KeyframeTrack>> aTracks{
+            std::make_shared<VectorKeyframeTrack>(
+                    "Cube.position", std::vector<float>{0.f, 1.f},
+                    std::vector<float>{0.f, 0.f, 0.f, 0.f, 0.f, 0.f})};
+    std::vector<std::shared_ptr<KeyframeTrack>> bTracks{
+            std::make_shared<VectorKeyframeTrack>(
+                    "Cube.position", std::vector<float>{0.f, 1.f},
+                    std::vector<float>{100.f, 0.f, 0.f, 100.f, 0.f, 0.f})};
+
+    auto* a = mixer.clipAction(std::make_shared<AnimationClip>("a", 1.f, aTracks));
+    auto* b = mixer.clipAction(std::make_shared<AnimationClip>("b", 1.f, bTracks));
+
+    a->setEffectiveWeight(0.5f).play();
+    b->setEffectiveWeight(0.5f).play();
+
+    mixer.update(0.1f);
+
+    INFO("blended x = " << rig.node->position.x);
+    CHECK_THAT(rig.node->position.x, WithinAbs(50.f, 1e-3));
+}
+
+TEST_CASE("A quaternion track keeps the rotation normalised") {
+
+    auto rig = makeRig();
+    AnimationMixer mixer(*rig.root);
+
+    const float s = std::sqrt(0.5f);
+    std::vector<std::shared_ptr<KeyframeTrack>> tracks{
+            std::make_shared<QuaternionKeyframeTrack>(
+                    "Cube.quaternion",
+                    std::vector<float>{0.f, 1.f},
+                    std::vector<float>{0.f, 0.f, 0.f, 1.f, 0.f, s, 0.f, s})};
+
+    auto* action = mixer.clipAction(std::make_shared<AnimationClip>("spin", 1.f, tracks));
+    action->play();
+
+    for (int i = 0; i < 10; ++i) {
+        mixer.update(0.1f);
+        const auto& q = rig.node->quaternion;
+        const float len = std::sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
+        INFO("step " << i << " |q| = " << len);
+        REQUIRE_THAT(len, WithinAbs(1.f, 1e-3));
+    }
+}
+
+TEST_CASE("timeScale scales playback rate") {
+
+    auto rig = makeRig();
+    AnimationMixer mixer(*rig.root);
+
+    auto* action = mixer.clipAction(makeMoveClip());
+    action->setEffectiveTimeScale(2.f).play();
+
+    // At 2x, 0.25 s of wall time is 0.5 s of clip time.
+    mixer.update(0.25f);
+    CHECK_THAT(rig.node->position.x, WithinAbs(5.f, 1e-3));
+}
+
+TEST_CASE("A track bound to a missing node does not crash the mixer") {
+
+    auto rig = makeRig("Cube");
+    AnimationMixer mixer(*rig.root);
+
+    // Name that exists in no node of the graph.
+    auto* action = mixer.clipAction(makeMoveClip("NoSuchNode"));
+    REQUIRE(action);
+    action->play();
+
+    CHECK_NOTHROW(mixer.update(0.5f));
+
+    // The real node must be untouched.
+    CHECK_THAT(rig.node->position.x, WithinAbs(0.f, 1e-5));
+}
+
+// ---------------------------------------------------------------------------
+// AnimationClip
+// ---------------------------------------------------------------------------
+
+TEST_CASE("AnimationClip::resetDuration takes the longest track") {
+
+    std::vector<std::shared_ptr<KeyframeTrack>> tracks{
+            NumberKeyframeTrack::create("Cube.foo", {0.f, 2.f}, {0.f, 1.f}),
+            NumberKeyframeTrack::create("Cube.bar", {0.f, 5.f}, {0.f, 1.f})};
+
+    // Declared duration is deliberately wrong; resetDuration must fix it.
+    AnimationClip clip("c", 0.5f, tracks);
+    clip.resetDuration();
+    CHECK_THAT(clip.getDuration(), WithinAbs(5.f, 1e-5));
+}
+
+TEST_CASE("AnimationClip::findByName finds the right clip") {
+
+    std::vector<std::shared_ptr<AnimationClip>> clips{
+            std::make_shared<AnimationClip>("walk", 1.f),
+            std::make_shared<AnimationClip>("run", 1.f)};
+
+    auto found = AnimationClip::findByName(clips, "run");
+    REQUIRE(found);
+    CHECK(found->name() == "run");
+
+    CHECK(AnimationClip::findByName(clips, "fly") == nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// KeyframeTrack transforms
+// ---------------------------------------------------------------------------
+
+TEST_CASE("KeyframeTrack shift/scale move the key times") {
+
+    auto track = NumberKeyframeTrack::create("n", {0.f, 1.f, 2.f}, {0.f, 1.f, 2.f});
+
+    track->shift(10.f);
+    CHECK_THAT(track->getTimes().front(), WithinAbs(10.f, 1e-5));
+    CHECK_THAT(track->getTimes().back(), WithinAbs(12.f, 1e-5));
+
+    track->scale(2.f);
+    CHECK_THAT(track->getTimes().front(), WithinAbs(20.f, 1e-5));
+    CHECK_THAT(track->getTimes().back(), WithinAbs(24.f, 1e-5));
+
+    // Values are untouched by time transforms.
+    CHECK_THAT(track->getValues().back(), WithinAbs(2.f, 1e-5));
+}
+
+TEST_CASE("KeyframeTrack reports its value size") {
+
+    auto scalar = NumberKeyframeTrack::create("n", {0.f, 1.f}, {0.f, 1.f});
+    CHECK(scalar->getValueSize() == 1);
+
+    auto vector = std::make_shared<VectorKeyframeTrack>(
+            "v", std::vector<float>{0.f, 1.f},
+            std::vector<float>{0.f, 0.f, 0.f, 1.f, 1.f, 1.f});
+    CHECK(vector->getValueSize() == 3);
+}
+
+TEST_CASE("KeyframeTrack honours the requested interpolation") {
+
+    const std::vector<float> times{0.f, 1.f};
+    const std::vector<float> values{0.f, 0.f, 0.f, 10.f, 10.f, 10.f};
+
+    // NumberKeyframeTrack forwards its interpolation argument.
+    auto discreteNumber = NumberKeyframeTrack::create(
+            "n", {0.f, 1.f}, {0.f, 10.f}, Interpolation::Discrete);
+    CHECK(discreteNumber->getInterpolation() == Interpolation::Discrete);
+
+    // VectorKeyframeTrack must forward it too — its constructor accepts the
+    // argument, so silently dropping it means asking for Discrete or Smooth
+    // and getting the default with no diagnostic.
+    VectorKeyframeTrack discreteVector("v", times, values, Interpolation::Discrete);
+    CHECK(discreteVector.getInterpolation() == Interpolation::Discrete);
+
+    VectorKeyframeTrack smoothVector("v", times, values, Interpolation::Smooth);
+    CHECK(smoothVector.getInterpolation() == Interpolation::Smooth);
+
+    // Quaternions are the deliberate exception: they must slerp, so the track
+    // pins Linear regardless of what is asked for.
+    QuaternionKeyframeTrack quat("q", times,
+                                 std::vector<float>{0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f},
+                                 Interpolation::Smooth);
+    CHECK(quat.getInterpolation() == Interpolation::Linear);
+}

--- a/tests/animation/AnimationMixer_test.cpp
+++ b/tests/animation/AnimationMixer_test.cpp
@@ -304,10 +304,48 @@ TEST_CASE("KeyframeTrack honours the requested interpolation") {
     VectorKeyframeTrack smoothVector("v", times, values, Interpolation::Smooth);
     CHECK(smoothVector.getInterpolation() == Interpolation::Smooth);
 
-    // Quaternions are the deliberate exception: they must slerp, so the track
-    // pins Linear regardless of what is asked for.
-    QuaternionKeyframeTrack quat("q", times,
-                                 std::vector<float>{0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f},
-                                 Interpolation::Smooth);
-    CHECK(quat.getInterpolation() == Interpolation::Linear);
+    // Quaternions accept Discrete (glTF STEP: keys are copied verbatim, so the
+    // rotation stays normalised) and Linear (slerp), but coerce Smooth, because
+    // a cubic evaluates the four components independently and denormalises.
+    const std::vector<float> quatValues{0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
+
+    QuaternionKeyframeTrack stepQuat("q", times, quatValues, Interpolation::Discrete);
+    CHECK(stepQuat.getInterpolation() == Interpolation::Discrete);
+
+    QuaternionKeyframeTrack smoothQuat("q", times, quatValues, Interpolation::Smooth);
+    CHECK(smoothQuat.getInterpolation() == Interpolation::Linear);
+
+    QuaternionKeyframeTrack defaultQuat("q", times, quatValues);
+    CHECK(defaultQuat.getInterpolation() == Interpolation::Linear);
+}
+
+TEST_CASE("A STEP rotation track snaps instead of slerping") {
+
+    // glTF's "Step Rotation" case. Two keys 1 s apart: identity, then 90 deg
+    // about Y. Discrete must hold the first key for the whole interval and
+    // switch at the second, never producing anything in between.
+    auto rig = makeRig();
+    AnimationMixer mixer(*rig.root);
+
+    const float s = std::sqrt(0.5f);
+    std::vector<std::shared_ptr<KeyframeTrack>> tracks{
+            std::make_shared<QuaternionKeyframeTrack>(
+                    "Cube.quaternion",
+                    std::vector<float>{0.f, 1.f},
+                    std::vector<float>{0.f, 0.f, 0.f, 1.f, 0.f, s, 0.f, s},
+                    Interpolation::Discrete)};
+
+    auto* action = mixer.clipAction(std::make_shared<AnimationClip>("step", 1.f, tracks));
+    action->play();
+
+    // Partway through the interval the rotation must still be exactly the
+    // first key — a slerp would have it partly rotated by now.
+    mixer.update(0.4f);
+    INFO("y at t=0.4 = " << rig.node->quaternion.y);
+    CHECK_THAT(rig.node->quaternion.y, WithinAbs(0.f, 1e-4));
+    CHECK_THAT(rig.node->quaternion.w, WithinAbs(1.f, 1e-4));
+
+    mixer.update(0.4f);
+    INFO("y at t=0.8 = " << rig.node->quaternion.y);
+    CHECK_THAT(rig.node->quaternion.y, WithinAbs(0.f, 1e-4));
 }

--- a/tests/animation/CMakeLists.txt
+++ b/tests/animation/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+add_test_executable(Interpolants_test)
+add_test_executable(AnimationMixer_test)

--- a/tests/animation/Interpolants_test.cpp
+++ b/tests/animation/Interpolants_test.cpp
@@ -1,0 +1,160 @@
+// The four interpolants underneath every KeyframeTrack.
+//
+// These are pure math with exact expected values, so they are worth pinning
+// directly rather than only through the animation stack: a regression here shows
+// up as "animation looks slightly wrong", which is near-impossible to bisect from
+// a scene.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "threepp/math/Interpolant.hpp"
+#include "threepp/math/MathUtils.hpp"
+#include "threepp/math/interpolants/CubicInterpolant.hpp"
+#include "threepp/math/interpolants/DiscreteInterpolant.hpp"
+#include "threepp/math/interpolants/LinearInterpolant.hpp"
+#include "threepp/math/interpolants/QuaternionLinearInterpolant.hpp"
+
+#include <cmath>
+#include <vector>
+
+using namespace threepp;
+using Catch::Matchers::WithinAbs;
+
+TEST_CASE("LinearInterpolant interpolates between keys") {
+
+    // Two keys at t=0 and t=1, one scalar each: 0 -> 10.
+    const Sample times{0.f, 1.f};
+    const Sample values{0.f, 10.f};
+    Sample result;
+    LinearInterpolant interp(times, values, 1, &result);
+
+    CHECK_THAT(interp.evaluate(0.f)[0], WithinAbs(0.f, 1e-5));
+    CHECK_THAT(interp.evaluate(0.25f)[0], WithinAbs(2.5f, 1e-5));
+    CHECK_THAT(interp.evaluate(0.5f)[0], WithinAbs(5.f, 1e-5));
+    CHECK_THAT(interp.evaluate(1.f)[0], WithinAbs(10.f, 1e-5));
+}
+
+TEST_CASE("LinearInterpolant clamps outside the key range") {
+
+    const Sample times{1.f, 2.f};
+    const Sample values{5.f, 7.f};
+    Sample result;
+    LinearInterpolant interp(times, values, 1, &result);
+
+    // Before the first key and after the last, the endpoint value is held.
+    CHECK_THAT(interp.evaluate(-10.f)[0], WithinAbs(5.f, 1e-5));
+    CHECK_THAT(interp.evaluate(0.f)[0], WithinAbs(5.f, 1e-5));
+    CHECK_THAT(interp.evaluate(99.f)[0], WithinAbs(7.f, 1e-5));
+}
+
+TEST_CASE("LinearInterpolant handles multi-component values") {
+
+    // Three keys, 3 floats each — the shape a `.position` track has.
+    const Sample times{0.f, 1.f, 2.f};
+    const Sample values{
+            0.f, 0.f, 0.f,
+            1.f, 2.f, 3.f,
+            2.f, 4.f, 6.f};
+    Sample result;
+    LinearInterpolant interp(times, values, 3, &result);
+
+    const auto mid = interp.evaluate(0.5f);
+    REQUIRE(mid.size() == 3);
+    CHECK_THAT(mid[0], WithinAbs(0.5f, 1e-5));
+    CHECK_THAT(mid[1], WithinAbs(1.0f, 1e-5));
+    CHECK_THAT(mid[2], WithinAbs(1.5f, 1e-5));
+
+    const auto exact = interp.evaluate(2.f);
+    CHECK_THAT(exact[0], WithinAbs(2.f, 1e-5));
+    CHECK_THAT(exact[2], WithinAbs(6.f, 1e-5));
+}
+
+TEST_CASE("DiscreteInterpolant holds the previous key") {
+
+    const Sample times{0.f, 1.f, 2.f};
+    const Sample values{10.f, 20.f, 30.f};
+    Sample result;
+    DiscreteInterpolant interp(times, values, 1, &result);
+
+    // No blending: the value steps at each key and holds until the next.
+    CHECK_THAT(interp.evaluate(0.0f)[0], WithinAbs(10.f, 1e-5));
+    CHECK_THAT(interp.evaluate(0.9f)[0], WithinAbs(10.f, 1e-5));
+    CHECK_THAT(interp.evaluate(1.0f)[0], WithinAbs(20.f, 1e-5));
+    CHECK_THAT(interp.evaluate(1.9f)[0], WithinAbs(20.f, 1e-5));
+    CHECK_THAT(interp.evaluate(2.0f)[0], WithinAbs(30.f, 1e-5));
+}
+
+TEST_CASE("CubicInterpolant passes exactly through its keyframes") {
+
+    const Sample times{0.f, 1.f, 2.f, 3.f};
+    const Sample values{0.f, 1.f, 0.f, 1.f};
+    Sample result;
+    CubicInterpolant interp(times, values, 1, &result);
+
+    // A smooth curve may overshoot between keys, but it must hit the keys.
+    for (std::size_t i = 0; i < times.size(); ++i) {
+        INFO("key " << i << " at t=" << times[i]);
+        CHECK_THAT(interp.evaluate(times[i])[0], WithinAbs(values[i], 1e-4));
+    }
+}
+
+TEST_CASE("CubicInterpolant stays bounded between keys") {
+
+    const Sample times{0.f, 1.f, 2.f, 3.f};
+    const Sample values{0.f, 1.f, 4.f, 9.f};
+    Sample result;
+    CubicInterpolant interp(times, values, 1, &result);
+
+    // A cubic may legitimately overshoot between keys, so this does not demand
+    // monotonicity — only that the curve stays in the neighbourhood of its data.
+    // Before the ending-settings fix the boundary intervals read indeterminate
+    // memory and this produced values in the thousands from data bounded by 9.
+    constexpr float lo = 0.f, hi = 9.f;
+    constexpr float slack = 2.f * (hi - lo);
+
+    for (int i = 0; i <= 300; ++i) {
+        const float t = 3.f * static_cast<float>(i) / 300.f;
+        const float v = interp.evaluate(t)[0];
+        INFO("t=" << t << " v=" << v);
+        REQUIRE(std::isfinite(v));
+        REQUIRE(v > lo - slack);
+        REQUIRE(v < hi + slack);
+    }
+}
+
+TEST_CASE("QuaternionLinearInterpolant slerps and stays unit length") {
+
+    // Identity -> 90 degrees about Y.
+    const float s = std::sqrt(0.5f);
+    const Sample times{0.f, 1.f};
+    const Sample values{
+            0.f, 0.f, 0.f, 1.f,
+            0.f, s, 0.f, s};
+    Sample result;
+    QuaternionLinearInterpolant interp(times, values, 4, &result);
+
+    // Endpoints exact.
+    const auto start = interp.evaluate(0.f);
+    CHECK_THAT(start[3], WithinAbs(1.f, 1e-5));
+
+    const auto end = interp.evaluate(1.f);
+    CHECK_THAT(end[1], WithinAbs(s, 1e-5));
+    CHECK_THAT(end[3], WithinAbs(s, 1e-5));
+
+    // Halfway is 45 degrees about Y, and every sample stays normalised —
+    // a plain lerp would shorten the quaternion in the middle.
+    const auto mid = interp.evaluate(0.5f);
+    const float len = std::sqrt(mid[0] * mid[0] + mid[1] * mid[1] + mid[2] * mid[2] + mid[3] * mid[3]);
+    CHECK_THAT(len, WithinAbs(1.f, 1e-4));
+    CHECK_THAT(mid[1], WithinAbs(std::sin(math::PI / 8.f), 1e-3));
+    CHECK_THAT(mid[3], WithinAbs(std::cos(math::PI / 8.f), 1e-3));
+
+    for (int i = 0; i <= 20; ++i) {
+        const float t = static_cast<float>(i) / 20.f;
+        const auto q = interp.evaluate(t);
+        const float l = std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+        INFO("t=" << t << " |q|=" << l);
+        REQUIRE_THAT(l, WithinAbs(1.f, 1e-4));
+    }
+}


### PR DESCRIPTION
Four bugs fixed

1. KeyframeTrack::interpolation_ was never assigned. setInterpolation() set only createInterpolant_, and the member has no default initialiser. So getInterpolation() has been returning indeterminate memory for every track ever created — the test read 0x5f0072. It's observable, not just cosmetic: optimize() branches on getInterpolation() == Smooth to decide whether to drop redundant keyframes, so optimisation has been behaving non-deterministically, and the Python binding exposes it as track.interpolation.
2. VectorKeyframeTrack silently dropped its interpolation argument — accepted the parameter, called the base constructor without it. Asking for Discrete or Smooth quietly gave you the default. (QuaternionKeyframeTrack also ignores it, but deliberately — rotations must slerp. I documented and pinned that rather than changing it.)3. 
3. Interpolant::settings was an uninitialised public raw pointer, and getSettings_() does if (settings) return *settings; — reading indeterminate memory then dereferencing it. Compounded by CubicInterpolant declaring its own DefaultSettings_ that shadowed the base's std::optional, so the constructor's ZeroCurvature assignment landed on the derived copy while getSettings_() kept reading the base's empty one.
4. CubicInterpolant read out of bounds at both ends of every curve. This is a straight JS-to-C++ port error: three.js finds the curve ends by reading pp[i1-2] / pp[i1+1] and testing for undefined, which JS returns for out-of-range indices. Ported literally as std::isnan on a std::vector subscript — i1-2 underflows size_t to SIZE_MAX on the first interval, i1+1 runs past the end on the last. The garbage was essentially never NaN, so the boundary branches never fired and the end intervals computed their weights from adjacent heap memory.