### PR TITLE
build: CMakePresets.json, with CI configured through it

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -27,6 +27,7 @@ jobs:
           xorg-dev \
           libglu1-mesa-dev \
           pkg-config \
+          ninja-build \
           libglfw3 \
           libglfw3-dev \
           libgl1-mesa-dri \
@@ -41,47 +42,67 @@ jobs:
       # CONFIGURE time, so the install has to precede cmake either way.
       - name: Configure and build
         run: |
-          cmake . -B build -DTHREEPP_USE_EXTERNAL_GLFW=ON -DCMAKE_BUILD_TYPE="Release"
-          cmake --build build
+          cmake --preset ci-linux
+          cmake --build --preset ci-linux
 
       - name: Test
-        run: |
-          cd build/tests
-          ctest --output-on-failure
+        run: ctest --preset ci-linux
 
-      # --- AddressSanitizer + UndefinedBehaviorSanitizer -----------------------
-      #
-      # Piggybacks on this job rather than taking its own runner: the apt set and
-      # the display stack are identical, so all a separate job would add is queue
-      # time. It uses its own build directory so the Release build above is not
-      # clobbered, and runs after the Release ctest so a plain regression is
-      # reported before a sanitizer one.
-      #
-      # Examples are off here — they are only ever compiled, never run, so
-      # instrumenting them buys nothing and they are the bulk of the build time.
-      #
-      # Leak detection is OFF on purpose: the GL driver, GLFW and X11 all leak
-      # per-process allocations we neither own nor can free, and their reports
-      # bury the ones that matter. The target is use-after-free, out-of-bounds and
-      # undefined behaviour, which detect_leaks does not affect.
+
+  # AddressSanitizer + UndefinedBehaviorSanitizer.
+  #
+  # Its own job, so that a plain regression and a sanitizer regression are
+  # reported independently rather than the first failure hiding the second.
+  # The apt set and the display stack are the same as the Release job above.
+  #
+  # Examples are off (see the ci-linux-asan preset) — they are only ever
+  # compiled, never run, so instrumenting them buys nothing and they are the
+  # bulk of the build time.
+  #
+  # Leak detection is OFF on purpose: the GL driver, GLFW and X11 all leak
+  # per-process allocations we neither own nor can free, and their reports
+  # bury the ones that matter. The target is use-after-free, out-of-bounds and
+  # undefined behaviour, which detect_leaks does not affect.
+  linux-asan:
+
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: gcc-${{ matrix.compiler_version }}
+      CXX: g++-${{ matrix.compiler_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+        compiler_version: [ 11 ]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+          libxinerama-dev \
+          libxcursor-dev \
+          xorg-dev \
+          libglu1-mesa-dev \
+          pkg-config \
+          ninja-build \
+          libglfw3 \
+          libglfw3-dev \
+          libgl1-mesa-dri \
+          xvfb
+
       - name: Configure and build (ASan + UBSan)
         run: |
-          cmake . -B build-asan \
-            -DTHREEPP_USE_EXTERNAL_GLFW=ON \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DTHREEPP_BUILD_EXAMPLES=OFF \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g" \
-            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g" \
-            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
-          cmake --build build-asan
+          cmake --preset ci-linux-asan
+          cmake --build --preset ci-linux-asan
 
       - name: Test (ASan + UBSan)
         env:
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:strict_string_checks=1:detect_stack_use_after_return=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-        run: |
-          cd build-asan/tests
-          ctest --output-on-failure
+        run: ctest --preset ci-linux-asan
+
 
   linux-no-glfw:
 
@@ -105,17 +126,16 @@ jobs:
           libxcursor-dev \
           xorg-dev \
           libglu1-mesa-dev \
-          pkg-config
+          pkg-config \
+          ninja-build
 
       - name: Configure and build
         run: |
-          cmake . -B build -DTHREEPP_WITH_GLFW=OFF -DTHREEPP_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE="Release"
-          cmake --build build
+          cmake --preset ci-linux-no-glfw
+          cmake --build --preset ci-linux-no-glfw
 
       - name: Test
-        run: |
-          cd build/tests
-          ctest --output-on-failure
+        run: ctest --preset ci-linux-no-glfw
 
 
   # Compile-only smoke test for the Vulkan path-tracing backend.
@@ -141,7 +161,8 @@ jobs:
           libxcursor-dev \
           xorg-dev \
           libglu1-mesa-dev \
-          pkg-config
+          pkg-config \
+          ninja-build
 
       - name: Install Vulkan SDK (headers, loader, current glslangValidator)
         run: |
@@ -161,13 +182,8 @@ jobs:
 
       - name: Configure and build (library only — compile check)
         run: |
-          cmake . -B build \
-            -DTHREEPP_WITH_VULKAN=ON \
-            -DTHREEPP_BUILD_EXAMPLES=OFF \
-            -DTHREEPP_BUILD_TESTS=OFF \
-            -DVMA_INCLUDE_DIR="$GITHUB_WORKSPACE/third_party/vma" \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
+          cmake --preset ci-linux-vulkan
+          cmake --build --preset ci-linux-vulkan
 
 
   windows:
@@ -189,13 +205,11 @@ jobs:
 
       - name: Configure and build
         run: |
-          cmake . -B build -G Ninja -DTHREEPP_TREAT_WARNINGS_AS_ERRORS=ON -DCMAKE_BUILD_TYPE="Release"
-          cmake --build build
+          cmake --preset ci-windows
+          cmake --build --preset ci-windows
 
       - name: Test
-        run: |
-          cd build/tests
-          ctest --output-on-failure
+        run: ctest --preset ci-windows
 
 
   darwin:
@@ -209,10 +223,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Ninja (which the ci-* presets select) comes from the runner image here —
+      # unlike the Linux jobs there is no package step to declare it in. If an
+      # image ever drops it, CMake fails at configure time with a missing
+      # CMAKE_MAKE_PROGRAM, which is immediate and unambiguous.
       - name: Configure and build
         run: |
-          cmake . -B build -DTHREEPP_BUILD_EXAMPLES=OFF -DTHREEPP_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE="Release"
-          cmake --build build
+          cmake --preset ci-macos
+          cmake --build --preset ci-macos
 
 
   linux-emscripten:
@@ -241,7 +259,8 @@ jobs:
           libxcursor-dev \
           xorg-dev \
           libglu1-mesa-dev \
-          pkg-config
+          pkg-config \
+          ninja-build
 
       - uses: mymindstorm/setup-emsdk@v14
         with:
@@ -250,8 +269,8 @@ jobs:
 
       - name: Configure and build
         run: |
-          cmake . -B build -DCMAKE_TOOLCHAIN_FILE=${{env.EMSDK}}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DTHREEPP_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE="Release"
-          cmake --build build
+          cmake --preset ci-wasm
+          cmake --build --preset ci-wasm
 
 
   # Build the pybind11 Python bindings (the `threepp` module) and run the binding
@@ -270,7 +289,7 @@ jobs:
         python-version: [ '3.10', '3.12' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install prerequisites
         run: |
@@ -280,6 +299,7 @@ jobs:
           xorg-dev \
           libglu1-mesa-dev \
           pkg-config \
+          ninja-build \
           libglfw3 \
           libglfw3-dev \
           libgl1-mesa-dri \
@@ -294,15 +314,8 @@ jobs:
 
       - name: Build the threepp module (GL only — PhysX/Vulkan need a GPU)
         run: |
-          cmake . -B build \
-            -DTHREEPP_WITH_PYTHON=ON \
-            -DTHREEPP_USE_EXTERNAL_GLFW=ON \
-            -DTHREEPP_BUILD_TESTS=OFF \
-            -DTHREEPP_BUILD_EXAMPLES=OFF \
-            -DPYBIND11_FINDPYTHON=ON \
-            -DPython_EXECUTABLE=$(which python) \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build --target threepp_py -j 2
+          cmake --preset ci-python -DPython_EXECUTABLE=$(which python)
+          cmake --build --preset ci-python
 
       - name: Run binding tests (headless GL under Xvfb)
         working-directory: python

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,6 @@
 name: Deploy WASM examples to GitHub Pages
 
-# Builds the Emscripten (WebGL2) examples and publishes build/bin — which
+# Builds the Emscripten (WebGL2) examples and publishes the build's bin/ — which
 # contains every web example plus the generated index.html — to GitHub Pages.
 # Runs on every push to master; can also be triggered manually from the Actions
 # tab (workflow_dispatch works from any branch, useful for previewing).
@@ -46,19 +46,18 @@ jobs:
 
       - name: Configure and build (Emscripten / WebGL2)
         run: |
-          cmake . -B build \
-            -DCMAKE_TOOLCHAIN_FILE=${{env.EMSDK}}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
-            -DTHREEPP_BUILD_TESTS=OFF \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
+          cmake --preset ci-wasm
+          cmake --build --preset ci-wasm
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
+      # The ci-wasm preset builds into build/ci-wasm; CMAKE_RUNTIME_OUTPUT_DIRECTORY
+      # puts the examples and the generated index.html in its bin/.
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build/bin
+          path: build/ci-wasm/bin
 
   deploy:
     needs: build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ ubuntu-22.04, windows-2022, macos-14 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # PEP 440 needs dots, not dashes: 2026-06-17 -> 2026.06.17 (pip normalises
       # the leading zeros). On dispatch (no tag) the pyproject default version is
@@ -78,7 +78,7 @@ jobs:
     name: Source distribution
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Derive version from the date tag
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ build-asan
 cmake-build-*
 compile_commands.json
 
+# CMakePresets.json is the project's, and is tracked. CMakeUserPresets.json is
+# yours: machine-specific paths, your own configurations. Presets in it may
+# `inherit` from the tracked ones. IDEs (CLion) write it for you.
+CMakeUserPresets.json
+
 # Python packaging / wheel-build artifacts (scikit-build-core)
 dist/
 wheelhouse/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,31 @@ cmake_dependent_option(THREEPP_BUILD_EXAMPLE_PROJECTS "Build example projects" O
 # Global internal configuration
 # ==============================================================================
 
+# Give a single-config generator (Ninja, Makefiles) a build type when nothing
+# else has. An empty CMAKE_BUILD_TYPE means no optimisation flags at all, which
+# is what a bare `cmake . -B build` produces on Linux and macOS: a silently
+# unoptimised build. MSVC is unaffected either way — its platform module already
+# defaults to Debug during project(), so this is a no-op on Windows.
+#
+# Only when we are the top-level project: as a subproject (FetchContent /
+# add_subdirectory) the build type belongs to whoever consumed us.
+#
+# Evaluating CMAKE_BUILD_TYPE here has a second effect, which is worth keeping
+# even where the assignment never fires. Multi-config generators (Visual Studio,
+# Xcode) choose the configuration at build time and ignore the variable, so a
+# preset that sets it — as ours do, for the single-config case — would otherwise
+# draw a "Manually-specified variables were not used by the project" warning on
+# every configure. Reading it in the test above is what marks it as used.
+if (PROJECT_IS_TOP_LEVEL AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (single-config generators)" FORCE)
+endif ()
+# Offers the usual four as a dropdown in cmake-gui / ccmake. Guarded because a
+# multi-config generator leaves no CMAKE_BUILD_TYPE cache entry to annotate, and
+# set_property(CACHE) on a missing entry is an error.
+if (DEFINED CACHE{CMAKE_BUILD_TYPE})
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
+endif ()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,316 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "gl",
+      "inherits": "base",
+      "displayName": "OpenGL (start here)",
+      "description": "Portable OpenGL 3.3 backend, with examples, tests and the editor. The configuration to use if you are unsure."
+    },
+    {
+      "name": "gl-debug",
+      "inherits": "gl",
+      "displayName": "OpenGL, Debug",
+      "description": "As 'gl', built with debug info and no optimisation.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "vulkan",
+      "inherits": "base",
+      "displayName": "Vulkan deferred backend",
+      "description": "Deferred Vulkan renderer: raster G-buffer with ray-traced AO, GI, reflections and shadows. Needs the Vulkan SDK on PATH, or the vcpkg 'vulkan' feature.",
+      "cacheVariables": {
+        "THREEPP_WITH_VULKAN": "ON"
+      }
+    },
+    {
+      "name": "vulkan-aaa",
+      "inherits": "vulkan",
+      "displayName": "Vulkan + FSR 3.1 + DLSS",
+      "description": "As 'vulkan', plus the AMD FidelityFX FSR 3.1 and NVIDIA DLSS temporal upscalers. Windows only; both SDKs are fetched at configure time (the DLSS archive is large).",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "THREEPP_WITH_FSR": "ON",
+        "THREEPP_WITH_DLSS": "ON"
+      }
+    },
+    {
+      "name": "python",
+      "inherits": "base",
+      "displayName": "Python bindings",
+      "description": "Builds the pybind11 'threepp' module (GL backend). Add -DPython_EXECUTABLE=<path> to select an interpreter; build the 'threepp_py' target.",
+      "cacheVariables": {
+        "THREEPP_WITH_PYTHON": "ON",
+        "THREEPP_BUILD_EXAMPLES": "OFF",
+        "THREEPP_BUILD_TESTS": "OFF",
+        "PYBIND11_FINDPYTHON": "ON"
+      }
+    },
+    {
+      "name": "no-glfw",
+      "inherits": "base",
+      "displayName": "Build check: no GLFW frontend",
+      "description": "The library without the GLFW frontend. Canvas is the only thing dropped, but Canvas is what creates the context — so this configuration cannot render at all, offscreen or otherwise. It exists to keep the windowing-independent code compiling, and runs the tests that need no window.",
+      "cacheVariables": {
+        "THREEPP_WITH_GLFW": "OFF",
+        "THREEPP_BUILD_EXAMPLES": "OFF"
+      }
+    },
+    {
+      "name": "wasm",
+      "inherits": "base",
+      "displayName": "Emscripten / WebGL2",
+      "description": "Web build of the examples. Requires an activated emsdk (EMSDK must be set in the environment).",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
+        "THREEPP_BUILD_TESTS": "OFF"
+      }
+    },
+
+    {
+      "name": "ci-base",
+      "hidden": true,
+      "inherits": "base",
+      "generator": "Ninja"
+    },
+    {
+      "name": "ci-linux",
+      "inherits": [
+        "gl",
+        "ci-base"
+      ],
+      "displayName": "CI: Linux, GL, system GLFW",
+      "cacheVariables": {
+        "THREEPP_USE_EXTERNAL_GLFW": "ON"
+      }
+    },
+    {
+      "name": "ci-linux-asan",
+      "inherits": "ci-linux",
+      "displayName": "CI: Linux, AddressSanitizer + UndefinedBehaviorSanitizer",
+      "description": "Examples are excluded: they are compiled but never run, so instrumenting them buys nothing and they dominate the build time.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "THREEPP_BUILD_EXAMPLES": "OFF",
+        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
+    },
+    {
+      "name": "ci-linux-no-glfw",
+      "inherits": [
+        "no-glfw",
+        "ci-base"
+      ],
+      "displayName": "CI: Linux, build check without the GLFW frontend"
+    },
+    {
+      "name": "ci-linux-vulkan",
+      "inherits": [
+        "vulkan",
+        "ci-base"
+      ],
+      "displayName": "CI: Linux, Vulkan compile check",
+      "description": "Library only. The runners have no GPU, but the backend and its GLSL shaders still compile: the loader links without a device and glslangValidator needs none.",
+      "cacheVariables": {
+        "THREEPP_BUILD_EXAMPLES": "OFF",
+        "THREEPP_BUILD_TESTS": "OFF",
+        "VMA_INCLUDE_DIR": "${sourceDir}/third_party/vma"
+      }
+    },
+    {
+      "name": "ci-windows",
+      "inherits": [
+        "gl",
+        "ci-base"
+      ],
+      "displayName": "CI: Windows, GL, warnings as errors",
+      "description": "Ninja needs cl.exe on PATH — run from a developer command prompt.",
+      "cacheVariables": {
+        "THREEPP_TREAT_WARNINGS_AS_ERRORS": "ON"
+      }
+    },
+    {
+      "name": "ci-macos",
+      "inherits": "ci-base",
+      "displayName": "CI: macOS, library compile check",
+      "cacheVariables": {
+        "THREEPP_BUILD_EXAMPLES": "OFF",
+        "THREEPP_BUILD_TESTS": "OFF"
+      }
+    },
+    {
+      "name": "ci-wasm",
+      "inherits": [
+        "wasm",
+        "ci-base"
+      ],
+      "displayName": "CI: Emscripten / WebGL2"
+    },
+    {
+      "name": "ci-python",
+      "inherits": [
+        "python",
+        "ci-base"
+      ],
+      "displayName": "CI: Python bindings, system GLFW",
+      "cacheVariables": {
+        "THREEPP_USE_EXTERNAL_GLFW": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "gl",
+      "configurePreset": "gl",
+      "configuration": "Release"
+    },
+    {
+      "name": "gl-debug",
+      "configurePreset": "gl-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "vulkan",
+      "configurePreset": "vulkan",
+      "configuration": "Release"
+    },
+    {
+      "name": "vulkan-aaa",
+      "configurePreset": "vulkan-aaa",
+      "configuration": "Release"
+    },
+    {
+      "name": "python",
+      "configurePreset": "python",
+      "configuration": "Release",
+      "targets": [
+        "threepp_py"
+      ]
+    },
+    {
+      "name": "no-glfw",
+      "configurePreset": "no-glfw",
+      "configuration": "Release"
+    },
+    {
+      "name": "wasm",
+      "configurePreset": "wasm",
+      "configuration": "Release"
+    },
+
+    {
+      "name": "ci-linux",
+      "configurePreset": "ci-linux",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-linux-asan",
+      "configurePreset": "ci-linux-asan",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ci-linux-no-glfw",
+      "configurePreset": "ci-linux-no-glfw",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-linux-vulkan",
+      "configurePreset": "ci-linux-vulkan",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-windows",
+      "configurePreset": "ci-windows",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-macos",
+      "configurePreset": "ci-macos",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-wasm",
+      "configurePreset": "ci-wasm",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-python",
+      "configurePreset": "ci-python",
+      "configuration": "Release",
+      "jobs": 2,
+      "targets": [
+        "threepp_py"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "configurePreset": "gl",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    },
+    {
+      "name": "gl",
+      "inherits": "base",
+      "configurePreset": "gl",
+      "configuration": "Release"
+    },
+    {
+      "name": "gl-debug",
+      "inherits": "base",
+      "configurePreset": "gl-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "ci-linux",
+      "inherits": "base",
+      "configurePreset": "ci-linux",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-linux-asan",
+      "inherits": "base",
+      "configurePreset": "ci-linux-asan",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ci-linux-no-glfw",
+      "inherits": "base",
+      "configurePreset": "ci-linux-no-glfw",
+      "configuration": "Release"
+    },
+    {
+      "name": "ci-windows",
+      "inherits": "base",
+      "configurePreset": "ci-windows",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -199,30 +199,80 @@ covering everything from geometries and loaders to full demo applications.
 
 ## How to build
 
-`threepp` comes bundled with all required core dependencies.
+`threepp` comes bundled with all required core dependencies. Use CMake for project
+configuration and building.
 
-Use CMake for project configuration and building.
-
-Do note that you may also use a system installation of GLFW3 if you want or have issues with the bundled setup by passing
-`-DTHREEPP_USE_EXTERNAL_GLFW=ON` to CMake.
-
-### Windows
+The project ships a `CMakePresets.json` holding the configurations that are actually
+built and tested in CI, so you don't have to assemble a flag list yourself:
 
 ```shell
+cmake --list-presets
+```
+
+| Preset       | What you get                                                          |
+|--------------|-----------------------------------------------------------------------|
+| `gl`         | OpenGL 3.3 backend, with examples, tests and the editor — start here  |
+| `gl-debug`   | as `gl`, unoptimised and with debug info                              |
+| `vulkan`     | the deferred Vulkan renderer (needs the Vulkan SDK)                   |
+| `vulkan-aaa` | as `vulkan`, plus the FSR 3.1 and DLSS upscalers (Windows)            |
+| `python`     | the pybind11 `threepp` module                                         |
+| `no-glfw`    | build check only: no GLFW frontend, and so no rendering at all        |
+| `wasm`       | Emscripten/WebGL2 examples (needs an activated emsdk)                 |
+
+```shell
+cmake --preset gl
+cmake --build --preset gl
+ctest --preset gl
+```
+
+Each preset builds into `build/<preset-name>`, so configurations don't clobber each other.
+The presets above deliberately leave the generator unset, so each platform uses its default.
+
+Local configurations of your own belong in `CMakeUserPresets.json`, which is untracked and
+whose presets can `inherit` from the ones above — this is where machine-specific paths and
+personal preferences go. To build with Ninja, for instance (CI does, but it needs `cl.exe`
+on `PATH` on Windows, so it is not the default here):
+
+```json
+{
+  "version": 3,
+  "configurePresets": [
+    { "name": "my-gl", "inherits": "gl", "generator": "Ninja" }
+  ]
+}
+```
+
+### Configuring by hand
+
+Presets are a convenience, not a requirement — and they don't apply when you consume
+`threepp` from another project via `FetchContent`/`add_subdirectory`. Everything a preset
+sets is an ordinary CMake option, so the classic invocation still works:
+
+```shell
+# Windows
 cmake . -A x64 -B build
 cmake --build build --config "Release"
 ```
 
-### Unix
-
 ```shell
+# Unix
 cmake . -B build -DCMAKE_BUILD_TYPE="Release"
 cmake --build build
 ```
 
+On a single-config generator (Ninja, Makefiles), a top-level build with no `CMAKE_BUILD_TYPE`
+given defaults to `Release` rather than to a build with no optimisation flags at all — so the
+flag above is explicit rather than required. Visual Studio picks the configuration at build
+time instead (`--config`), and on Windows MSVC supplies its own default. Consumed as a
+subproject, `threepp` leaves the build type entirely to the parent project.
+
+Do note that you may also use a system installation of GLFW3 if you want or have issues with the bundled setup by passing
+`-DTHREEPP_USE_EXTERNAL_GLFW=ON` to CMake.
+
 ### Building examples with Emscripten
 
-Pass to CMake:
+With an activated emsdk (`EMSDK` set in your environment), `cmake --preset wasm` does this
+for you. By hand, pass to CMake:
 ```shell
 -DCMAKE_TOOLCHAIN_FILE="[path to emscripten]\emsdk\upstream\emscripten\cmake\Modules\Platform\Emscripten.cmake"
 ```


### PR DESCRIPTION
CI hand-assembled its -D flags in eight places, so a local build and the one gating a PR could drift silently. The presets are now the single definition — ci-* presets inherit the user-facing ones, and every job configures with cmake --preset.

Ninja on every job. Only Windows used it before; cmake --build passes no -j, so Linux and macOS were compiling serially. ASan+UBSan also moves back to its own job.

Contributors get cmake --preset gl instead of a flag list. CMakeUserPresets.json is gitignored.

CI: all 9 jobs green. Critical path 64.8m → 19.3m; runner-minutes 132 → 75.