### PR TITLE
editor: scripts docks into the bottom panel, one tab per script

### DIFF
--- a/apps/editor/EditorApp.cpp
+++ b/apps/editor/EditorApp.cpp
@@ -610,14 +610,15 @@ void EditorApp::drawUi() {
 
     drawMenuBar();
     drawToolbar();
+    // Before the panels: the Scripts tab lives in the bottom panel, and which
+    // scripts are in it — if any — is decided here.
+    updateScriptEditors();
     drawHierarchy();
     drawInspector();
     drawBottomPanel();
     drawStatusBar();
     drawPlayBanner();
     drawImportToast();
-    // A floating window, so it goes over the fixed panels and under the modals.
-    drawScriptEditor();
 
     if (preview_.visible) {
         // Background list, not foreground: the camera image is drawn by the
@@ -1204,42 +1205,100 @@ float EditorApp::inspectorPx() const {
     return settings_.inspectorWidth * contentScale_;
 }
 
-void EditorApp::drawSplitter(const char* id, float x, float top, float height,
-                             float& width, float sign) {
+float EditorApp::bottomHeightLimit() const {
 
     const float s = contentScale_;
-    const float thickness = layout::splitterThickness * s;
+    // Against the render surface rather than the ImGui viewport, because
+    // cameraDockRect() asks for this outside the frame.
+    const float total = static_cast<float>(renderer_->size().height());
+    // A viewport strip has to survive: dragging the panel up to the toolbar
+    // would leave nothing to drag it back down against.
+    const float free = total - menuHeight_ - toolbarHeight_ - statusHeight_ - 140.f * s;
+
+    return std::max(free / s, EditorSettings::minBottomHeight);
+}
+
+float EditorApp::bottomPanelPx() const {
+
+    return std::clamp(settings_.bottomPanelHeight,
+                      EditorSettings::minBottomHeight, bottomHeightLimit()) *
+           contentScale_;
+}
+
+float EditorApp::collapsedBottomPx() const {
+
+    return ImGui::GetFrameHeight() + 6 * contentScale_;
+}
+
+float EditorApp::bottomBandPx() const {
+
+    // Exactly the panel, with nothing reserved for the splitter: a band held
+    // clear for the grip is a strip of bare viewport between the side panels
+    // and the bottom one — a seam across the whole window. The grip overlays
+    // the boundary instead (drawHeightSplitter), which costs the side panels
+    // their last few pixels and costs the layout nothing.
+    return bottomPanelOpen_ ? bottomPanelPx() : collapsedBottomPx();
+}
+
+// One implementation for both axes. `horizontal` is the strip's long axis being
+// horizontal — the handle that moves things up and down.
+void EditorApp::drawSplitterStrip(const char* id, float x, float top, float width, float height,
+                                  bool horizontal, float& value, float sign, float lo, float hi) {
+
+    const float s = contentScale_;
 
     ImGui::SetNextWindowPos({x, top});
-    ImGui::SetNextWindowSize({thickness, height});
+    ImGui::SetNextWindowSize({width, height});
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4{0.f, 0.f, 0.f, 0.f});
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0.f, 0.f});
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
 
     if (ImGui::Begin(id, nullptr, layout::barFlags)) {
 
-        ImGui::InvisibleButton("##grip", {thickness, std::max(height, 1.f)});
+        ImGui::InvisibleButton("##grip", {std::max(width, 1.f), std::max(height, 1.f)});
 
         const bool active = ImGui::IsItemActive();
         if (active || ImGui::IsItemHovered()) {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+            ImGui::SetMouseCursor(horizontal ? ImGuiMouseCursor_ResizeNS : ImGuiMouseCursor_ResizeEW);
             // Only hint at the handle once the pointer finds it; an always-on
             // divider would just be chrome.
             auto* draw = ImGui::GetWindowDrawList();
             const auto min = ImGui::GetWindowPos();
-            draw->AddRectFilled({min.x + thickness * 0.5f - 1.f * s, min.y},
-                                {min.x + thickness * 0.5f + 1.f * s, min.y + height},
-                                ImGui::GetColorU32(active ? theme::accent() : theme::muted()));
+            const auto colour = ImGui::GetColorU32(active ? theme::accent() : theme::muted());
+            if (horizontal) {
+                draw->AddRectFilled({min.x, min.y + height * 0.5f - 1.f * s},
+                                    {min.x + width, min.y + height * 0.5f + 1.f * s}, colour);
+            } else {
+                draw->AddRectFilled({min.x + width * 0.5f - 1.f * s, min.y},
+                                    {min.x + width * 0.5f + 1.f * s, min.y + height}, colour);
+            }
         }
         if (active) {
-            width = std::clamp(width + ImGui::GetIO().MouseDelta.x * sign / s,
-                               EditorSettings::minPanelWidth, EditorSettings::maxPanelWidth);
+            const auto& delta = ImGui::GetIO().MouseDelta;
+            value = std::clamp(value + (horizontal ? delta.y : delta.x) * sign / s, lo, hi);
         }
     }
     ImGui::End();
 
     ImGui::PopStyleVar(2);
     ImGui::PopStyleColor();
+}
+
+void EditorApp::drawSplitter(const char* id, float x, float top, float height,
+                             float& width, float sign) {
+
+    drawSplitterStrip(id, x, top, layout::splitterThickness * contentScale_, height,
+                      false, width, sign,
+                      EditorSettings::minPanelWidth, EditorSettings::maxPanelWidth);
+}
+
+void EditorApp::drawHeightSplitter(const char* id, float x, float top, float width,
+                                   float& height) {
+
+    // Dragging up grows the panel, hence the -1.
+    drawSplitterStrip(id, x, top, width, layout::splitterThickness * contentScale_,
+                      true, height, -1.f,
+                      EditorSettings::minBottomHeight, bottomHeightLimit());
 }
 
 void EditorApp::flashStatus(std::string message) {
@@ -1271,7 +1330,7 @@ void EditorApp::drawImportToast() {
     const float width = textSize.x + radius * 2 + 34 * s;
 
     // Bottom-left of the viewport (the camera preview owns the bottom-right).
-    const float bottom = viewport->Size.y - statusHeight_ - (bottomPanelOpen_ ? layout::bottomHeight * s : 0.f);
+    const float bottom = viewport->Size.y - statusHeight_ - bottomBandPx();
     ImGui::SetNextWindowPos({viewport->Pos.x + hierarchyPx() + 12 * s,
                              viewport->Pos.y + bottom - height - 12 * s});
     ImGui::SetNextWindowSize({width, height});
@@ -2171,7 +2230,7 @@ bool EditorApp::cameraDockRect(float& x, float& y, float& w, float& h) const {
     const float s = contentScale_;
 
     w = inspectorPx();
-    h = layout::bottomHeight * s;
+    h = bottomPanelPx();
     x = static_cast<float>(size.width()) - w;
     y = static_cast<float>(size.height()) - statusHeight_ - h;
 

--- a/apps/editor/EditorApp.hpp
+++ b/apps/editor/EditorApp.hpp
@@ -227,14 +227,43 @@ namespace threepp::editor {
         // Record toggle. A sensor is invisible without this.
         void drawSensorsTab();
 
-        // Script Editor (apps/editor/panels/ScriptEditorPanel.cpp). One
-        // floating window, editing one object's inline script source.
-        void drawScriptEditor();
-        // Points the window at `object` and shows it. Reopening the same object
-        // keeps whatever was being typed — closing the window is not a decision
-        // to throw text away.
-        void openScriptEditor(const Object3D& object);
+        // Script Editor (apps/editor/panels/ScriptEditorPanel.cpp): a Scripts
+        // tab in the bottom panel, holding one inner tab per open script.
+        //
+        // Several at once, because editing one object's script while reading
+        // another's is the normal way to write two things that talk to each
+        // other. One per object — the object still carries a single script.
+        struct ScriptEditorState;
+
+        // The unsaved marker, the raise-on-selection rule and the
+        // close-when-the-script-is-gone rule are per-frame state, so they run
+        // here rather than in a tab body — a collapsed panel, or a tab that is
+        // not the visible one, must not freeze them. Called before
+        // drawBottomPanel(), which draws the tabs.
+        void updateScriptEditors();
+        // The Scripts tab body: the inner tab bar, and the visible script.
+        void drawScriptsTab();
+        void drawScriptTab(ScriptEditorState& state);
+        // Labels: the outer tab, and one script's inner tab.
+        [[nodiscard]] std::string scriptsTabLabel() const;
+        [[nodiscard]] static std::string scriptTabLabel(const ScriptEditorState& state);
+        // The editor open on `uuid`, or nullptr. Invalidated by any open, so do
+        // not hold it across one.
+        [[nodiscard]] ScriptEditorState* scriptEditorFor(const std::string& uuid);
+        // The script the user is looking at: what Apply, Revert and Ctrl+Enter
+        // act on. Null with no scripts open.
+        [[nodiscard]] ScriptEditorState* activeScriptEditor();
+        // Opens a tab on `object`, or reuses the one already on it. `reveal`
+        // brings that tab forward (and the bottom panel with it); an external
+        // session syncing in the background passes false, since it must not
+        // pull the panel out from under whatever the user was looking at.
+        //
+        // Reopening an object that already has a tab keeps whatever was being
+        // typed — closing a tab is not a decision to throw text away.
+        void openScriptEditor(const Object3D& object, bool reveal = true);
         // Normalizes, syntax-checks and commits the buffer as one undo step.
+        void applyScriptEditor(ScriptEditorState& state);
+        // The same, on whichever script is visible.
         void applyScriptEditor();
 
         // --- external editing (apps/editor/ExternalScriptEdit.cpp) ----------
@@ -244,7 +273,7 @@ namespace threepp::editor {
         // Which inline source an external session is editing. A behaviour script
         // and a generator live on the same object under different keys, so the
         // session has to know which one it exported — and they commit through
-        // different paths (the Script Editor window vs the Generator's own
+        // different paths (the Script Editor tab vs the Generator's own
         // property write).
         enum class ExternalEditKind {
             Script,
@@ -582,16 +611,36 @@ namespace threepp::editor {
         void persistSettings();
         [[nodiscard]] float scale() const { return contentScale_; }
 
-        // Side panel widths in device pixels. The unscaled values are a user
+        // Panel sizes in device pixels. The unscaled values are a user
         // preference (draggable, persisted); everything that lays out against
         // a panel goes through these.
         [[nodiscard]] float hierarchyPx() const;
         [[nodiscard]] float inspectorPx() const;
-        // Drag handle along a panel edge. `x` is the strip's left edge and
-        // `sign` is +1 when dragging right widens the panel (left-hand panels),
-        // -1 when it narrows it (right-hand panels).
+        // Height of the open bottom panel, clamped to what the window can
+        // actually spare (bottomHeightLimit()) so shrinking the window cannot
+        // leave the editor all panel and no viewport.
+        [[nodiscard]] float bottomPanelPx() const;
+        // The tab strip that is left when the panel is collapsed.
+        [[nodiscard]] float collapsedBottomPx() const;
+        // What the side panels have to keep clear above the status bar: the
+        // panel plus its splitter when open, the collapsed strip when not.
+        [[nodiscard]] float bottomBandPx() const;
+        // Largest bottom panel height, unscaled, for the current window.
+        [[nodiscard]] float bottomHeightLimit() const;
+
+        // The grab strip both splitters below are made of. `sign` is +1 when
+        // dragging along the axis grows the value, -1 when it shrinks it.
+        void drawSplitterStrip(const char* id, float x, float top, float width, float height,
+                               bool horizontal, float& value, float sign, float lo, float hi);
+        // Vertical drag handle beside a side panel. `x` is the strip's left
+        // edge and `sign` is +1 when dragging right widens the panel (left-hand
+        // panels), -1 when it narrows it (right-hand panels).
         void drawSplitter(const char* id, float x, float top, float height,
                           float& width, float sign);
+        // The horizontal twin, along the top edge of the bottom panel: dragging
+        // up makes it taller.
+        void drawHeightSplitter(const char* id, float x, float top, float width,
+                                float& height);
 
         // Undo-friendly ImGui helpers: begin a transaction when a widget is
         // activated and close it when the edit finishes, so a drag collapses to
@@ -849,6 +898,11 @@ namespace threepp::editor {
         // bar on the next frame it draws. Exists for --screenshot: a live readout
         // that nobody has looked at is a readout nobody knows is right.
         bool selectSensorsTab_ = false;
+        // The same, for the Scripts tab, on an explicit open — and, separately,
+        // for which script inside it. They are two bars: raising a script the
+        // selection moved onto must not also drag the panel off the Console.
+        bool selectScriptsTab_ = false;
+        std::string selectScriptUuid_;
         std::deque<std::string> console_;
         std::string renameBuffer_;
         // Name as it was when the inspector's name field gained focus, so the
@@ -876,16 +930,19 @@ namespace threepp::editor {
         };
         std::unique_ptr<AnimPreview> animPreview_;
 
-        // The Script Editor window. One instance, editing one object — a text
-        // buffer that is not the document until Apply commits it, which is what
-        // makes the unsaved marker in the title mean something.
+        // One open script — a text buffer that is not the document until Apply
+        // commits it, which is what makes the unsaved marker on its tab mean
+        // something.
         //
         // Not gated on Python: a build without it still edits and saves the
         // source, it just cannot check or run it.
         struct ScriptEditorState {
-            bool open = false;
+            // Presence in scriptEditors_ IS being open; the flag exists because
+            // ImGui's tab close button writes through a bool*. Cleared entries
+            // are erased at the top of the next updateScriptEditors().
+            bool open = true;
             // The object being edited, by uuid: a play/stop replaces the whole
-            // graph, and the window has to survive that.
+            // graph, and the tabs have to survive that.
             std::string uuid;
             std::string label;
             // What the text box holds, and what the document holds. Different
@@ -895,10 +952,21 @@ namespace threepp::editor {
             // Syntax error from the last Apply, shown in red until the next.
             std::string status;
             // Take the keyboard on the frame after an explicit open (but never
-            // when the window merely follows the selection).
+            // when a tab is merely raised or synced under the user).
             bool focus = false;
+            // The object is gone from the scene, as of the last update. Resolved
+            // there so the tab body does not walk the graph a second time.
+            bool missing = false;
         };
-        ScriptEditorState scriptEditor_;
+        // In tab order, one entry per open script. A vector and not a map: the
+        // order on screen is the order they were opened in, and there are never
+        // enough of them for the lookup to be worth a hash.
+        std::vector<ScriptEditorState> scriptEditors_;
+        // Which one is visible, by uuid — set by the inner tab bar as it draws.
+        std::string activeScriptUuid_;
+        // The selection as the raise-on-selection rule last saw it, so that the
+        // rule fires on a change rather than on a mismatch.
+        std::string lastScriptSelection_;
 
         // "Edit in VS Code" on an inline script. The source is exported to a
         // scratch .py, VS Code is pointed at it, and the file is polled once a

--- a/apps/editor/EditorSelfTest.cpp
+++ b/apps/editor/EditorSelfTest.cpp
@@ -740,6 +740,41 @@ int EditorApp::runScreenshot() {
     }
 #endif
 
+    // And the Script Editor, docked. It is the shot that shows what it stopped
+    // being: a floating window parked over the viewport, covering the object
+    // the script was being written about. Dragged tall, because the height is
+    // a preference now and this is the one tab that wants it.
+    if (auto* subject = document_.scene().getObjectByName("Box near the crest")) {
+        // Two of them, because one script open and several open do not look the
+        // same and both are worth having a picture of.
+        setInlineScript(*subject, inlineScriptTemplate(), "New Inline Script");
+        selectObject(subject);
+        openScriptEditor(*subject);
+
+        const float userHeight = settings_.bottomPanelHeight;
+        settings_.bottomPanelHeight = std::min(340.f, bottomHeightLimit());
+        camera_.position.set(-4.f, 9.f, 20.f);
+        orbit_->target.set(0.f, 2.f, 10.f);
+        playFor(0.3f);
+        wrote = shoot(sibling("_script_editor")) && wrote;
+
+        if (auto* other = document_.scene().getObjectByName("Lidar Mast")) {
+            setInlineScript(*other,
+                            "# A second script, open at the same time as the first.\n"
+                            "class Sweep:\n"
+                            "\n"
+                            "    rate = 0.5\n"
+                            "\n"
+                            "    def update(self, dt):\n"
+                            "        self.obj.rotation.y += self.rate * dt\n",
+                            "New Inline Script");
+            openScriptEditor(*other);
+            playFor(0.3f);
+            wrote = shoot(sibling("_script_editor_two")) && wrote;
+        }
+        settings_.bottomPanelHeight = userHeight;
+    }
+
     return wrote ? 0 : 1;
 }
 
@@ -2019,6 +2054,66 @@ int EditorApp::runSelfTest() {
     selectObject(cameraRaw);
     step();
 
+    // --- the bottom panel is a size, not a switch --------------------------
+    // The height is a dragged preference, so everything laid out against the
+    // panel has to read it rather than a constant — the camera dock above all,
+    // since it shares the band and is drawn by the renderer, not by ImGui.
+    {
+        const float s = contentScale_;
+        // Saved and put back: this is a persisted preference the user has
+        // dragged, and a test run is not a reason to move it. Every height
+        // below is derived from the minimum rather than from theirs — someone
+        // who has already dragged the panel to the limit leaves no headroom to
+        // grow into, and that is a valid preference, not a failing editor.
+        const float userHeight = settings_.bottomPanelHeight;
+        float dockX = 0, dockY = 0, dockW = 0, dockH = 0;
+
+        settings_.bottomPanelHeight = EditorSettings::minBottomHeight;
+        step();
+
+        check(cameraDockRect(dockX, dockY, dockW, dockH) &&
+                      std::abs(dockH - bottomPanelPx()) < 0.5f,
+              "the camera dock is exactly as tall as the bottom panel");
+        check(std::abs(bottomBandPx() - bottomPanelPx()) < 0.5f,
+              "the side panels come down to the bottom panel with no seam between");
+
+        // Against the limit, not a round number: a test window on a 200% display
+        // has little room to spare, and the point here is that the panel takes
+        // the height it is given, not that any particular height fits.
+        const float taller = std::min(EditorSettings::minBottomHeight + 60.f, bottomHeightLimit());
+        settings_.bottomPanelHeight = taller;
+        step();
+        check(taller > EditorSettings::minBottomHeight &&
+                      std::abs(bottomPanelPx() - taller * s) < 0.5f,
+              "a taller panel is a taller panel");
+        check(cameraDockRect(dockX, dockY, dockW, dockH) &&
+                      std::abs(dockH - bottomPanelPx()) < 0.5f,
+              "the dock grows with it");
+
+        // A settings file (or a shrunken window) must not be able to push the
+        // viewport off the screen.
+        settings_.bottomPanelHeight = 100000.f;
+        step();
+        check(std::abs(bottomPanelPx() - bottomHeightLimit() * s) < 0.5f,
+              "an absurd height clamps to what the window can spare");
+        check(bottomPanelPx() < static_cast<float>(renderer_->size().height()) -
+                                        menuHeight_ - toolbarHeight_ - statusHeight_,
+              "the clamp leaves a viewport to look at");
+        check(settings_.bottomPanelHeight == 100000.f,
+              "clamping the layout does not rewrite the preference");
+
+        settings_.bottomPanelHeight = userHeight;
+        bottomPanelOpen_ = false;
+        step();
+        check(std::abs(bottomBandPx() - collapsedBottomPx()) < 0.5f,
+              "collapsed, the band is just the tab strip");
+        check(!cameraDockRect(dockX, dockY, dockW, dockH),
+              "and the camera dock collapses with it");
+
+        bottomPanelOpen_ = true;
+        step();
+    }
+
     // --- the preview dock SHADES ------------------------------------------
     // A selected camera renders its view through the renderer's secondary
     // scissored pane. On Vulkan that path drew flat unlit fills with no clear
@@ -2246,25 +2341,30 @@ int EditorApp::runSelfTest() {
         std::filesystem::remove(throwerPath, ec);
 
         // The same drive again with no file anywhere: source authored in the
-        // Script Editor and stored in the scene. Through the window's own apply
+        // Script Editor and stored in the scene. Through the tab's own apply
         // path, which is what the user's Ctrl+Enter runs.
         if (auto* box = document_.scene().getObjectByName("Box")) {
 
             const auto undosBefore = commands_.undoCount();
 
+            const auto boxUuid = box->uuid;
             openScriptEditor(*box);
-            check(scriptEditor_.open, "the Script Editor opens on the object");
+            check(scriptEditorFor(boxUuid) != nullptr, "the Script Editor opens on the object");
+            check(bottomPanelOpen_, "opening it brings the bottom panel up with it");
+            check(activeScriptEditor() && activeScriptEditor()->uuid == boxUuid,
+                  "and that script is the one Apply acts on");
             // Indented with TABS on purpose: Apply has to normalize them, or
             // this source is a TabError waiting for the first space-indented
             // line somebody adds later.
-            scriptEditor_.buffer = "class Inline:\n"
-                                   "\tspeed = 2.0\n"
-                                   "\n"
-                                   "\tdef start(self, obj):\n"
-                                   "\t\tself.obj = obj\n"
-                                   "\n"
-                                   "\tdef update(self, dt):\n"
-                                   "\t\tself.obj.rotation.y += self.speed * dt\n";
+            scriptEditorFor(boxUuid)->buffer =
+                    "class Inline:\n"
+                    "\tspeed = 2.0\n"
+                    "\n"
+                    "\tdef start(self, obj):\n"
+                    "\t\tself.obj = obj\n"
+                    "\n"
+                    "\tdef update(self, dt):\n"
+                    "\t\tself.obj.rotation.y += self.speed * dt\n";
             applyScriptEditor();
             step();
 
@@ -2272,13 +2372,14 @@ int EditorApp::runSelfTest() {
             check(stored.isInline(), "the inline source is recorded in userData");
             check(stored.path.empty(), "an inline script carries no file path");
             check(stored.source.find('\t') == std::string::npos, "Apply normalizes tabs to spaces");
-            check(scriptEditor_.status.empty(), "valid source passes the syntax check");
+            check(scriptEditorFor(boxUuid)->status.empty(), "valid source passes the syntax check");
             check(commands_.undoCount() == undosBefore + 1, "Apply is one undo entry");
 
             commands_.undo();
             step();
             check(!ScriptConfig::read(*box).has_value(), "undo takes the inline script back off");
-            check(!scriptEditor_.open, "the window closes when its script is undone away");
+            check(scriptEditorFor(boxUuid) == nullptr,
+                  "the script's tab closes when its script is undone away");
             commands_.redo();
             step();
             check(ScriptConfig::read(*box).has_value(), "redo puts it back");
@@ -2321,15 +2422,16 @@ int EditorApp::runSelfTest() {
             if (restored) {
                 const auto uuid = restored->uuid;
                 openScriptEditor(*restored);
-                scriptEditor_.buffer = "class Broken:\n    def update(self dt):\n        pass\n";
+                scriptEditorFor(uuid)->buffer =
+                        "class Broken:\n    def update(self dt):\n        pass\n";
                 applyScriptEditor();
                 step();
 
-                check(!scriptEditor_.status.empty(), "Apply reports the syntax error");
-                check(scriptEditor_.status.find("line 2") != std::string::npos,
+                check(!scriptEditorFor(uuid)->status.empty(), "Apply reports the syntax error");
+                check(scriptEditorFor(uuid)->status.find("line 2") != std::string::npos,
                       "the syntax error carries its line number");
                 check(ScriptConfig::read(*restored).value_or(ScriptConfig{}).source ==
-                              scriptEditor_.buffer,
+                              scriptEditorFor(uuid)->buffer,
                       "a syntax error does not block Apply");
 
                 startPlay();
@@ -2443,15 +2545,125 @@ int EditorApp::runSelfTest() {
                 }
 
                 if (auto* clear = document_.scene().getObjectByName("Box")) {
+                    const auto uuid = clear->uuid;
                     assignScript(*clear, {});
                     step();
                     check(!ScriptConfig::read(*clear).has_value(), "clearing removes the inline script");
-                    check(!scriptEditor_.open, "clearing the script closes the Script Editor");
+                    check(scriptEditorFor(uuid) == nullptr, "clearing the script closes its tab");
                 }
             }
         }
     }
 #endif
+
+    // --- two scripts open at once ------------------------------------------
+    // The editor used to be ONE buffer that retargeted itself onto whatever was
+    // selected, which is unusable for the thing people actually do: write two
+    // scripts that talk to each other. Each open script now keeps its own tab,
+    // its own buffer and its own syntax error, and the only thing the selection
+    // does is raise a tab that already exists.
+    {
+        auto* first = document_.scene().getObjectByName("Box");
+        auto* second = document_.scene().getObjectByName("Ground");
+        if (first && second) {
+
+            const auto firstUuid = first->uuid;
+            const auto secondUuid = second->uuid;
+
+            setInlineScript(*first, "class A:\n    def update(self, dt):\n        pass\n", "Script A");
+            setInlineScript(*second, "class B:\n    def update(self, dt):\n        pass\n", "Script B");
+            step();
+
+            openScriptEditor(*first);
+            openScriptEditor(*second);
+            step();
+
+            check(scriptEditors_.size() == 2, "two scripts open as two tabs");
+            check(scriptEditorFor(firstUuid) && scriptEditorFor(secondUuid),
+                  "each object keeps its own");
+            check(activeScriptEditor() && activeScriptEditor()->uuid == secondUuid,
+                  "the one opened last is the one in front");
+
+            // With `first` selected the whole time: an explicit open outranks
+            // the raise-on-selection rule, which otherwise pulls the bar back to
+            // the selected object on the next frame and makes opening a script
+            // for anything else impossible.
+            selectObject(first);
+            step();
+            openScriptEditor(*second);
+            step(3);
+            check(activeScriptEditor() && activeScriptEditor()->uuid == secondUuid,
+                  "opening a script for an object that is not selected stays open");
+
+            // The whole point: an edit in one is not an edit in the other, and
+            // neither is silently retargeted by clicking around the scene.
+            const std::string edited = "class A:\n    speed = 3.0\n"
+                                       "    def update(self, dt):\n        pass\n";
+            scriptEditorFor(firstUuid)->buffer = edited;
+            selectObject(second);
+            step();
+            check(scriptEditorFor(firstUuid) && scriptEditorFor(firstUuid)->buffer == edited,
+                  "an unsaved buffer survives the selection moving off it");
+            check(scriptEditorFor(secondUuid) &&
+                          scriptEditorFor(secondUuid)->buffer.find("class B") != std::string::npos,
+                  "and the other tab still holds its own object's source");
+
+            // Selecting an object that has a tab raises it; selecting one that
+            // does not opens nothing (that is what Edit… is for).
+            selectObject(first);
+            step();
+            check(activeScriptEditor() && activeScriptEditor()->uuid == firstUuid,
+                  "selecting an object with a tab open raises that tab");
+            selectObject(&document_.scene());
+            step();
+            check(scriptEditors_.size() == 2,
+                  "selecting something without one opens nothing");
+
+            // Reopening a tab that is already there keeps what was typed into
+            // it rather than reloading over the top of it.
+            openScriptEditor(*first);
+            step();
+            check(scriptEditors_.size() == 2, "reopening an object reuses its tab");
+            check(scriptEditorFor(firstUuid)->buffer == edited, "and keeps the unsaved text in it");
+
+            // Apply acts on the visible one, and only on it.
+            const auto sourceOf = [this](const char* name) {
+                auto* object = document_.scene().getObjectByName(name);
+                return object ? ScriptConfig::read(*object).value_or(ScriptConfig{}).source
+                              : std::string{};
+            };
+            applyScriptEditor();
+            step();
+            check(sourceOf("Box").find("speed = 3.0") != std::string::npos,
+                  "Apply commits the visible script");
+            check(sourceOf("Ground").find("class B") != std::string::npos,
+                  "and leaves the other object's alone");
+
+            // Both survive a play/stop: the graph is replaced wholesale and the
+            // tabs are keyed by uuid precisely so they do not go with it.
+            startPlay();
+            step(3);
+            stopPlay();
+            step();
+            check(scriptEditors_.size() == 2, "both tabs survive play/stop");
+            check(scriptEditorFor(firstUuid) && !scriptEditorFor(firstUuid)->missing,
+                  "and are still pointing at live objects");
+
+            // Closing one leaves the other, and closing the last takes the
+            // Scripts tab with it.
+            scriptEditorFor(firstUuid)->open = false;
+            step();
+            check(scriptEditors_.size() == 1 && scriptEditorFor(secondUuid),
+                  "closing one tab leaves the other");
+            scriptEditorFor(secondUuid)->open = false;
+            step();
+            check(scriptEditors_.empty(), "closing the last leaves no Scripts tab at all");
+
+            if (auto* a = document_.scene().getObjectByName("Box")) assignScript(*a, {});
+            if (auto* b = document_.scene().getObjectByName("Ground")) assignScript(*b, {});
+            step();
+        }
+    }
 
     // "Edit in VS Code", end to end and without VS Code: the export, the
     // workspace, the poll, the sync back through the Script Editor's Apply, and
@@ -2515,7 +2727,7 @@ int EditorApp::runSelfTest() {
             check(std::filesystem::exists(scratch), "the source is exported to a scratch file");
             check(ScriptWorkspace::readSource(scratch) == source,
                   "the export is the committed source, byte for byte");
-            check(scriptEditor_.open, "the Script Editor comes along to show the session");
+            check(scriptEditorFor(uuid) != nullptr, "the Script Editor comes along to show the session");
 
             // The workspace: written once, carrying this build's stub path, and
             // never written over the top of what the user made of it.

--- a/apps/editor/ExternalScriptEdit.cpp
+++ b/apps/editor/ExternalScriptEdit.cpp
@@ -265,9 +265,10 @@ void EditorApp::startExternalEdit(Object3D& object, ExternalEditKind kind) {
         source = config.source;
     }
 
-    // One session at a time — the same rule the Script Editor window follows,
-    // and for the same reason: two of them would be two answers to "what is
-    // this object's source".
+    // One session at a time. Not for the reason the editor once held one tab —
+    // it holds as many as you open now — but because a session owns a scratch
+    // file, a command-stack transaction and a poll slot, and two of them would
+    // be two writers racing to answer "what is this object's source".
     if (externalEdit_.active) {
         if (externalEdit_.uuid == object.uuid) return;
         stopExternalEdit("another object took over");
@@ -307,10 +308,10 @@ void EditorApp::startExternalEdit(Object3D& object, ExternalEditKind kind) {
     commands_.beginTransaction();
     externalEdit_.transaction = true;
 
-    // The window comes along read-only, because a session needs somewhere to
+    // A tab comes along read-only, because a session needs somewhere to
     // announce itself and somewhere to be stopped.
     openScriptEditor(object);
-    scriptEditor_.focus = false;
+    if (auto* editor = scriptEditorFor(object.uuid)) editor->focus = false;
 
     log("editing " + label + " externally - " + file.generic_string());
     launchExternalEditor(dir, file);
@@ -395,8 +396,8 @@ void EditorApp::pollExternalEdit(float dt) {
     externalEdit_.waiting = false;
 
     if (externalEdit_.kind == ExternalEditKind::Generator) {
-        // No Script Editor window in this path — a generator's source is not a
-        // behaviour script and does not belong in the window that owns those.
+        // No Script Editor tab in this path — a generator's source is not a
+        // behaviour script and does not belong in the tab that owns those.
         externalEdit_.synced = applyGeneratorSource(*target, text);
         ++externalEdit_.syncs;
 
@@ -419,19 +420,22 @@ void EditorApp::pollExternalEdit(float dt) {
         return;
     }
 
-    // Through the window, not around it. Retargeting it first is for the case
-    // where the user opened the Script Editor on some other object in the
-    // meantime — Apply writes to whatever the window is pointing at.
-    if (scriptEditor_.uuid != externalEdit_.uuid) {
-        openScriptEditor(*target);
-        scriptEditor_.focus = false;
-    }
-    scriptEditor_.buffer = text;
-    applyScriptEditor();
+    // Through this object's own tab, not around it and not through whichever
+    // one happens to be visible: the sync is the same normalization, the same
+    // compile check and the same undo entry a typed edit gets. Reopened without
+    // revealing if the user closed it — the session outlives its tab, and a
+    // save must not yank the panel out from under them to say so.
+    if (!scriptEditorFor(externalEdit_.uuid)) openScriptEditor(*target, false);
 
-    externalEdit_.synced = scriptEditor_.committed;
+    auto* editor = scriptEditorFor(externalEdit_.uuid);
+    if (!editor) return;
+
+    editor->buffer = text;
+    applyScriptEditor(*editor);
+
+    externalEdit_.synced = editor->committed;
     ++externalEdit_.syncs;
 
     log("synced " + externalEdit_.label + " from " + externalEdit_.file.filename().string() +
-        (scriptEditor_.status.empty() ? "" : " - with a syntax error"));
+        (editor->status.empty() ? "" : " - with a syntax error"));
 }

--- a/apps/editor/PanelLayout.hpp
+++ b/apps/editor/PanelLayout.hpp
@@ -11,12 +11,11 @@
 
 namespace threepp::editor::layout {
 
-    // Height at 100% DPI; multiply by the monitor content scale. The side
-    // panel widths are user-draggable and live in EditorSettings instead —
-    // see EditorApp::hierarchyPx() / inspectorPx().
-    inline constexpr float bottomHeight = 200.f;
+    // Every panel size is user-draggable and lives in EditorSettings rather
+    // than here — see EditorApp::hierarchyPx() / inspectorPx() /
+    // bottomPanelPx(), which apply the monitor content scale.
 
-    // Grab strip between a side panel and the viewport.
+    // Grab strip between a panel and the viewport.
     inline constexpr float splitterThickness = 6.f;
 
     inline constexpr ImGuiWindowFlags panelFlags =

--- a/apps/editor/panels/AssetPanel.cpp
+++ b/apps/editor/panels/AssetPanel.cpp
@@ -200,11 +200,10 @@ void EditorApp::drawBottomPanel() {
     // viewport, too short to see anything in and too small to click in. The
     // matching strip on the right is the camera dock — see cameraDockRect().
     const float right = inspectorPx();
-    const float collapsedHeight = ImGui::GetFrameHeight() + 6 * s;
-    const float height = bottomPanelOpen_ ? layout::bottomHeight * s : collapsedHeight;
+    const float height = bottomPanelOpen_ ? bottomPanelPx() : collapsedBottomPx();
+    const float top = viewport->Pos.y + viewport->Size.y - statusHeight_ - height;
 
-    ImGui::SetNextWindowPos({viewport->Pos.x,
-                             viewport->Pos.y + viewport->Size.y - statusHeight_ - height});
+    ImGui::SetNextWindowPos({viewport->Pos.x, top});
     ImGui::SetNextWindowSize({std::max(viewport->Size.x - right, 120.f * s), height});
 
     if (ImGui::Begin("##bottom", nullptr, layout::barFlags)) {
@@ -239,8 +238,35 @@ void EditorApp::drawBottomPanel() {
                 drawSensorsTab();
                 ImGui::EndTabItem();
             }
+            // Last, and only while a script is open: it is the one tab that
+            // comes and goes, and a tab bar whose fixed entries move under the
+            // pointer is a tab bar nobody can aim at. No close button — the
+            // scripts inside it have their own, and this tab is gone when the
+            // last of them is.
+            if (!scriptEditors_.empty()) {
+                ImGuiTabItemFlags scriptFlags = 0;
+                if (selectScriptsTab_) {
+                    scriptFlags = ImGuiTabItemFlags_SetSelected;
+                    selectScriptsTab_ = false;
+                }
+                const auto label = scriptsTabLabel();
+                if (ImGui::BeginTabItem(label.c_str(), nullptr, scriptFlags)) {
+                    drawScriptsTab();
+                    ImGui::EndTabItem();
+                }
+            }
             ImGui::EndTabBar();
         }
     }
     ImGui::End();
+
+    // Straddling the boundary rather than sitting in a gap of its own, and
+    // across the camera dock too: the dock's top edge is the panel's, so the
+    // whole band moves together. Drawn last, so it takes the hover from the
+    // side panels it overlaps.
+    if (bottomPanelOpen_) {
+        drawHeightSplitter("##bottomSplit", viewport->Pos.x,
+                           top - layout::splitterThickness * s, viewport->Size.x,
+                           settings_.bottomPanelHeight);
+    }
 }

--- a/apps/editor/panels/HierarchyPanel.cpp
+++ b/apps/editor/panels/HierarchyPanel.cpp
@@ -224,8 +224,7 @@ void EditorApp::drawHierarchy() {
 
     const float width = hierarchyPx();
     const float top = menuHeight_ + toolbarHeight_;
-    const float bottom = statusHeight_ + (bottomPanelOpen_ ? layout::bottomHeight * s
-                                                           : ImGui::GetFrameHeight() + 6 * s);
+    const float bottom = statusHeight_ + bottomBandPx();
     const float height = std::max(viewport->Size.y - top - bottom, 40.f * s);
 
     ImGui::SetNextWindowPos({viewport->Pos.x, viewport->Pos.y + top});

--- a/apps/editor/panels/InspectorPanel.cpp
+++ b/apps/editor/panels/InspectorPanel.cpp
@@ -215,8 +215,7 @@ void EditorApp::drawInspector() {
 
     const float width = inspectorPx();
     const float top = menuHeight_ + toolbarHeight_;
-    const float bottom = statusHeight_ + (bottomPanelOpen_ ? layout::bottomHeight * s
-                                                           : ImGui::GetFrameHeight() + 6 * s);
+    const float bottom = statusHeight_ + bottomBandPx();
     const float height = std::max(viewport->Size.y - top - bottom, 40.f * s);
 
     ImGui::SetNextWindowPos({viewport->Pos.x + viewport->Size.x - width, viewport->Pos.y + top});
@@ -1307,7 +1306,7 @@ void EditorApp::drawScriptSection(Object3D& object) {
 
     // --- where the code is ---------------------------------------------------
     // Two forms, never both: a .py file, or source stored in this scene and
-    // edited in the Script Editor window.
+    // edited in the Script Editor tab.
     const float buttonWidth = 90 * contentScale_;
 
     if (config.isInline()) {
@@ -1369,7 +1368,7 @@ void EditorApp::drawScriptSection(Object3D& object) {
     if (!externalEditActive(object) && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
         ImGui::SetTooltip(config.isInline()
                                   ? "Export the source to a file, open it in VS Code, and take\n"
-                                    "every save back into the scene while the window is open.\n"
+                                    "every save back into the scene while the session is live.\n"
                                     "A .vscode/settings.json is written beside it so Pylance\n"
                                     "completes `import threepp`."
                                   : "Open the script's folder in VS Code, with a\n"

--- a/apps/editor/panels/ScriptEditorPanel.cpp
+++ b/apps/editor/panels/ScriptEditorPanel.cpp
@@ -1,13 +1,23 @@
-// The Script Editor: a floating window over one object's inline script source.
+// The Script Editor: the bottom panel's Scripts tab, holding one inner tab per
+// open script.
 //
 // Deliberately a plain text box. No syntax highlighting, no autocomplete, no
 // third-party editor widget — v1 is "type Python, see whether it parses, press
 // Play", and the one thing it does add over Notepad is that the source lives in
 // the scene rather than in a file beside it.
 //
-// It is a normal ImGui window, not one of the fixed panels: movable, resizable
-// and closable, because it is a tool you open over your work rather than part
-// of the frame around it.
+// It used to be a floating window, and floating over the viewport is exactly
+// what was wrong with it: a text box big enough to write in covered the thing
+// the script was being written about. Docked beside the console it takes room
+// from nothing — the bottom panel is draggable now, so "big enough" is a drag
+// on its top edge rather than a window parked over the scene.
+//
+// It also used to be ONE editor that retargeted itself onto the selection,
+// which meant writing two scripts that talk to each other was a matter of
+// clicking back and forth and hoping nothing was dropped in transit. Now every
+// script you open keeps its own tab, its own buffer and its own syntax error
+// until you close it. Still one script per object — that is ScriptConfig's
+// rule, not this file's.
 //
 // Nothing in here runs the script. Apply compiles the source to find syntax
 // errors and stops there; the code executes when the user presses Play, and
@@ -24,8 +34,10 @@
 #include "threepp/extras/imgui/ImguiContext.hpp"
 #include "threepp/scenes/Scene.hpp"
 
+#include <algorithm>
 #include <cfloat>
 #include <string>
+#include <vector>
 
 using namespace threepp;
 using namespace threepp::editor;
@@ -91,28 +103,63 @@ std::string EditorApp::inlineScriptTemplate() {
            "        self.obj.rotation.y += self.speed * dt\n";
 }
 
-void EditorApp::openScriptEditor(const Object3D& object) {
+EditorApp::ScriptEditorState* EditorApp::scriptEditorFor(const std::string& uuid) {
 
-    auto& state = scriptEditor_;
+    for (auto& state : scriptEditors_) {
+        if (state.uuid == uuid) return &state;
+    }
+    return nullptr;
+}
+
+EditorApp::ScriptEditorState* EditorApp::activeScriptEditor() {
+
+    if (auto* state = scriptEditorFor(activeScriptUuid_)) return state;
+    // Nothing has drawn yet this session, or the active one was just closed:
+    // the first tab is what the bar will show.
+    return scriptEditors_.empty() ? nullptr : &scriptEditors_.front();
+}
+
+void EditorApp::openScriptEditor(const Object3D& object, bool reveal) {
+
     const auto config = ScriptConfig::read(object).value_or(ScriptConfig{});
 
-    // Reopening the object we were already on keeps the working text: the
-    // window's Close button is not a decision to discard an edit, and Revert
-    // is right there for when it is.
-    const bool same = state.uuid == object.uuid && !state.buffer.empty();
-    state.committed = config.source;
-    if (!same) state.buffer = config.source;
+    auto* state = scriptEditorFor(object.uuid);
+    if (!state) {
+        state = &scriptEditors_.emplace_back();
+        state->uuid = object.uuid;
+        state->buffer = config.source;
+    }
+    // An object that already has a tab keeps its working text and its syntax
+    // error: both describe the buffer, and the buffer is still there. Closing a
+    // tab is not a decision to discard an edit, and Revert is right there for
+    // when it is.
+    state->committed = config.source;
+    state->label = object.name.empty() ? object.type() : object.name;
+    state->missing = false;
+    state->open = true;
 
-    state.uuid = object.uuid;
-    state.label = object.name.empty() ? object.type() : object.name;
-    state.status.clear();
-    state.open = true;
-    state.focus = true;
+    if (reveal) {
+        // A tab nobody can see is not an editor. Opening one is an explicit
+        // request to look at it, so the panel comes up with it.
+        bottomPanelOpen_ = true;
+        selectScriptsTab_ = true;
+        selectScriptUuid_ = state->uuid;
+        activeScriptUuid_ = state->uuid;
+        state->focus = true;
+        // Whatever is selected has now been accounted for: an explicit open
+        // outranks the raise-on-selection rule, which would otherwise pull the
+        // bar back to the selected object on the very next frame.
+        lastScriptSelection_ = selection_.get() ? selection_.get()->uuid : std::string{};
+    }
 }
 
 void EditorApp::applyScriptEditor() {
 
-    auto& state = scriptEditor_;
+    if (auto* state = activeScriptEditor()) applyScriptEditor(*state);
+}
+
+void EditorApp::applyScriptEditor(ScriptEditorState& state) {
+
     auto* target = findByUuid(document_.scene(), state.uuid);
     if (!target || isPlaying()) return;
 
@@ -137,175 +184,239 @@ void EditorApp::applyScriptEditor() {
     state.committed = state.buffer;
 }
 
-void EditorApp::drawScriptEditor() {
+void EditorApp::updateScriptEditors() {
 
-    auto& state = scriptEditor_;
-    if (!state.open) return;
+    const auto closed = [](const ScriptEditorState& state) { return !state.open; };
 
-    const float s = contentScale_;
+    // Tabs closed by their × last frame. Buried here rather than mid-draw: the
+    // inner tab bar holds a pointer into this vector for the length of a frame.
+    std::erase_if(scriptEditors_, closed);
 
-    // The object this window is showing is being edited in VS Code: the buffer
-    // is a mirror of that file, and the window is where the session announces
-    // itself and can be stopped.
-    const bool external = externalEdit_.active && externalEdit_.uuid == state.uuid;
-
-    // Follow the selection — but only with nothing to lose. Retargeting a
-    // buffer someone is still typing into would silently drop it, so an unsaved
-    // window stays on the object it was opened for however the selection moves.
-    // An external session pins it outright: it is that object's file on screen.
-    if (state.buffer == state.committed && !external) {
-        if (auto* selected = selection_.get(); selected && selected->uuid != state.uuid) {
-            if (const auto config = ScriptConfig::read(*selected); config && config->isInline()) {
-                openScriptEditor(*selected);
-                // Following the selection must not steal the keyboard from
-                // whatever the user was actually doing.
-                state.focus = false;
-            }
+    // Selecting an object that already has a tab raises it. That is what
+    // following the selection means once there can be more than one: the single
+    // editor used to RETARGET itself onto the selection, which is exactly what
+    // tabs exist to stop — and it could only ever do it with nothing to lose,
+    // because retargeting a buffer somebody is typing into drops it. Only the
+    // inner bar moves; the panel stays on whatever tab you were reading.
+    //
+    // On the CHANGE, not on the mismatch. A rule that fired whenever the
+    // selection and the visible tab disagreed would fight every explicit open —
+    // opening a script on one object while another is selected would bounce
+    // straight back on the next frame — and would pin the bar so that clicking
+    // between two open scripts did nothing.
+    const std::string selected = selection_.get() ? selection_.get()->uuid : std::string{};
+    if (selected != lastScriptSelection_) {
+        lastScriptSelection_ = selected;
+        if (!selected.empty() && scriptEditorFor(selected)) {
+            selectScriptUuid_ = selected;
+            // Active immediately, not when the bar catches up: ImGui applies a
+            // SetSelected at the NEXT BeginTabBar, and Apply must not act on
+            // the script the user just navigated away from in between.
+            activeScriptUuid_ = selected;
         }
     }
 
-    // By uuid, not by pointer: a play/stop replaces the whole graph.
-    auto* target = findByUuid(document_.scene(), state.uuid);
-    if (target) {
+    if (scriptEditors_.empty()) return;
+
+    for (auto& state : scriptEditors_) {
+        // By uuid, not by pointer: a play/stop replaces the whole graph.
+        auto* target = findByUuid(document_.scene(), state.uuid);
+        state.missing = target == nullptr;
+        if (!target) continue;
+
         // The document is the truth. An undo, or Clear in the inspector, moves
-        // the committed text under the window, and the unsaved marker has to
+        // the committed text under the tab, and the unsaved marker has to
         // reflect that rather than the state at open time.
         state.committed = ScriptConfig::read(*target).value_or(ScriptConfig{}).source;
         state.label = target->name.empty() ? target->type() : target->name;
+
+        // The object's inline script is gone (Clear in the inspector, an undo,
+        // or an Apply of an empty buffer): there is nothing left to edit, so
+        // the tab goes away. Nothing is lost by it — the removal is one Ctrl+Z
+        // away and the text stays in the buffer, so reopening the object brings
+        // it back.
+        if (state.committed.empty()) state.open = false;
     }
 
+    // And the ones that just lost their script, in the same frame the document
+    // lost it: "the tab is gone" has to be true the moment Clear or Ctrl+Z
+    // says so, not a frame later.
+    std::erase_if(scriptEditors_, closed);
+}
+
+std::string EditorApp::scriptsTabLabel() const {
+
+    // No object name and no count: this tab sits beside Console and Assets in
+    // a bar only as wide as the window minus the camera dock, and a label that
+    // grows pushes them off the end of it. Which scripts are open is the inner
+    // bar's job. The ### id keeps the tab's identity stable while the unsaved
+    // marker comes and goes — otherwise every keystroke would close the tab and
+    // open a new one beside it.
+    const bool unsaved = std::any_of(scriptEditors_.begin(), scriptEditors_.end(),
+                                     [](const ScriptEditorState& state) {
+                                         return state.buffer != state.committed;
+                                     });
+
+    return std::string("Scripts") + (unsaved ? "*" : "") + "###scriptsTab";
+}
+
+std::string EditorApp::scriptTabLabel(const ScriptEditorState& state) {
+
+    // Here the object name IS the label — this bar holds nothing else, and
+    // which object a script belongs to is the only thing that tells two of them
+    // apart. Keyed by uuid so a rename moves the label rather than the tab.
+    return state.label + (state.buffer == state.committed ? "" : "*") +
+           "###script:" + state.uuid;
+}
+
+void EditorApp::drawScriptsTab() {
+
+    // A switch asked for this frame lands on the next one — ImGui reads
+    // SetSelected at the following BeginTabBar — so for one frame this bar is
+    // still drawing the tab we are leaving. It must not write that back as the
+    // active script: that would undo the switch and point Apply at the script
+    // the user just navigated away from.
+    const bool switching = !selectScriptUuid_.empty();
+
+    if (ImGui::BeginTabBar("##openScripts",
+                           // The list button is not decoration here: a handful
+                           // of open scripts overflows a panel this wide, and
+                           // scroll arrows alone make you hunt for one by name.
+                           ImGuiTabBarFlags_TabListPopupButton |
+                                   ImGuiTabBarFlags_FittingPolicyScroll)) {
+
+        for (auto& state : scriptEditors_) {
+
+            ImGuiTabItemFlags flags = 0;
+            if (selectScriptUuid_ == state.uuid) {
+                flags = ImGuiTabItemFlags_SetSelected;
+                selectScriptUuid_.clear();
+            }
+
+            const auto label = scriptTabLabel(state);
+            if (ImGui::BeginTabItem(label.c_str(), &state.open, flags)) {
+                if (!switching) activeScriptUuid_ = state.uuid;
+                drawScriptTab(state);
+                ImGui::EndTabItem();
+            }
+        }
+        ImGui::EndTabBar();
+    }
+}
+
+void EditorApp::drawScriptTab(ScriptEditorState& state) {
+
+    const float s = contentScale_;
+    const bool external = externalEdit_.active && externalEdit_.uuid == state.uuid;
+    const bool playing = isPlaying();
+    // Read-only during an external session too, and for the same reason as
+    // during Play: the next save would overwrite whatever was typed here.
+    const bool locked = state.missing || playing || external;
     const bool unsaved = state.buffer != state.committed;
+    const float buttonWidth = 110 * s;
 
-    // The object's inline script is gone (Clear in the inspector, an undo, or
-    // an Apply of an empty buffer): there is nothing left to edit, so the window
-    // goes away. Nothing is lost by it — the removal is one Ctrl+Z away and the
-    // text stays in the buffer, so reopening the object brings it back.
-    if (target && state.committed.empty()) {
-        state.open = false;
-        return;
+    // Every widget below is per script, and the text box above all: ImGui keys
+    // an InputText's cursor, selection and undo stack by id, so two scripts
+    // sharing one would carry all three across when you switch tabs.
+    ImGui::PushID(state.uuid.c_str());
+
+    ImGui::BeginDisabled(locked);
+    if (ImGui::Button("Apply", {buttonWidth, 0})) applyScriptEditor(state);
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("Ctrl+Enter. Saves the source into the scene as one undoable step.\n"
+                          "Tabs become four spaces, because Python will not mix them.\n"
+                          "The source is compiled to check that it parses - nothing runs\n"
+                          "until you press Play.");
+    }
+    ImGui::EndDisabled();
+
+    ImGui::SameLine();
+    ImGui::BeginDisabled(locked || !unsaved);
+    if (ImGui::Button("Revert", {buttonWidth, 0})) {
+        state.buffer = state.committed;
+        state.status.clear();
+    }
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        ImGui::SetTooltip("Throw away the edits since the last Apply.");
+    }
+    ImGui::EndDisabled();
+
+    // Everything that says why the box is locked shares the button row: the
+    // panel is as tall as the user dragged it, and a banner on its own line is
+    // a line the script does not get. Which object this is does NOT need a
+    // place here — it is the tab's own label, right above.
+    ImGui::SameLine();
+    if (state.missing) {
+        ImGui::TextColored(theme::danger(), "The object is no longer in the scene.");
+    } else if (external) {
+        if (ImGui::Button("Stop external edit", {buttonWidth * 1.7f, 0})) {
+            stopExternalEdit("stopped from the Script Editor");
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Stop watching the file and delete it. Everything saved so far\n"
+                              "is already in the scene, and the box becomes editable again.");
+        }
+        ImGui::SameLine();
+        ImGui::TextColored(theme::accent(), "Editing externally - syncing on save");
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("%s", externalEdit_.file.generic_string().c_str());
+        }
+        if (playing) {
+            ImGui::SameLine();
+            ImGui::TextColored(theme::warning(), "- applied when you press Stop");
+        }
+    } else if (playing) {
+        // Same rule as the inspector: the play snapshot is put back on Stop, so
+        // an edit made now would be thrown away without a word.
+        ImGui::TextColored(theme::warning(), "Read-only while playing");
+    } else {
+        ImGui::TextColored(theme::muted(), "%s", unsaved ? "unsaved" : "saved in the scene");
     }
 
-    const auto* viewport = ImGui::GetMainViewport();
-    ImGui::SetNextWindowSize({700 * s, 500 * s}, ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowPos({viewport->Pos.x + (viewport->Size.x - 700 * s) * 0.5f,
-                             viewport->Pos.y + (viewport->Size.y - 500 * s) * 0.5f},
-                            ImGuiCond_FirstUseEver);
+    if (!state.status.empty()) {
+        ImGui::PushStyleColor(ImGuiCol_Text, theme::danger());
+        ImGui::TextWrapped("%s", state.status.c_str());
+        ImGui::PopStyleColor();
+    }
 
-    // The ### id keeps the window identity (and therefore its position and
-    // size) stable while the visible title gains and loses its unsaved marker
-    // and follows the object's name.
-    const std::string title = "Script Editor" + std::string(unsaved ? "*" : "") +
-                              " - " + state.label + "###scriptEditor";
+    ImGuiInputTextFlags flags = ImGuiInputTextFlags_AllowTabInput |
+                                ImGuiInputTextFlags_CallbackResize |
+                                // Multiline turns Ctrl+Enter into a validate
+                                // rather than a newline, which is exactly the
+                                // Apply shortcut.
+                                ImGuiInputTextFlags_EnterReturnsTrue;
+    if (locked) flags |= ImGuiInputTextFlags_ReadOnly;
 
-    bool keepOpen = true;
-    if (ImGui::Begin(title.c_str(), &keepOpen, ImGuiWindowFlags_NoSavedSettings)) {
+    if (state.focus) {
+        ImGui::SetKeyboardFocusHere();
+        state.focus = false;
+    }
 
-        const bool missing = target == nullptr;
-        const bool playing = isPlaying();
-        // Read-only during an external session too, and for the same reason as
-        // during Play: the next save would overwrite whatever was typed here.
-        const bool locked = missing || playing || external;
-        const float buttonWidth = 110 * s;
+    // Two widget ids, one per lock state, and that is not cosmetic:
+    // flipping ReadOnly on a LIVE InputText crashes ImGui. A widget
+    // activated while read-only never fills its editing copy (read-only
+    // reads the user buffer directly), so the frame the flag comes off,
+    // the widget dereferences that null copy with the read-only length —
+    // which is exactly what pressing Play with the keyboard in this box
+    // and then pressing Stop used to do. Changing the id instead means the
+    // active widget simply stops being submitted, which ImGui retires
+    // cleanly, and the other one starts from the buffer.
+    const char* boxId = locked ? "##scriptSourceLocked" : "##scriptSource";
 
-        if (missing) {
-            ImGui::TextColored(theme::danger(), "The object is no longer in the scene.");
-        } else if (external) {
-            ImGui::TextColored(theme::accent(), "Editing externally - syncing on save");
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("%s", externalEdit_.file.generic_string().c_str());
-            }
-            if (playing) {
-                ImGui::TextColored(theme::warning(),
-                                   "Playing - a save is applied when you press Stop.");
-            }
-        } else if (playing) {
-            // Same rule as the inspector: the play snapshot is put back on
-            // Stop, so an edit made now would be thrown away without a word.
-            ImGui::TextColored(theme::warning(), "Read-only while playing");
-        }
-
-        if (external) {
-            if (ImGui::Button("Stop external edit", {buttonWidth * 1.7f, 0})) {
-                stopExternalEdit("stopped from the Script Editor");
-            }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Stop watching the file and delete it. Everything saved so far\n"
-                                  "is already in the scene, and the box becomes editable again.");
-            }
-        }
-
-        ImGui::BeginDisabled(locked);
-        if (ImGui::Button("Apply", {buttonWidth, 0})) applyScriptEditor();
-        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            ImGui::SetTooltip("Ctrl+Enter. Saves the source into the scene as one undoable step.\n"
-                              "Tabs become four spaces, because Python will not mix them.\n"
-                              "The source is compiled to check that it parses - nothing runs\n"
-                              "until you press Play.");
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-        ImGui::BeginDisabled(locked || !unsaved);
-        if (ImGui::Button("Revert", {buttonWidth, 0})) {
-            state.buffer = state.committed;
-            state.status.clear();
-        }
-        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-            ImGui::SetTooltip("Throw away the edits since the last Apply.");
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-        if (ImGui::Button("Close", {buttonWidth, 0})) keepOpen = false;
-
-        ImGui::SameLine();
-        ImGui::TextColored(theme::muted(), "%s", unsaved ? "unsaved" : "saved in the scene");
-
-        if (!state.status.empty()) {
-            ImGui::PushStyleColor(ImGuiCol_Text, theme::danger());
-            ImGui::TextWrapped("%s", state.status.c_str());
-            ImGui::PopStyleColor();
-        }
-
-        ImGuiInputTextFlags flags = ImGuiInputTextFlags_AllowTabInput |
-                                    ImGuiInputTextFlags_CallbackResize |
-                                    // Multiline turns Ctrl+Enter into a
-                                    // validate rather than a newline, which is
-                                    // exactly the Apply shortcut.
-                                    ImGuiInputTextFlags_EnterReturnsTrue;
-        if (locked) flags |= ImGuiInputTextFlags_ReadOnly;
-
-        if (state.focus) {
-            ImGui::SetKeyboardFocusHere();
-            state.focus = false;
-        }
-
-        // Two widget ids, one per lock state, and that is not cosmetic:
-        // flipping ReadOnly on a LIVE InputText crashes ImGui. A widget
-        // activated while read-only never fills its editing copy (read-only
-        // reads the user buffer directly), so the frame the flag comes off,
-        // the widget dereferences that null copy with the read-only length —
-        // which is exactly what pressing Play with the keyboard in this box
-        // and then pressing Stop used to do. Changing the id instead means the
-        // active widget simply stops being submitted, which ImGui retires
-        // cleanly, and the other one starts from the buffer.
-        const char* boxId = locked ? "##scriptSourceLocked" : "##scriptSource";
-
-        const float footer = ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
-        if (ImGui::InputTextMultiline(boxId, state.buffer.data(), state.buffer.capacity() + 1,
-                                      {-FLT_MIN, -footer}, flags, growBuffer, &state.buffer)) {
-            if (!locked) applyScriptEditor();
-        }
+    const float footer = ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
+    if (ImGui::InputTextMultiline(boxId, state.buffer.data(), state.buffer.capacity() + 1,
+                                  {-FLT_MIN, -footer}, flags, growBuffer, &state.buffer)) {
+        if (!locked) applyScriptEditor(state);
+    }
 
 #ifdef THREEPP_EDITOR_WITH_PYTHON
-        ImGui::TextColored(theme::muted(),
-                           "Stored in userData[\"scriptSource\"] - it runs when you press Play.");
+    ImGui::TextColored(theme::muted(),
+                       "Stored in userData[\"scriptSource\"] - it runs when you press Play. "
+                       "Drag the panel's top edge for more room.");
 #else
-        ImGui::TextColored(theme::muted(),
-                           "Built without Python scripting - the source is saved, not checked or run.");
+    ImGui::TextColored(theme::muted(),
+                       "Built without Python scripting - the source is saved, not checked or run.");
 #endif
-    }
-    ImGui::End();
 
-    if (!keepOpen) state.open = false;
+    ImGui::PopID();
 }

--- a/doc/editor.md
+++ b/doc/editor.md
@@ -155,10 +155,11 @@ counts, light parameters, camera parameters, spline curve parameters, attached
 scripts and physics. Every edit is undoable, and a drag collapses into a single
 undo step.
 
-**Bottom panel.** A console showing loader and exporter warnings, and an asset
-browser (double-click a file to open/import/assign). Console is the first tab —
-it is where import results and errors land. Collapsible, and it runs to the left
-edge of the window.
+**Bottom panel.** A console showing loader and exporter warnings, an asset
+browser (double-click a file to open/import/assign), the live sensor readout,
+and — while any are open — the Script Editor's scripts. Console is the first tab: it is
+where import results and errors land. Collapsible, resizable by dragging its top
+edge, and it runs to the left edge of the window.
 
 **Camera dock.** The band beside the bottom panel, under the inspector, renders
 the selected camera live. It collapses with the bottom panel and paints itself
@@ -166,7 +167,10 @@ when nothing is selected, so that corner is never a sliver of viewport too small
 to see into or click in.
 
 **Panel sizes.** The hierarchy and inspector are resized by dragging their inner
-edge, and the widths persist in the settings file. The hierarchy also scrolls
+edge, the bottom panel by dragging its top edge, and all three sizes persist in
+the settings file. Every one is clamped on read and on drag — the bottom panel
+against the window itself, so a settings file written on a bigger monitor cannot
+leave a small one with no viewport at all. The hierarchy also scrolls
 horizontally, because a deep tree indents past any fixed width and the panel
 cannot be widened past the screen.
 
@@ -761,7 +765,7 @@ scene back.
 
 The code comes in one of two forms, never both: a `.py` **file** referenced by
 path, or **inline source** stored in the scene itself and edited in the editor's
-Script Editor window. A file is shared between objects and scenes and editable
+Script Editor tab. A file is shared between objects and scenes and editable
 in whatever tooling you already have; inline source travels with the scene, so a
 `.json` handed to somebody else is complete.
 
@@ -1280,12 +1284,33 @@ exactly one script.
 #### The Script Editor
 
 `New Inline Script` in the Script section writes a template into the object and
-opens a floating **Script Editor** window on it — movable, resizable, closable,
-and one instance: it edits the selected object's inline script, following the
-selection while there is nothing to lose and **staying on the object it was
-opened for whenever the buffer has unsaved edits**, because retargeting text
-somebody is still typing would drop it without a word. `Edit…` reopens it, and
-the title carries an asterisk while the buffer differs from the document.
+opens it in the bottom panel's **Scripts** tab, bringing the panel up if it was
+collapsed. `Edit…` opens an existing one the same way.
+
+**As many at once as you open.** Inside the Scripts tab is a second bar with one
+entry per open script, labelled with its object and carrying an asterisk while
+its buffer differs from the document. Each keeps its own text, its own undo
+position in the box and its own syntax error until you close it with its ×, so
+writing two scripts that talk to each other is a click between tabs rather than
+a round trip through the hierarchy. When more are open than fit, the ▾ button at
+the left of the bar lists them all by name. Still **one script per object** —
+that is `ScriptConfig`'s rule; this is one tab per object.
+
+Selecting an object that already has a tab open **raises that tab**, and that is
+all the selection does: on a change of selection, not on every frame the visible
+tab and the selection disagree — otherwise opening a script for anything other
+than what is selected would bounce straight back. Selecting an object with no
+tab open opens nothing; `Edit…` is what opens one. The single editor this
+replaced instead *retargeted itself* onto the selection, and could only ever do
+it when the buffer was clean, because pointing a buffer somebody is typing into
+at another object drops what they typed.
+
+It is docked rather than floating because floating is what was wrong with it: a
+text box big enough to write in covered the object the script was about. Beside
+the console it takes room from nothing, and the bottom panel's top edge drags,
+so "big enough" costs a drag rather than a window parked over the scene. The
+panel's `v` collapses the lot; the Scripts tab itself is there only while at
+least one script is.
 
 * **Apply** (or `Ctrl+Enter`) commits the buffer as one undoable step, keyed per
   object so it lands in the undo stack next to every other inspector edit.
@@ -1298,7 +1323,7 @@ the title carries an asterisk while the buffer differs from the document.
   Apply: half-written code is a normal thing to want to save, and an editor that
   refuses to let go of what you typed is a worse editor.
 * **Revert** reloads the committed text; **Clear** in the inspector removes the
-  script and closes the window (one `Ctrl+Z` away, and the buffer is still there
+  script and closes the tab (one `Ctrl+Z` away, and the buffer is still there
   if you reopen the object).
 * It is read-only while playing, like the inspector: the snapshot restore on Stop
   would throw the edit away.
@@ -1313,7 +1338,7 @@ module defines, or failing that the single one defining `update()`; several
 candidates is reported against the object, not guessed at.
 
 Plain text, deliberately: no highlighting, no completion, no third-party editor
-widget and no new dependency. Editing an external `.py` in this window is out of
+widget and no new dependency. Editing an external `.py` in this tab is out of
 scope — that file already has an editor, and so, now, does inline source: see
 below.
 
@@ -1332,7 +1357,7 @@ to `<temp>/threepp-editor/scripts/<uuid8>_<name>.py`, VS Code opens on it, and
 the editor polls that file about once a second from the frame loop. Every save
 comes back in through the Script Editor's own **Apply** — the same tab and
 line-ending normalization, the same compile check, the same undoable commit —
-and the window shows the source read-only with a banner and a **Stop external
+and the tab shows the source read-only with a banner and a **Stop external
 edit** button for as long as the session lives.
 
 Details that are not incidental:
@@ -2119,9 +2144,12 @@ their say.
   one or the other. Several behaviours on one object means several child
   objects, or one script that composes them.
 * **The Script Editor is a text box.** No syntax highlighting, no completion, no
-  find-and-replace, and it edits inline source only. The one thing it adds over
-  Notepad is the compile check — for anything more, `Edit in VS Code` hands the
-  same source to an editor that has all of it.
+  find-and-replace, and it edits inline source only. It does hold several
+  scripts open at once, one tab each, because that costs nothing but a vector
+  and the alternative — one buffer retargeting itself onto the selection — makes
+  writing two scripts that talk to each other a chore. The one thing it adds
+  over Notepad is the compile check; for anything more, `Edit in VS Code` hands
+  the same source to an editor that has all of it.
 * **External editing syncs one way.** The scratch file is the source of truth
   while a session is live: an undo in the editor moves the document out from
   under it without touching the file, and the next save puts the file's version

--- a/include/threepp/extras/editor/EditorSettings.hpp
+++ b/include/threepp/extras/editor/EditorSettings.hpp
@@ -65,6 +65,15 @@ namespace threepp::editor {
         static constexpr float minPanelWidth = 180.f;
         static constexpr float maxPanelWidth = 720.f;
 
+        // Bottom panel height, same units and draggable for the same reason:
+        // the console is fine in a 200 px strip and the docked script editor is
+        // not. The viewport is the real upper bound — see
+        // EditorApp::bottomHeightLimit() — so this cap only guards the file.
+        float bottomPanelHeight = 200.f;
+
+        static constexpr float minBottomHeight = 90.f;
+        static constexpr float maxBottomHeight = 1200.f;
+
     private:
         std::vector<std::string> recentFiles_;
     };

--- a/include/threepp/extras/editor/ScriptConfig.hpp
+++ b/include/threepp/extras/editor/ScriptConfig.hpp
@@ -10,7 +10,7 @@
 //   * a .py FILE, referenced by path — shared between objects and scenes, and
 //     editable in whatever editor the user already has open;
 //   * INLINE SOURCE, stored in the document itself — self-contained, travels
-//     with the scene, and edited in the editor's own Script Editor window.
+//     with the scene, and edited in the editor's own Script Editor tab.
 //
 // Unlike PhysicsConfig and AnimationConfig this does NOT pack everything into
 // one key=value string: a Windows path contains the characters that format uses

--- a/src/threepp/extras/editor/EditorSettings.cpp
+++ b/src/threepp/extras/editor/EditorSettings.cpp
@@ -108,12 +108,14 @@ bool EditorSettings::load(const std::filesystem::path& path) {
 
     // Clamped on read: a settings file edited by hand (or written by a build
     // with different limits) must not be able to push a panel off-screen.
-    const auto readWidth = [&j](const char* key, float fallback) {
+    const auto readSize = [&j](const char* key, float fallback, float lo, float hi) {
         if (!j.contains(key) || !j[key].is_number()) return fallback;
-        return std::clamp(j[key].get<float>(), minPanelWidth, maxPanelWidth);
+        return std::clamp(j[key].get<float>(), lo, hi);
     };
-    hierarchyWidth = readWidth("hierarchyWidth", hierarchyWidth);
-    inspectorWidth = readWidth("inspectorWidth", inspectorWidth);
+    hierarchyWidth = readSize("hierarchyWidth", hierarchyWidth, minPanelWidth, maxPanelWidth);
+    inspectorWidth = readSize("inspectorWidth", inspectorWidth, minPanelWidth, maxPanelWidth);
+    bottomPanelHeight = readSize("bottomPanelHeight", bottomPanelHeight,
+                                 minBottomHeight, maxBottomHeight);
 
     recentFiles_.clear();
     if (j.contains("recentFiles") && j["recentFiles"].is_array()) {
@@ -147,6 +149,7 @@ bool EditorSettings::save(const std::filesystem::path& path) const {
     j["modelStorage"] = modelStorage == ModelStorage::Reference ? "reference" : "embed";
     j["hierarchyWidth"] = hierarchyWidth;
     j["inspectorWidth"] = inspectorWidth;
+    j["bottomPanelHeight"] = bottomPanelHeight;
     j["recentFiles"] = recentFiles_;
 
     std::ofstream file(path);


### PR DESCRIPTION

It was a floating window, and floating over the viewport is what was wrong with it: a text box big enough to write in covered the object the script was being written about. It is now the bottom panel's Scripts tab.

The bottom panel is a size rather than a constant to make that worth having. EditorSettings::bottomPanelHeight is dragged from the panel's top edge and persisted next to the side panel widths, clamped on read and on drag against bottomHeightLimit() - derived from the window, so a settings file written on a bigger monitor cannot leave a small one with no viewport. drawSplitter grew a horizontal twin; both are one strip implementation now.

The grab strip overlays the panel boundary instead of reserving a band above it. A reserved band was a strip of bare viewport between the side panels and the bottom one - a seam across the whole window.

And the editor holds as many scripts as you open, one tab each, because the single retargeting buffer made writing two scripts that talk to each other a round trip through the hierarchy. Each keeps its own text, its own syntax error and its own text-box state (PushID per uuid, or ImGui carries one script's cursor and undo stack into the next). Still one script per object - that is ScriptConfig's rule, not this file's.

Selecting an object now RAISES its tab if one is open rather than retargeting a buffer onto it, and does nothing at all if none is. On a change of selection, not on a mismatch: a rule that fired whenever the selection and the visible tab disagreed bounced every explicit open straight back on the next frame. The active script is settled at request time too - ImGui applies SetSelected at the following BeginTabBar, so the outgoing tab was writing itself back as active for one frame, undoing the switch and pointing Apply at the script you just left.

External sessions sync into their own object's tab rather than whichever is visible, and reopen it unrevealed if it was closed under them.
