### PR TITLE
threepp_player: a headless-capable player for editor-authored scenes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ endif ()
 
 if (THREEPP_BUILD_EDITOR)
     add_subdirectory(apps/editor)
+    # threepp_player: the same play runtime with no editing machinery, for
+    # policy validation and data generation. After apps/editor, not beside it —
+    # the Python scripting library it links is declared there.
+    add_subdirectory(apps/player)
 endif ()
 
 if (NOT DEFINED EMSCRIPTEN AND THREEPP_BUILD_TESTS)

--- a/apps/editor/EditorApp.cpp
+++ b/apps/editor/EditorApp.cpp
@@ -13,6 +13,7 @@
 #include "threepp/extras/editor/ScriptConfig.hpp"
 #include "threepp/extras/editor/ScriptWorkspace.hpp"
 #include "threepp/extras/editor/SplineConfig.hpp"
+#include "threepp/extras/editor/ViewSpec.hpp"
 #include "threepp/extras/imgui/ImguiContext.hpp"
 
 #ifdef THREEPP_EDITOR_WITH_PYTHON
@@ -908,35 +909,13 @@ void EditorApp::openExample(const std::string& slug) {
 
 bool EditorApp::parseViewSpec(const std::string& text, Vector3& position, Vector3& target) {
 
-    const auto at = text.find('@');
-    if (at == std::string::npos) return false;
-
-    const auto triple = [](const std::string& part, Vector3& out) {
-        std::istringstream stream(part);
-        std::string field;
-        float values[3];
-        for (float& value : values) {
-            if (!std::getline(stream, field, ',')) return false;
-            try {
-                value = std::stof(field);
-            } catch (const std::exception&) {
-                return false;
-            }
-        }
-        // Everything after the third number is a typo, not a fourth axis.
-        if (std::getline(stream, field, ',')) return false;
-        out.set(values[0], values[1], values[2]);
-        return true;
-    };
-
-    Vector3 wantPosition;
-    Vector3 wantTarget;
-    if (!triple(text.substr(0, at), wantPosition)) return false;
-    if (!triple(text.substr(at + 1), wantTarget)) return false;
-
-    position.copy(wantPosition);
-    target.copy(wantTarget);
-    return true;
+    // The parse itself is in the library (extras/editor/ViewSpec.hpp), because
+    // the editor is no longer the only front end that places a camera from a
+    // document's authored vantage — threepp_player reads the same
+    // userData["editorView"] and --shot takes the same text. This stays as the
+    // editor's public spelling of it; main.cpp's --shot handling and every
+    // caller below are unchanged.
+    return editor::parseViewSpec(text, position, target);
 }
 
 bool EditorApp::applyDocumentView() {

--- a/apps/player/CMakeLists.txt
+++ b/apps/player/CMakeLists.txt
@@ -65,6 +65,13 @@ add_executable(threepp_player
 
 target_link_libraries(threepp_player PRIVATE threepp_player_core)
 
+# THREEPP_WITH_VULKAN is PRIVATE on the threepp lib (the editor happens to
+# inherit it through imgui, which the player deliberately does not link), so
+# --vulkan's compile-time gate needs the define stated here.
+if (THREEPP_WITH_VULKAN)
+    target_compile_definitions(threepp_player PRIVATE THREEPP_WITH_VULKAN=1)
+endif ()
+
 # The GPU libraries PhysX loads at runtime, beside the binary — the same
 # POST_BUILD copies threepp_editor does, so the player can be run from its own
 # output directory without one.

--- a/apps/player/CMakeLists.txt
+++ b/apps/player/CMakeLists.txt
@@ -1,0 +1,83 @@
+
+# threepp_player — the second front end over the editor's play runtime.
+#
+# Pulled in AFTER apps/editor (see the top-level CMakeLists), because the Python
+# scripting library is declared there: threepp_editor_scripting is what makes a
+# document's scripts actually run, and hover_arena_author is the precedent for a
+# sibling executable that links it. The player links no part of the editor APP —
+# no ImGui, no panels — only the play core in libthreepp and that scripting
+# library.
+#
+# Every optional half is gated the way the editor gates it, and the player builds
+# and runs without any of them: no PhysX means a document plays without physics,
+# no Python means its scripts are loaded and not run.
+
+# The player minus the window. Its own library for the same reason
+# threepp_editor_scripting and threepp_editor_examples are: the headless test
+# links the code the binary runs, rather than a second copy of it that can drift.
+add_library(threepp_player_core STATIC
+        PlayerCore.cpp)
+
+target_link_libraries(threepp_player_core PUBLIC threepp)
+target_include_directories(threepp_player_core PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_features(threepp_player_core PUBLIC cxx_std_20)
+
+# PhysX is an optional vcpkg dependency (feature "physx"). Found here rather than
+# relying on apps/editor having looked for it, because find_package's imported
+# targets are directory-scoped — the same dance tests/extras/CMakeLists.txt does.
+if (NOT TARGET unofficial::omniverse-physx-sdk::sdk)
+    find_package(unofficial-omniverse-physx-sdk CONFIG QUIET)
+endif ()
+
+if (TARGET unofficial::omniverse-physx-sdk::sdk)
+    # PUBLIC throughout: PlayerCore.hpp does not include the PhysX headers, but
+    # PlayerCore.cpp includes PhysicsPlaySession.hpp, whose inline methods branch
+    # on THREEPP_EDITOR_WITH_VHACD. Every target that shares a binary with this
+    # one must compile that header identically or they disagree within one
+    # program (ODR). Linking V-HACD carries its INTERFACE macro out to all of
+    # them, which is what keeps the definitions in step without a per-target
+    # macro to get wrong.
+    target_link_libraries(threepp_player_core PUBLIC unofficial::omniverse-physx-sdk::sdk)
+    target_compile_definitions(threepp_player_core PUBLIC THREEPP_EDITOR_WITH_PHYSX=1)
+    if (TARGET threepp_convex_decomp)
+        target_link_libraries(threepp_player_core PUBLIC threepp_convex_decomp)
+    endif ()
+    message(STATUS "threepp_player: PhysX play session enabled")
+else ()
+    message(STATUS "threepp_player: physx not found, documents play without physics")
+endif ()
+
+# Python scripting. Declared by apps/editor, which is where the embedded
+# interpreter and the bind_*.cpp translation units live; PUBLIC on that target
+# carries THREEPP_EDITOR_WITH_PYTHON and the scripting include directory here.
+if (TARGET threepp_editor_scripting)
+    target_link_libraries(threepp_player_core PUBLIC threepp_editor_scripting)
+    message(STATUS "threepp_player: Python scripting enabled")
+else ()
+    message(STATUS "threepp_player: scripting not built, a document's scripts will not run")
+endif ()
+
+add_executable(threepp_player
+        main.cpp
+        PlayerApp.cpp
+        DebugDrawOverlay.cpp)
+
+target_link_libraries(threepp_player PRIVATE threepp_player_core)
+
+# The GPU libraries PhysX loads at runtime, beside the binary — the same
+# POST_BUILD copies threepp_editor does, so the player can be run from its own
+# output directory without one.
+if (TARGET unofficial::omniverse-physx-sdk::sdk)
+    if (WIN32 AND TARGET unofficial::omniverse-physx-sdk::gpu-library)
+        add_custom_command(TARGET threepp_player POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                $<TARGET_FILE:unofficial::omniverse-physx-sdk::gpu-library>
+                $<TARGET_FILE_DIR:threepp_player>)
+    endif ()
+    if (WIN32 AND TARGET unofficial::omniverse-physx-sdk::gpu-device-library)
+        add_custom_command(TARGET threepp_player POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                $<TARGET_FILE:unofficial::omniverse-physx-sdk::gpu-device-library>
+                $<TARGET_FILE_DIR:threepp_player>)
+    endif ()
+endif ()

--- a/apps/player/CMakeLists.txt
+++ b/apps/player/CMakeLists.txt
@@ -60,7 +60,8 @@ endif ()
 add_executable(threepp_player
         main.cpp
         PlayerApp.cpp
-        DebugDrawOverlay.cpp)
+        DebugDrawOverlay.cpp
+        SensorCloudOverlay.cpp)
 
 target_link_libraries(threepp_player PRIVATE threepp_player_core)
 

--- a/apps/player/DebugDrawOverlay.cpp
+++ b/apps/player/DebugDrawOverlay.cpp
@@ -1,0 +1,139 @@
+
+#include "DebugDrawOverlay.hpp"
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+#include "Scripting.hpp"
+#endif
+
+#include "threepp/core/BufferGeometry.hpp"
+#include "threepp/materials/LineBasicMaterial.hpp"
+#include "threepp/objects/Group.hpp"
+#include "threepp/objects/LineSegments.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace threepp;
+using namespace threepp::player;
+
+namespace {
+
+    // The player draws nothing else, so this only has to beat the scene. Kept at
+    // the editor's number so a script that tuned its overdraw against one front
+    // end sees the same thing in the other.
+    constexpr int kRenderOrder = 3200;
+
+}// namespace
+
+
+DebugDrawOverlay::DebugDrawOverlay(Group& parent)
+    : parent_(parent) {}
+
+DebugDrawOverlay::~DebugDrawOverlay() {
+
+    clear();
+}
+
+void DebugDrawOverlay::setLogger(std::function<void(const std::string&)> logger) {
+
+    logger_ = std::move(logger);
+}
+
+void DebugDrawOverlay::sync() {
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+
+    auto& list = editor::scripting::debugDraw();
+
+    // Inactive means no script session is running: not "nothing drawn this
+    // frame" but "nobody there to draw". Take the node down with the session.
+    if (!list.active) {
+        clear();
+        return;
+    }
+
+    if (list.dropped > 0 && !warned_) {
+        warned_ = true;
+        if (logger_) {
+            logger_("debug draw capped at " + std::to_string(editor::scripting::DebugDrawList::cap) +
+                    " segments - " + std::to_string(list.dropped) + " dropped this frame");
+        }
+    }
+
+    const auto segmentCount = static_cast<int>(list.segments.size());
+    const int vertices = segmentCount * 2;
+
+    if (!lines_) {
+        auto material = LineBasicMaterial::create(
+                LineBasicMaterial::Params().vertexColors(true).toneMapped(false));
+        material->depthTest = false;
+        material->depthWrite = false;
+        lines_ = LineSegments::create(BufferGeometry::create(), material);
+        lines_->renderOrder = kRenderOrder;
+        lines_->frustumCulled = false;
+        lines_->matrixAutoUpdate = false;
+        capacity_ = 0;
+        parent_.add(lines_);
+    }
+
+    if (vertices > capacity_) {
+        const auto old = lines_->geometry();
+        auto geometry = BufferGeometry::create();
+        geometry->setAttribute("position", FloatBufferAttribute::create(
+                                                   std::vector<float>(vertices * 3), 3));
+        geometry->setAttribute("color", FloatBufferAttribute::create(
+                                                std::vector<float>(vertices * 3), 3));
+        lines_->setGeometry(geometry);
+        if (old) old->dispose();
+        capacity_ = vertices;
+    }
+
+    // Empty is authoritative: the scripts DID run this frame and drew nothing.
+    // Hide rather than hold the last picture.
+    lines_->visible = vertices > 0;
+    if (vertices == 0) {
+        lines_->geometry()->drawRange = {0, 0};
+        return;
+    }
+
+    auto* position = lines_->geometry()->getAttribute<float>("position");
+    auto* color = lines_->geometry()->getAttribute<float>("color");
+    if (!position || !color) {
+        lines_->visible = false;
+        return;
+    }
+
+    for (int i = 0; i < segmentCount; ++i) {
+        const auto& s = list.segments[static_cast<std::size_t>(i)];
+        position->setXYZ(i * 2, s.ax, s.ay, s.az);
+        position->setXYZ(i * 2 + 1, s.bx, s.by, s.bz);
+        color->setXYZ(i * 2, s.r, s.g, s.b);
+        color->setXYZ(i * 2 + 1, s.r, s.g, s.b);
+    }
+    position->needsUpdate();
+    color->needsUpdate();
+    lines_->geometry()->drawRange = {0, vertices};
+
+    // Drained: next frame starts from nothing, which is what makes a line that
+    // stopped being drawn actually disappear — and what keeps the list off its
+    // cap over a long run.
+    list.clear();
+
+#else
+    clear();
+#endif
+}
+
+void DebugDrawOverlay::clear() {
+
+    warned_ = false;
+    if (!lines_) return;
+
+    lines_->removeFromParent();
+    // Undisposed, the orphan both leaks its GPU buffers and re-arms the
+    // recycled-pointer trap described in the header.
+    if (const auto geometry = lines_->geometry()) geometry->dispose();
+    lines_.reset();
+    capacity_ = 0;
+}

--- a/apps/player/DebugDrawOverlay.hpp
+++ b/apps/player/DebugDrawOverlay.hpp
@@ -1,0 +1,72 @@
+// Script debug draw, for the player's viewport.
+//
+// The same seam and the same geometry contract as the editor's
+// (apps/editor/DebugDrawOverlay.cpp) — threepp.editor.draw_line and friends land
+// in scripting::debugDraw() as world-space segments, and this drains the list
+// into ONE LineSegments each rendered frame. A standalone object rather than a
+// member of the app, because the player's core needs to hand somebody a drain
+// callback and the editor's version is welded to EditorApp.
+//
+// The rules that matter, restated because getting them wrong is silent:
+//
+//   * the attributes are rewritten IN PLACE and replaced only when outgrown,
+//     and the orphaned geometry is disposed when they are. The renderer caches
+//     GPU buffers by ATTRIBUTE IDENTITY, so a fresh attribute every frame can
+//     hand it a recycled pointer that reads as already uploaded;
+//   * frustumCulled and matrixAutoUpdate are off, because the segments are
+//     already world-space and in-place updates never refresh cached bounds;
+//   * depth test AND depth write off — debugging wants to see the ray that ends
+//     inside a mesh, and the lines must not shadow anything drawn after them.
+//
+// Immediate mode: drained is gone. A script that wants a line to persist draws
+// it again next update(), which it is called every frame to do.
+
+#ifndef THREEPP_PLAYER_DEBUGDRAWOVERLAY_HPP
+#define THREEPP_PLAYER_DEBUGDRAWOVERLAY_HPP
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace threepp {
+
+    class Group;
+    class LineSegments;
+
+}// namespace threepp
+
+namespace threepp::player {
+
+    class DebugDrawOverlay {
+
+    public:
+        // `parent` is the player's overlay group — editor-only, and hidden for
+        // the duration of every sensor scan, so a lidar can never range against
+        // one of these lines.
+        explicit DebugDrawOverlay(Group& parent);
+        ~DebugDrawOverlay();
+
+        DebugDrawOverlay(const DebugDrawOverlay&) = delete;
+        DebugDrawOverlay& operator=(const DebugDrawOverlay&) = delete;
+
+        void setLogger(std::function<void(const std::string&)> logger);
+
+        // Drain the list into the lines. This is what PlayerCore calls as its
+        // debug-draw drain, so consuming the segments and emptying the list are
+        // the same act.
+        void sync();
+
+        // Take the node down (the session went away).
+        void clear();
+
+    private:
+        Group& parent_;
+        std::shared_ptr<LineSegments> lines_;
+        std::function<void(const std::string&)> logger_;
+        int capacity_ = 0;
+        bool warned_ = false;
+    };
+
+}// namespace threepp::player
+
+#endif//THREEPP_PLAYER_DEBUGDRAWOVERLAY_HPP

--- a/apps/player/PlayerApp.cpp
+++ b/apps/player/PlayerApp.cpp
@@ -6,6 +6,10 @@
 #include "threepp/canvas/Canvas.hpp"
 #include "threepp/controls/OrbitControls.hpp"
 #include "threepp/core/Clock.hpp"
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+#include "Scripting.hpp"// keyStateProvider - the seam behind threepp.editor.is_key_down
+#include "threepp/input/KeyFromName.hpp"
+#endif
 #include "threepp/extras/editor/RenderConfig.hpp"
 #include "threepp/extras/editor/ViewSpec.hpp"
 #include "threepp/math/Box3.hpp"
@@ -57,6 +61,12 @@ PlayerApp::PlayerApp(PlayerOptions options)
 
 PlayerApp::~PlayerApp() {
 
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+    // The provider closes over `this` and the canvas; neither survives the
+    // destructor, so the seam must not either. One player per process, so no
+    // ownership token needed — there is nobody to take it back from.
+    editor::scripting::keyStateProvider() = nullptr;
+#endif
     // The overlay parents a node into the core's overlay group. Drop it while
     // that group is still alive — member order would otherwise take the core
     // (and its groups) down first.
@@ -142,6 +152,19 @@ void PlayerApp::buildView() {
     // Orbit and the drawn lines are for a person watching, so neither is stood
     // up for a run nobody can see.
     if (canvas_ && !options_.headless) {
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+        // threepp.editor.is_key_down, answered from the window's own key state —
+        // a scene authored to be DRIVEN (the hover arena's W/A/S/D drone) is
+        // drivable here too, not only in the editor. The editor answers this
+        // from ImGui because it must ignore keys typed into its panels; the
+        // player has no panels, so the Canvas state IS the answer. Headless
+        // installs nothing, and the provider then answers False — a script that
+        // steers still runs, just uncommanded, which is what an unattended
+        // evaluation wants (and what keeps episode CSVs reproducible).
+        editor::scripting::keyStateProvider() = [this](const std::string& name) {
+            return canvas_ && canvas_->isKeyDown(keyFromName(name));
+        };
+#endif
         orbit_ = std::make_unique<OrbitControls>(camera_, *canvas_);
         orbit_->enableDamping = true;
 

--- a/apps/player/PlayerApp.cpp
+++ b/apps/player/PlayerApp.cpp
@@ -1,0 +1,344 @@
+
+#include "PlayerApp.hpp"
+
+#include "DebugDrawOverlay.hpp"
+
+#include "threepp/canvas/Canvas.hpp"
+#include "threepp/controls/OrbitControls.hpp"
+#include "threepp/core/Clock.hpp"
+#include "threepp/extras/editor/RenderConfig.hpp"
+#include "threepp/extras/editor/ViewSpec.hpp"
+#include "threepp/math/Box3.hpp"
+#include "threepp/objects/Group.hpp"
+#include "threepp/renderers/RendererFactory.hpp"
+#include "threepp/scenes/Scene.hpp"
+
+#include <algorithm>
+#include <any>
+#include <cmath>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <utility>
+
+using namespace threepp;
+using namespace threepp::player;
+
+namespace {
+
+    // A wall-clock delta big enough to be a stall rather than a frame. Letting a
+    // 900 ms hitch through would step the solver 900 ms in one go and explode
+    // whatever it is simulating; the sim simply loses the time instead.
+    constexpr float kMaxWallDt = 0.1f;
+
+    // A flat userData string on the scene root, or "" when the document does not
+    // carry one. Same two keys the editor reads.
+    std::string userDataString(const Object3D& object, const char* key) {
+
+        const auto it = object.userData.find(key);
+        if (it == object.userData.end() || it->second.type() != typeid(std::string)) {
+            return {};
+        }
+        return std::any_cast<const std::string&>(it->second);
+    }
+
+}// namespace
+
+
+PlayerApp::PlayerApp(PlayerOptions options)
+    : options_(std::move(options)) {
+
+    core_.setLogger([](const std::string& message) {
+        // Everything the sessions say goes to stdout, one line each, unadorned:
+        // this is a program whose output somebody greps.
+        std::cout << "  " << message << std::endl;
+    });
+}
+
+PlayerApp::~PlayerApp() {
+
+    // The overlay parents a node into the core's overlay group. Drop it while
+    // that group is still alive — member order would otherwise take the core
+    // (and its groups) down first.
+    debugDraw_.reset();
+    orbit_.reset();
+}
+
+int PlayerApp::run() {
+
+    std::string error;
+    if (!core_.open(options_.scene, &error)) {
+        std::cerr << "threepp player: cannot open " << options_.scene.string() << " - " << error
+                  << std::endl;
+        // Deliberately not exitCode(): no episode ran, and the caller needs a
+        // nonzero code for a document that would not even load.
+        return 1;
+    }
+    log("opened " + options_.scene.filename().string());
+
+    if (!options_.record.empty()) {
+        // Per-episode subdirectories only when there is more than one episode:
+        // a single run should put its CSVs exactly where it was told, and a
+        // multi-episode run must not have every episode overwrite the last (see
+        // PlayerCore::beginEpisode).
+        core_.setRecordDirectory(options_.record, options_.episodes > 1);
+        log("recording sensors to " + options_.record.string() +
+            (options_.episodes > 1 ? "/episode_NNN" : ""));
+    }
+
+    buildView();
+
+    for (int index = 0; index < options_.episodes; ++index) {
+        if (!playEpisode(index)) break;
+    }
+
+    const auto failed = core_.failedEpisodes();
+    std::cout << "threepp player: " << core_.results().size() << " episode(s), " << failed
+              << " failed, " << core_.totalScriptErrors() << " script error(s)" << std::endl;
+
+    return core_.exitCode();
+}
+
+void PlayerApp::buildView() {
+
+    // The window comes up hidden in headless mode (GLFW_VISIBLE false) rather
+    // than not at all. A depth or lidar sensor scans with the RENDERER, so it
+    // needs a live GL context; an invisible window is the cheapest honest way to
+    // have one. If even that fails — no display, no driver — the run continues
+    // with no renderer at all, which the sensor session already tolerates: the
+    // vision sensors are built, say so once and never scan, and every
+    // proprioceptive sensor records exactly as it would have.
+    try {
+        canvas_ = std::make_unique<Canvas>(
+                Canvas::Parameters()
+                        .title("threepp player - " + options_.scene.filename().string())
+                        .size(options_.width, options_.height)
+                        .antialiasing(4)
+                        // Headless is a batch run, and a FIFO swapchain would
+                        // pin it to the monitor's refresh rate for no reason.
+                        .vsync(!options_.headless)
+                        .headless(options_.headless)
+                        .exitOnKeyEscape(true));
+        renderer_ = createRenderer(*canvas_, GraphicsAPI::OpenGL);
+    } catch (const std::exception& e) {
+        std::cerr << "threepp player: no renderer (" << e.what()
+                  << ") - vision sensors will not scan" << std::endl;
+        renderer_.reset();
+        canvas_.reset();
+    }
+
+    if (renderer_) {
+        renderer_->shadowMap().enabled = true;
+        renderer_->shadowMap().type = ShadowMap::PFC;
+        renderer_->toneMapping = ToneMapping::ACESFilmic;
+        renderer_->toneMappingExposure = 1.0f;
+        core_.setRenderer(renderer_.get());
+        applyDocumentRender();
+    }
+
+    if (canvas_) camera_.aspect = canvas_->aspect();
+    camera_.updateProjectionMatrix();
+
+    // Orbit and the drawn lines are for a person watching, so neither is stood
+    // up for a run nobody can see.
+    if (canvas_ && !options_.headless) {
+        orbit_ = std::make_unique<OrbitControls>(camera_, *canvas_);
+        orbit_->enableDamping = true;
+
+        canvas_->onWindowResize([this](WindowSize size) {
+            camera_.aspect = size.aspect();
+            camera_.updateProjectionMatrix();
+            if (renderer_) renderer_->setSize(size);
+        });
+
+        if (auto* overlay = core_.overlay()) {
+            debugDraw_ = std::make_unique<DebugDrawOverlay>(*overlay);
+            debugDraw_->setLogger([this](const std::string& message) { log(message); });
+            // Drawing the lines is how they get drained. Without this the core
+            // clears the list itself each step, which is what the headless path
+            // does — either way it never reaches its cap.
+            core_.setDebugDrawDrain([this] { debugDraw_->sync(); });
+        }
+    }
+
+    applyDocumentView();
+}
+
+void PlayerApp::applyDocumentRender() {
+
+    // A document's own exposure, fog and tone map, layered over what the player
+    // just set as its baseline — the same read the editor does on open, so a
+    // scene looks the same in both.
+    const auto base = editor::RenderConfig::capture(*renderer_);
+    editor::RenderConfig::read(core_.scene(), base).value_or(base).apply(*renderer_);
+}
+
+void PlayerApp::applyDocumentView() {
+
+    followName_ = userDataString(core_.scene(), "editorFollow");
+    follow_ = nullptr;
+    followSeeded_ = false;
+
+    const auto view = userDataString(core_.scene(), "editorView");
+    Vector3 position;
+    Vector3 target;
+    // The parse is the library's, shared with the editor and with --shot, so a
+    // vantage copied between them means the same thing (extras/editor/ViewSpec).
+    if (!view.empty() && editor::parseViewSpec(view, position, target)) {
+        camera_.position.copy(position);
+        camera_.lookAt(target);
+        if (orbit_) orbit_->target.copy(target);
+        log("using the document's authored view");
+        return;
+    }
+    if (!view.empty()) {
+        log("editorView is \"" + view + "\" - want px,py,pz@tx,ty,tz; ignored");
+    }
+    frameSceneBounds();
+}
+
+void PlayerApp::frameSceneBounds() {
+
+    // Nothing authored: back off far enough to see everything, from the
+    // three-quarter angle an editor opens at.
+    Box3 bounds;
+    bounds.setFromObject(core_.scene());
+    if (bounds.isEmpty()) {
+        camera_.position.set(6.f, 5.f, 8.f);
+        camera_.lookAt({0.f, 0.f, 0.f});
+        return;
+    }
+
+    Vector3 center;
+    Vector3 size;
+    bounds.getCenter(center);
+    bounds.getSize(size);
+
+    const float extent = std::max({size.x, size.y, size.z, 1.f});
+    const float distance = extent * 1.6f;
+
+    camera_.position.set(center.x + distance * 0.6f,
+                         center.y + distance * 0.5f,
+                         center.z + distance * 0.8f);
+    camera_.lookAt(center);
+    if (orbit_) orbit_->target.copy(center);
+}
+
+bool PlayerApp::playEpisode(int index) {
+
+    std::string error;
+    if (!core_.beginEpisode(index, &error)) {
+        std::cerr << "threepp player: episode " << index << " would not play - " << error
+                  << std::endl;
+        // A document that refuses once refuses every time; nothing is learned by
+        // trying it another ninety-nine times. The refusal is already recorded
+        // as a failed episode, so the exit code is nonzero.
+        return false;
+    }
+
+    // The scene is rebuilt by each stop(), so the followed object is a different
+    // pointer every episode. Re-resolve here, against the graph play() just
+    // started on.
+    follow_ = followName_.empty() ? nullptr : core_.scene().getObjectByName(followName_);
+    followSeeded_ = false;
+    if (!followName_.empty() && !follow_) {
+        log("editorFollow names \"" + followName_ + "\", which is not in this scene - ignored");
+        followName_.clear();
+    }
+
+    // Zero means unbounded. Headless has to have SOME bound or it never returns,
+    // so it takes a default rather than hanging a CI job.
+    float budgetSeconds = options_.seconds;
+    if (options_.headless && options_.frames <= 0 && budgetSeconds <= 0.f) {
+        budgetSeconds = PlayerOptions::headlessDefaultSeconds;
+        if (index == 0) {
+            log("headless with no --frames/--seconds: using --seconds=" +
+                std::to_string(static_cast<int>(budgetSeconds)));
+        }
+    }
+
+    // A fixed step is reproducible and is what a headless evaluation wants; the
+    // wall clock is what a person watching a window wants. --dt forces the
+    // former either way.
+    const bool fixed = options_.dt > 0.f || options_.headless;
+    const float fixedDt = options_.dt > 0.f ? options_.dt : PlayerCore::defaultDt;
+
+    Clock clock;
+    float elapsed = 0.f;
+    int frames = 0;
+    bool windowOpen = true;
+
+    while (true) {
+        if (options_.frames > 0 && frames >= options_.frames) break;
+        if (budgetSeconds > 0.f && elapsed >= budgetSeconds) break;
+
+        float dt = fixedDt;
+        if (!fixed) dt = std::min(clock.getDelta(), kMaxWallDt);
+
+        if (canvas_) {
+            if (!canvas_->animateOnce([&] { frame(dt); })) {
+                windowOpen = false;
+                break;
+            }
+        } else {
+            frame(dt);
+        }
+
+        elapsed += dt;
+        ++frames;
+    }
+
+    const auto result = core_.endEpisode();
+    // stop() replaced the scene the subject lived in. Let go before the pointer
+    // is a pointer into a freed graph rather than after.
+    follow_ = nullptr;
+    followSeeded_ = false;
+
+    report(result);
+    return windowOpen;
+}
+
+void PlayerApp::frame(float dt) {
+
+    core_.step(dt);
+
+    updateFollow();
+    if (orbit_) orbit_->update();
+
+    if (renderer_) renderer_->render(core_.scene(), camera_);
+}
+
+void PlayerApp::updateFollow() {
+
+    if (!follow_) return;
+
+    Vector3 position;
+    follow_->getWorldPosition(position);
+
+    // A rigid translation of camera AND target by the subject's own movement:
+    // the view keeps whatever angle and distance somebody orbited to, and the
+    // damping the orbit is carrying still resolves against the same offset.
+    if (followSeeded_) {
+        const Vector3 delta = position.clone().sub(followLast_);
+        camera_.position.add(delta);
+        if (orbit_) orbit_->target.add(delta);
+    }
+    followLast_.copy(position);
+    followSeeded_ = true;
+}
+
+void PlayerApp::report(const EpisodeResult& result) {
+
+    std::cout << "episode " << result.index << ": " << result.frames << " frames, "
+              << result.seconds << " s sim, " << result.scriptInstances << " script(s), "
+              << result.scriptErrors << " error(s), " << result.bodyCount << " bodies, "
+              << result.sensorCount << " sensor(s)";
+    if (core_.recording()) std::cout << ", " << result.sensorRows << " row(s) recorded";
+    if (!result.error.empty()) std::cout << " [" << result.error << "]";
+    std::cout << std::endl;
+}
+
+void PlayerApp::log(const std::string& message) {
+
+    std::cout << "  " << message << std::endl;
+}

--- a/apps/player/PlayerApp.cpp
+++ b/apps/player/PlayerApp.cpp
@@ -36,6 +36,23 @@ namespace {
     // whatever it is simulating; the sim simply loses the time instead.
     constexpr float kMaxWallDt = 0.1f;
 
+    // Always names a backend — the editor's rule, for the editor's reason:
+    // handing createRenderer no preference makes it print a console menu and
+    // block on std::cin, which would hang every piped or scripted run this tool
+    // exists for.
+    GraphicsAPI requestedApi(bool vulkan) {
+
+#ifdef THREEPP_WITH_VULKAN
+        if (vulkan) return GraphicsAPI::Vulkan;
+#else
+        if (vulkan) {
+            std::cerr << "threepp player: built without Vulkan support, using OpenGL"
+                      << std::endl;
+        }
+#endif
+        return GraphicsAPI::OpenGL;
+    }
+
     // A flat userData string on the scene root, or "" when the document does not
     // carry one. Same two keys the editor reads.
     std::string userDataString(const Object3D& object, const char* key) {
@@ -131,7 +148,7 @@ void PlayerApp::buildView() {
                         .vsync(!options_.headless)
                         .headless(options_.headless)
                         .exitOnKeyEscape(true));
-        renderer_ = createRenderer(*canvas_, GraphicsAPI::OpenGL);
+        renderer_ = createRenderer(*canvas_, requestedApi(options_.vulkan));
     } catch (const std::exception& e) {
         std::cerr << "threepp player: no renderer (" << e.what()
                   << ") - vision sensors will not scan" << std::endl;

--- a/apps/player/PlayerApp.cpp
+++ b/apps/player/PlayerApp.cpp
@@ -2,6 +2,7 @@
 #include "PlayerApp.hpp"
 
 #include "DebugDrawOverlay.hpp"
+#include "SensorCloudOverlay.hpp"
 
 #include "threepp/canvas/Canvas.hpp"
 #include "threepp/controls/OrbitControls.hpp"
@@ -67,9 +68,10 @@ PlayerApp::~PlayerApp() {
     // ownership token needed — there is nobody to take it back from.
     editor::scripting::keyStateProvider() = nullptr;
 #endif
-    // The overlay parents a node into the core's overlay group. Drop it while
+    // The overlays parent nodes into the core's overlay group. Drop them while
     // that group is still alive — member order would otherwise take the core
     // (and its groups) down first.
+    sensorCloud_.reset();
     debugDraw_.reset();
     orbit_.reset();
 }
@@ -181,6 +183,13 @@ void PlayerApp::buildView() {
             // clears the list itself each step, which is what the headless path
             // does — either way it never reaches its cap.
             core_.setDebugDrawDrain([this] { debugDraw_->sync(); });
+
+            // What the vision sensors measured, as the editor draws it: one
+            // range-coloured cloud. Under the same scan-hidden overlay group, so
+            // a lidar never ranges against its own returns.
+            if (auto* sensors = core_.sensors()) {
+                sensorCloud_ = std::make_unique<SensorCloudOverlay>(*overlay, *sensors);
+            }
         }
     }
 
@@ -316,6 +325,9 @@ bool PlayerApp::playEpisode(int index) {
     // is a pointer into a freed graph rather than after.
     follow_ = nullptr;
     followSeeded_ = false;
+    // The cloud's "keep the last frame" rule must not cross an episode
+    // boundary: episode N+1 opens clean, not wearing episode N's returns.
+    if (sensorCloud_) sensorCloud_->clear();
 
     report(result);
     return windowOpen;
@@ -324,6 +336,10 @@ bool PlayerApp::playEpisode(int index) {
 void PlayerApp::frame(float dt) {
 
     core_.step(dt);
+
+    // After the step (the sensors have drained this frame's returns), before
+    // the render (this frame should show them).
+    if (sensorCloud_) sensorCloud_->sync();
 
     updateFollow();
     if (orbit_) orbit_->update();

--- a/apps/player/PlayerApp.hpp
+++ b/apps/player/PlayerApp.hpp
@@ -60,6 +60,10 @@ namespace threepp::player {
         // so there is still a GL context and the vision sensors still scan.
         bool headless = false;
 
+        // The Vulkan backend, same flag as the editor's. A build without it
+        // warns once and plays on OpenGL rather than refusing the document.
+        bool vulkan = false;
+
         // Fixed simulation step. Zero means "use the wall clock", which is what
         // a windowed run wants; a headless run defaults this to 1/60 because a
         // bounded, reproducible run is the whole point of being headless.

--- a/apps/player/PlayerApp.hpp
+++ b/apps/player/PlayerApp.hpp
@@ -1,0 +1,124 @@
+// threepp_player — the editor's play runtime with the editor taken off.
+//
+// The editor AUTHORS a document: physics bodies, articulations, sensors and
+// scripts, all declarative userData that serializes with the scene (see
+// doc/editor.md). This plays one. No ImGui, no panels, no undo, no gizmos, no
+// selection — a window, a camera and the four play sessions, or not even the
+// window.
+//
+// It exists to be a gate. Point it at a scene whose script drives a trained
+// policy, give it a seed budget and an episode count, let the sensors write
+// their CSVs, and read the exit code: zero if every episode ran clean, nonzero
+// if any script raised or the document would not play. That is a thing CI can
+// hold, which the editor — an interactive application whose success condition is
+// "somebody looked at it" — is not.
+//
+// It is an EVALUATION vehicle. It runs the document as written, one instance at
+// a time, at the fidelity the editor would. Batched rollouts across hundreds of
+// parallel environments are GpuSim's job and are deliberately not this.
+
+#ifndef THREEPP_PLAYER_PLAYERAPP_HPP
+#define THREEPP_PLAYER_PLAYERAPP_HPP
+
+#include "PlayerCore.hpp"
+
+#include "threepp/cameras/PerspectiveCamera.hpp"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace threepp {
+
+    class Canvas;
+    class OrbitControls;
+    class Renderer;
+
+}// namespace threepp
+
+namespace threepp::player {
+
+    class DebugDrawOverlay;
+
+    struct PlayerOptions {
+
+        std::filesystem::path scene;
+
+        // How many times to play the document, back to back. Each one is a full
+        // play -> run -> stop cycle, and stop restores the snapshot, so they are
+        // independent by construction.
+        int episodes = 1;
+
+        // Per-episode budget. Zero means unbounded; a windowed run then plays
+        // until the window is closed. Both may be set, and whichever is reached
+        // first ends the episode.
+        int frames = 0;
+        float seconds = 0.f;
+
+        // No visible window. The canvas is still created (GLFW_VISIBLE false),
+        // so there is still a GL context and the vision sensors still scan.
+        bool headless = false;
+
+        // Fixed simulation step. Zero means "use the wall clock", which is what
+        // a windowed run wants; a headless run defaults this to 1/60 because a
+        // bounded, reproducible run is the whole point of being headless.
+        float dt = 0.f;
+
+        // Root for the sensor CSVs. Empty means do not record.
+        std::filesystem::path record;
+
+        int width = 1280;
+        int height = 720;
+
+        // What a headless run does when given neither --frames nor --seconds.
+        // Ten seconds of simulation: long enough for a controller to have done
+        // something, short enough that a mistake in a CI file is not a hang.
+        static constexpr float headlessDefaultSeconds = 10.f;
+    };
+
+
+    class PlayerApp {
+
+    public:
+        explicit PlayerApp(PlayerOptions options);
+        ~PlayerApp();
+
+        // Opens the document, plays every episode and returns the process's
+        // exit code.
+        int run();
+
+    private:
+        // False when the window was closed mid-episode, which ends the run.
+        bool playEpisode(int index);
+        void frame(float dt);
+
+        void buildView();
+        void applyDocumentRender();
+        void applyDocumentView();
+        void frameSceneBounds();
+        void updateFollow();
+
+        void log(const std::string& message);
+        void report(const EpisodeResult& result);
+
+        PlayerOptions options_;
+        PlayerCore core_;
+
+        std::unique_ptr<Canvas> canvas_;
+        std::unique_ptr<Renderer> renderer_;
+        std::unique_ptr<OrbitControls> orbit_;
+        std::unique_ptr<DebugDrawOverlay> debugDraw_;
+
+        PerspectiveCamera camera_{55.f, 16.f / 9.f, 0.05f, 5000.f};
+
+        // scene.userData["editorFollow"] — the object the camera chases, by
+        // name, re-resolved every episode because stop() rebuilds the scene.
+        std::string followName_;
+        Object3D* follow_ = nullptr;
+        Vector3 followLast_;
+        bool followSeeded_ = false;
+    };
+
+}// namespace threepp::player
+
+#endif//THREEPP_PLAYER_PLAYERAPP_HPP

--- a/apps/player/PlayerApp.hpp
+++ b/apps/player/PlayerApp.hpp
@@ -39,6 +39,7 @@ namespace threepp {
 namespace threepp::player {
 
     class DebugDrawOverlay;
+    class SensorCloudOverlay;
 
     struct PlayerOptions {
 
@@ -108,6 +109,7 @@ namespace threepp::player {
         std::unique_ptr<Renderer> renderer_;
         std::unique_ptr<OrbitControls> orbit_;
         std::unique_ptr<DebugDrawOverlay> debugDraw_;
+        std::unique_ptr<SensorCloudOverlay> sensorCloud_;
 
         PerspectiveCamera camera_{55.f, 16.f / 9.f, 0.05f, 5000.f};
 

--- a/apps/player/PlayerCore.cpp
+++ b/apps/player/PlayerCore.cpp
@@ -1,0 +1,310 @@
+
+#include "PlayerCore.hpp"
+
+#include "threepp/extras/editor/AnimationPlaySession.hpp"
+#include "threepp/extras/editor/SensorPlaySession.hpp"
+
+#ifdef THREEPP_EDITOR_WITH_PHYSX
+#include "threepp/extras/editor/PhysicsPlaySession.hpp"
+#include "threepp/extras/editor/PhysxSensorPlaySession.hpp"
+#endif
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+#include "Scripting.hpp"
+#endif
+
+#include "threepp/objects/Group.hpp"
+#include "threepp/scenes/Scene.hpp"
+
+#include <iomanip>
+#include <sstream>
+#include <utility>
+
+using namespace threepp;
+using namespace threepp::player;
+
+namespace {
+
+    // "007" — an episode's directory suffix, zero-padded so a shell listing
+    // sorts the way the run happened.
+    std::string episodeTag(int index) {
+
+        std::ostringstream text;
+        text << std::setw(3) << std::setfill('0') << index;
+        return text.str();
+    }
+
+}// namespace
+
+
+PlayerCore::PlayerCore() {
+
+    // Two nodes the document carries but never saves. Registered as
+    // editor-only, which means SceneDocument detaches them for every export AND
+    // for every play snapshot, and re-attaches them to the scene each episode's
+    // stop() restores — so they survive an arbitrary number of episodes without
+    // ever becoming part of one.
+    overlay_ = Group::create();
+    overlay_->name = "__player_overlay";
+    document_.addEditorOnly(*overlay_);
+
+    // A SIBLING of the overlay, not a child of it: the overlay is hidden for the
+    // duration of every sensor scan (a lidar must not range against a script's
+    // debug arrow), and a sensor must not be hidden from itself. Same split, and
+    // same reason, as the editor's.
+    sensorRig_ = Group::create();
+    sensorRig_->name = "__player_sensor_rig";
+    document_.addEditorOnly(*sensorRig_);
+
+    // --- the editor's registration order, and nothing else -------------------
+    // Update order is registration order; stop order is its reverse. See the
+    // header, and EditorApp's constructor, which this mirrors line for line.
+
+#ifdef THREEPP_EDITOR_WITH_PHYSX
+    physics_ = std::make_shared<editor::PhysicsPlaySession>();
+    physics_->setLogger([this](const std::string& message) { log(message); });
+    play_.addSession(physics_);
+#endif
+
+    play_.addSession(std::make_shared<editor::AnimationPlaySession>());
+
+    // After physics (whose world the pushed sensors register with) and after the
+    // animation player, so a scan sees the pose the frame ended on.
+#ifdef THREEPP_EDITOR_WITH_PHYSX
+    {
+        auto sensors = std::make_shared<editor::PhysxSensorPlaySession>();
+        sensors->setPhysics(physics_.get());
+        sensors_ = std::move(sensors);
+    }
+#else
+    // The base session runs the VISION sensors, which need a renderer rather
+    // than a physics world. The body and joint sensors author and say which
+    // build they are waiting for.
+    sensors_ = std::make_shared<editor::SensorPlaySession>();
+#endif
+    sensors_->setRig(sensorRig_.get());
+    sensors_->setHiddenDuringScan(overlay_.get());
+    sensors_->setLogger([this](const std::string& message) { log(message); });
+    play_.addSession(sensors_);
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+    // Last, so a script's transform edits are the final word for the frame.
+    scripts_ = std::make_shared<editor::ScriptPlaySession>();
+    scripts_->setLogger([this](const std::string& message) { log(message); });
+    play_.addSession(scripts_);
+#endif
+}
+
+PlayerCore::~PlayerCore() {
+
+    // An episode still running at destruction is a caller that threw or bailed.
+    // Stop it properly rather than letting the sessions be destroyed mid-play.
+    if (!play_.stopped()) {
+        std::string error;
+        play_.stop(document_, &error);
+    }
+
+    // The sensor session parents nodes into sensorRig_, which is a member of
+    // this same object: member destruction order would take the rig down first
+    // and leave the session's destructor unlinking from freed memory. Drop the
+    // sessions here, while everything they point into is still alive. (The
+    // editor's destructor does exactly this, for exactly this reason.)
+    play_.clearSessions();
+    scripts_.reset();
+    sensors_.reset();
+    physics_.reset();
+
+    if (sensorRig_) {
+        sensorRig_->clear();
+        document_.removeEditorOnly(*sensorRig_);
+    }
+    if (overlay_) {
+        overlay_->clear();
+        document_.removeEditorOnly(*overlay_);
+    }
+}
+
+void PlayerCore::setLogger(std::function<void(const std::string&)> logger) {
+
+    logger_ = std::move(logger);
+}
+
+void PlayerCore::setRenderer(Renderer* renderer) {
+
+    if (sensors_) sensors_->setRenderer(renderer);
+}
+
+void PlayerCore::setRecordDirectory(const std::filesystem::path& dir, bool perEpisodeSubdirectories) {
+
+    recordRoot_ = dir;
+    recordPerEpisode_ = perEpisodeSubdirectories;
+    recording_ = !dir.empty();
+}
+
+void PlayerCore::setDebugDrawDrain(std::function<void()> drain) {
+
+    drain_ = std::move(drain);
+}
+
+Group* PlayerCore::overlay() const {
+
+    return overlay_.get();
+}
+
+bool PlayerCore::open(const std::filesystem::path& path, std::string* error) {
+
+    if (!document_.open(path, error)) return false;
+    for (const auto& warning : document_.warnings()) log(warning);
+    return true;
+}
+
+bool PlayerCore::openJson(const std::string& json, std::string* error) {
+
+    if (!document_.openJson(json, error)) return false;
+    for (const auto& warning : document_.warnings()) log(warning);
+    return true;
+}
+
+bool PlayerCore::playing() const {
+
+    return !play_.stopped();
+}
+
+bool PlayerCore::beginEpisode(int index, std::string* error) {
+
+    if (!play_.stopped()) {
+        if (error) *error = "an episode is already playing";
+        return false;
+    }
+
+    current_ = EpisodeResult{};
+    current_.index = index;
+
+    // Where this episode's CSVs go, decided BEFORE play() because the files are
+    // opened lazily on the first measurement — which happens inside the first
+    // step().
+    //
+    // The per-episode subdirectory is not decoration. SensorPlaySession names a
+    // file for the sensor's label and the first 8 characters of its uuid, and
+    // opens it with std::ios::trunc. Those are stable across episodes (the
+    // snapshot restores the same uuids, which is the point of episodes being
+    // independent), so a second episode recording into the same directory would
+    // silently overwrite the first one's rows and a --episodes=100 run would
+    // leave exactly one episode's data behind.
+    if (sensors_ && recording_) {
+        auto directory = recordRoot_;
+        if (recordPerEpisode_) directory /= ("episode_" + episodeTag(index));
+        sensors_->setRecordDirectory(directory);
+        sensors_->setRecording(true);
+    }
+
+    std::string failure;
+    if (!play_.play(document_, &failure)) {
+        current_.error = failure.empty() ? "play refused the document" : failure;
+        if (error) *error = current_.error;
+        results_.push_back(current_);
+        return false;
+    }
+
+    current_.started = true;
+
+    // Read while the sessions are up: stop() drops the entries these count.
+    if (sensors_) current_.sensorCount = sensors_->sensorCount();
+#ifdef THREEPP_EDITOR_WITH_PHYSX
+    if (physics_) current_.bodyCount = physics_->bodyCount();
+#endif
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+    if (scripts_) current_.scriptInstances = scripts_->instanceCount();
+    // ScriptPlaySession::start() switched the list on; anything left in it from
+    // the previous episode is not this one's.
+    editor::scripting::debugDraw().clear();
+#endif
+
+    return true;
+}
+
+void PlayerCore::step(float dt) {
+
+    if (play_.stopped()) return;
+
+    play_.update(dt);
+    ++current_.frames;
+    current_.seconds += dt;
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+    // Somebody has to empty this every frame — see setDebugDrawDrain(). A
+    // drainer that renders the lines does it by consuming them; with none set,
+    // the list is simply cleared, which is what a headless run wants: the
+    // scripts still RUN their draw calls (a draw is not allowed to behave
+    // differently just because nobody is looking), the segments just go nowhere.
+    if (drain_) {
+        drain_();
+    } else {
+        editor::scripting::debugDraw().clear();
+    }
+#endif
+}
+
+EpisodeResult PlayerCore::endEpisode() {
+
+    if (play_.stopped()) return current_;
+
+    // Before the sessions go: this counts rows on entries stop() is about to
+    // destroy.
+    if (sensors_) current_.sensorRows = sensors_->recordedRows();
+
+    std::string error;
+    if (!play_.stop(document_, &error)) {
+        current_.error = error.empty() ? "stop failed" : error;
+    }
+
+    // AFTER stop(), and this is the only correct moment. A script's own stop()
+    // can raise, so reading before it would miss the last error of the episode;
+    // and the next start() clears the map, so reading later would report zero.
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+    if (scripts_) current_.scriptErrors = scripts_->errorCount();
+    // The session switched the list off with its stop(); drop whatever the last
+    // frame left in it so the next episode starts from nothing.
+    editor::scripting::debugDraw().clear();
+#endif
+
+    results_.push_back(current_);
+    return current_;
+}
+
+EpisodeResult PlayerCore::runEpisode(int index, int frames, float dt) {
+
+    if (!beginEpisode(index)) return results_.back();
+    for (int i = 0; i < frames; ++i) step(dt);
+    return endEpisode();
+}
+
+std::size_t PlayerCore::failedEpisodes() const {
+
+    std::size_t failed = 0;
+    for (const auto& result : results_) {
+        if (!result.ok()) ++failed;
+    }
+    return failed;
+}
+
+std::size_t PlayerCore::totalScriptErrors() const {
+
+    std::size_t errors = 0;
+    for (const auto& result : results_) errors += result.scriptErrors;
+    return errors;
+}
+
+int PlayerCore::exitCode() const {
+
+    // Nothing ran: the player was asked to validate something and did not. That
+    // is a failure of the job, not a vacuous pass — a CI gate that goes green
+    // because the scene never loaded is worse than no gate.
+    if (results_.empty()) return 1;
+    return failedEpisodes() > 0 ? 1 : 0;
+}
+
+void PlayerCore::log(const std::string& message) {
+
+    if (logger_) logger_(message);
+}

--- a/apps/player/PlayerCore.hpp
+++ b/apps/player/PlayerCore.hpp
@@ -140,6 +140,11 @@ namespace threepp::player {
         // range against somebody's debug arrow.
         [[nodiscard]] Group* overlay() const;
 
+        // The sensor session, for a front end that VISUALIZES what it measured —
+        // the point-cloud overlay reads its entries. Never null after
+        // construction; its entries are empty between episodes.
+        [[nodiscard]] editor::SensorPlaySession* sensors() const { return sensors_.get(); }
+
         // --- episodes --------------------------------------------------------
 
         [[nodiscard]] bool playing() const;

--- a/apps/player/PlayerCore.hpp
+++ b/apps/player/PlayerCore.hpp
@@ -1,0 +1,197 @@
+// The player, minus the window.
+//
+// Everything threepp_player does to a document that does not involve a screen:
+// open it, stand the play sessions up, step them, tear them down, and count what
+// happened. The binary adds a canvas, a camera and a debug-draw overlay on top;
+// a test links this and drives it headlessly, which is how the exit-code
+// contract and episode independence are actually asserted rather than asserted
+// about.
+//
+// The sessions and their ORDER are the editor's, deliberately (see
+// EditorApp's constructor): physics, animation, sensors, scripts. Registration
+// order is update order, and PlayController stops them in the reverse of it, so
+// a script's stop() still has a world and the sensors still have an SDK. The
+// player is a second front end over that runtime, not a second runtime — if the
+// two ever disagree about the order, a scene that works in the editor stops
+// working in CI, which is the one thing this must never do.
+//
+// An EPISODE is one full play -> step* -> stop cycle. Stop restores the snapshot
+// PlayController took at play(), so the document an episode starts from is
+// byte-for-byte the one the last episode started from: episodes are independent
+// by construction, not by anybody remembering to reset something.
+
+#ifndef THREEPP_PLAYER_PLAYERCORE_HPP
+#define THREEPP_PLAYER_PLAYERCORE_HPP
+
+#include "threepp/extras/editor/PlaySession.hpp"
+#include "threepp/extras/editor/SceneDocument.hpp"
+
+#include <cstddef>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace threepp {
+
+    class Group;
+    class Renderer;
+    class Scene;
+
+}// namespace threepp
+
+namespace threepp::editor {
+
+    class PhysicsPlaySession;
+    class ScriptPlaySession;
+    class SensorPlaySession;
+
+}// namespace threepp::editor
+
+namespace threepp::player {
+
+    // What one episode did. Everything a CI gate could reasonably want to see in
+    // a log line, and the `ok()` that decides the process's exit code.
+    struct EpisodeResult {
+
+        int index = 0;
+        // The sessions came up. False means play() refused — a physics world that
+        // would not start, a script that raised at import — and `error` says so.
+        bool started = false;
+        std::string error;
+
+        int frames = 0;
+        // Simulated seconds, summed from the deltas actually stepped. With a
+        // fixed step this is exact; with a real clock it is what the sim saw,
+        // which is the number worth reporting either way.
+        float seconds = 0.f;
+
+        // Scripts that raised and were disabled for the rest of the episode,
+        // read after stop() — see endEpisode() for why that is the only correct
+        // moment to read it.
+        std::size_t scriptErrors = 0;
+        std::size_t scriptInstances = 0;
+
+        std::size_t sensorCount = 0;
+        std::size_t sensorRows = 0;
+        std::size_t bodyCount = 0;
+
+        [[nodiscard]] bool ok() const {
+            return started && error.empty() && scriptErrors == 0;
+        }
+    };
+
+
+    class PlayerCore {
+
+    public:
+        PlayerCore();
+        ~PlayerCore();
+
+        PlayerCore(const PlayerCore&) = delete;
+        PlayerCore& operator=(const PlayerCore&) = delete;
+
+        // --- wiring (set before the first episode) ---------------------------
+
+        // Console sink for what the sessions have to say. Called on the calling
+        // thread, from open/beginEpisode/step/endEpisode only.
+        void setLogger(std::function<void(const std::string&)> logger);
+
+        // The renderer the VISION sensors (depth, lidar) scan with. Null is a
+        // supported state, not a degraded one the caller has to guard: the
+        // sensor session builds those sensors anyway, says once that it has no
+        // renderer, and never scans them. The proprioceptive half (IMU,
+        // encoders, contact, force/torque) needs nothing but a physics world and
+        // records exactly as it would with a screen attached.
+        void setRenderer(Renderer* renderer);
+
+        // Turn CSV recording on and point it somewhere. See beginEpisode() for
+        // what a multi-episode run does with the path — the short version is
+        // that each episode gets its own subdirectory, because the sensor
+        // session names its files after the sensor and truncates them on open.
+        void setRecordDirectory(const std::filesystem::path& dir, bool perEpisodeSubdirectories);
+        [[nodiscard]] bool recording() const { return recording_; }
+
+        // Who empties scripting::debugDraw() at the end of each step.
+        //
+        // The list is filled by every threepp.editor.draw_* call a script makes
+        // and is capped; ScriptPlaySession switches it ON and nothing switches
+        // it off, so a front end that neither draws nor drains it runs until the
+        // cap and then logs a drop every frame. A windowed player passes the
+        // overlay's sync here (it drains by drawing); with no drain set, step()
+        // clears the list itself. Either way the list does not grow.
+        void setDebugDrawDrain(std::function<void()> drain);
+
+        // --- the document ----------------------------------------------------
+
+        bool open(const std::filesystem::path& path, std::string* error = nullptr);
+        // The same parse from text the caller already has — a document over a
+        // socket, a scene compiled into a test.
+        bool openJson(const std::string& json, std::string* error = nullptr);
+
+        [[nodiscard]] editor::SceneDocument& document() { return document_; }
+        [[nodiscard]] Scene& scene() const { return document_.scene(); }
+
+        // Where a front end parents what it draws but must never save: it is
+        // registered with the document as editor-only (so it survives the
+        // snapshot/restore of every episode without ever entering one) and is
+        // handed to the sensor session as hidden-during-scan, so a lidar cannot
+        // range against somebody's debug arrow.
+        [[nodiscard]] Group* overlay() const;
+
+        // --- episodes --------------------------------------------------------
+
+        [[nodiscard]] bool playing() const;
+
+        bool beginEpisode(int index, std::string* error = nullptr);
+        void step(float dt);
+        // Stops the sessions, restores the snapshot and returns the finished
+        // result, which is also appended to results().
+        EpisodeResult endEpisode();
+
+        // begin + `frames` steps of `dt` + end, for a caller with no window to
+        // pump. A refused start still produces (and records) a result.
+        EpisodeResult runEpisode(int index, int frames, float dt);
+
+        [[nodiscard]] const std::vector<EpisodeResult>& results() const { return results_; }
+        [[nodiscard]] std::size_t failedEpisodes() const;
+        [[nodiscard]] std::size_t totalScriptErrors() const;
+
+        // The whole point of the player: 0 when every episode ran clean, 1 when
+        // any of them failed to start, failed to stop or ended with a script
+        // error — and 1 when nothing ran at all, which is a failure to do the
+        // job rather than a vacuous success.
+        [[nodiscard]] int exitCode() const;
+
+        // One frame of a 60 Hz simulation. The default PhysxWorld timestep too,
+        // so a step of exactly this is one substep.
+        static constexpr float defaultDt = 1.f / 60.f;
+
+    private:
+        void log(const std::string& message);
+
+        editor::SceneDocument document_;
+        editor::PlayController play_;
+
+        std::shared_ptr<editor::PhysicsPlaySession> physics_;
+        std::shared_ptr<editor::SensorPlaySession> sensors_;
+        std::shared_ptr<editor::ScriptPlaySession> scripts_;
+
+        std::shared_ptr<Group> overlay_;
+        std::shared_ptr<Group> sensorRig_;
+
+        std::function<void(const std::string&)> logger_;
+        std::function<void()> drain_;
+
+        std::filesystem::path recordRoot_;
+        bool recording_ = false;
+        bool recordPerEpisode_ = false;
+
+        EpisodeResult current_;
+        std::vector<EpisodeResult> results_;
+    };
+
+}// namespace threepp::player
+
+#endif//THREEPP_PLAYER_PLAYERCORE_HPP

--- a/apps/player/SensorCloudOverlay.cpp
+++ b/apps/player/SensorCloudOverlay.cpp
@@ -1,0 +1,141 @@
+
+#include "SensorCloudOverlay.hpp"
+
+#include "threepp/extras/editor/SensorPlaySession.hpp"
+
+#include "threepp/core/BufferGeometry.hpp"
+#include "threepp/materials/PointsMaterial.hpp"
+#include "threepp/math/Color.hpp"
+#include "threepp/objects/Group.hpp"
+#include "threepp/objects/Points.hpp"
+
+#include <algorithm>
+
+using namespace threepp;
+using namespace threepp::player;
+
+namespace {
+
+    // The editor's band for measurement overlays, kept so a scene reads the
+    // same in both front ends.
+    constexpr int kCloudRenderOrder = 3000;
+
+    // PIXELS (sizeAttenuation off), for the reason the editor's overlay
+    // documents at length: a world-space size makes the far half of every scan
+    // sub-pixel, and the returns out at the range limit are exactly the ones
+    // worth looking at.
+    constexpr float kPointSize = 4.f;
+
+}// namespace
+
+
+SensorCloudOverlay::SensorCloudOverlay(Group& parent, editor::SensorPlaySession& session)
+    : parent_(parent), session_(session) {}
+
+SensorCloudOverlay::~SensorCloudOverlay() {
+
+    clear();
+}
+
+void SensorCloudOverlay::sync() {
+
+    // entries() is empty between episodes: the session drops them in stop().
+    int points = 0;
+    for (const auto& entry : session_.entries()) {
+        points += static_cast<int>(entry->pointCount());
+    }
+    if (points == 0) {
+        // Keep the last cloud rather than blinking — a sensor at 10 Hz would
+        // otherwise strobe the overlay at its own rate.
+        if (cloud_) cloud_->visible = cloud_->geometry()->drawRange.count > 0;
+        return;
+    }
+
+    if (!cloud_) {
+        auto material = PointsMaterial::create(PointsMaterial::Params()
+                                                       .size(kPointSize)
+                                                       .sizeAttenuation(false)
+                                                       .vertexColors(true));
+        // Range colour is data, not shading: tone mapping would compress the
+        // far end of the ramp into the near end.
+        material->toneMapped = false;
+        cloud_ = Points::create(BufferGeometry::create(), material);
+        cloud_->renderOrder = kCloudRenderOrder;
+        cloud_->frustumCulled = false;
+        cloud_->matrixAutoUpdate = false;
+        capacity_ = 0;
+        parent_.add(cloud_);
+    }
+
+    if (points > capacity_) {
+        const auto old = cloud_->geometry();
+        auto geometry = BufferGeometry::create();
+        geometry->setAttribute("position", FloatBufferAttribute::create(
+                                                   std::vector<float>(points * 3), 3));
+        geometry->setAttribute("color", FloatBufferAttribute::create(
+                                                std::vector<float>(points * 3), 3));
+        geometry->getAttribute<float>("position")->setUsage(DrawUsage::Dynamic);
+        geometry->getAttribute<float>("color")->setUsage(DrawUsage::Dynamic);
+        cloud_->setGeometry(geometry);
+        if (old) old->dispose();
+        capacity_ = points;
+    }
+
+    auto* position = cloud_->geometry()->getAttribute<float>("position");
+    auto* color = cloud_->geometry()->getAttribute<float>("color");
+    if (!position || !color) {
+        cloud_->visible = false;
+        return;
+    }
+    cloud_->visible = true;
+
+    Color tint;
+    int written = 0;
+    for (const auto& entry : session_.entries()) {
+
+        // Range normalised per sensor: a 5 m depth camera and a 100 m LIDAR in
+        // one scene must not share one hue ramp.
+        const float maxRange = std::max(entry->config.farPlane, 1e-3f);
+
+        if (entry->lidar) {
+            for (const auto& r : entry->returns) {
+                if (written >= capacity_) break;
+                position->setXYZ(written, r.position.x, r.position.y, r.position.z);
+                // Green near, red far — the same ramp the editor and the lidar
+                // example use, so one cloud reads the same everywhere.
+                tint.setHSL(0.33f * (1.f - std::min(r.distance / maxRange, 1.f)), 1.f, 0.5f);
+                color->setXYZ(written, tint.r, tint.g, tint.b);
+                ++written;
+            }
+        } else if (entry->depth) {
+            Vector3 origin;
+            entry->depth->getWorldPosition(origin);
+            for (const auto& p : entry->cloud) {
+                if (written >= capacity_) break;
+                position->setXYZ(written, p.x, p.y, p.z);
+                const float range = p.distanceTo(origin);
+                tint.setHSL(0.33f * (1.f - std::min(range / maxRange, 1.f)), 1.f, 0.5f);
+                color->setXYZ(written, tint.r, tint.g, tint.b);
+                ++written;
+            }
+        }
+    }
+
+    position->needsUpdate();
+    color->needsUpdate();
+    // The tail beyond `written` still holds whatever a busier frame left there.
+    cloud_->geometry()->drawRange = {0, written};
+}
+
+void SensorCloudOverlay::clear() {
+
+    if (!cloud_) return;
+
+    cloud_->removeFromParent();
+    // The renderer keys GPU buffers on geometry identity; an undisposed orphan
+    // both leaks them and re-arms the recycled-pointer staleness the in-place
+    // writes above exist to avoid.
+    if (const auto geometry = cloud_->geometry()) geometry->dispose();
+    cloud_.reset();
+    capacity_ = 0;
+}

--- a/apps/player/SensorCloudOverlay.hpp
+++ b/apps/player/SensorCloudOverlay.hpp
@@ -1,0 +1,68 @@
+// Sensor point cloud, for the player's viewport.
+//
+// The player records what the sensors measured, but a CSV answers "how many"
+// and never "where did the beams land" — the only question that matters when a
+// scan looks wrong. The editor draws every playing vision sensor's returns as
+// ONE Points, coloured green-to-red by range (apps/editor/SensorOverlay.cpp);
+// this is that overlay for the player, a standalone object for the same reason
+// DebugDrawOverlay is: the editor's version is welded to EditorApp.
+//
+// Same geometry contract as its siblings, restated because getting it wrong is
+// silent: attributes rewritten IN PLACE, replaced only when the cloud outgrows
+// them, orphaned geometry disposed (the renderer caches GPU buffers by
+// ATTRIBUTE IDENTITY); frustumCulled and matrixAutoUpdate off, because the
+// points are world-space and in-place writes never refresh cached bounds.
+//
+// The cloud MUST live under the core's overlay group, which the sensor session
+// hides for the duration of every scan. That is not a nicety: a lidar that can
+// see last frame's points builds a shell around itself and the cloud collapses
+// to arm's length within a second.
+
+#ifndef THREEPP_PLAYER_SENSORCLOUDOVERLAY_HPP
+#define THREEPP_PLAYER_SENSORCLOUDOVERLAY_HPP
+
+#include <memory>
+
+namespace threepp {
+
+    class Group;
+    class Points;
+
+    namespace editor {
+        class SensorPlaySession;
+    }
+
+}// namespace threepp
+
+namespace threepp::player {
+
+    class SensorCloudOverlay {
+
+    public:
+        // `parent` is the player's overlay group (editor-only, hidden during
+        // scans); `session` is borrowed and must outlive this object — in the
+        // player both belong to PlayerCore, which the app destroys last.
+        SensorCloudOverlay(Group& parent, editor::SensorPlaySession& session);
+        ~SensorCloudOverlay();
+
+        SensorCloudOverlay(const SensorCloudOverlay&) = delete;
+        SensorCloudOverlay& operator=(const SensorCloudOverlay&) = delete;
+
+        // Rewrite the cloud from the session's current returns. A frame where
+        // nothing scanned keeps the last cloud (sensors tick on their own
+        // rates, slower than the frame — blinking would just track the beat).
+        void sync();
+
+        // Take the node down (the episode ended; entries are gone).
+        void clear();
+
+    private:
+        Group& parent_;
+        editor::SensorPlaySession& session_;
+        std::shared_ptr<Points> cloud_;
+        int capacity_ = 0;
+    };
+
+}// namespace threepp::player
+
+#endif//THREEPP_PLAYER_SENSORCLOUDOVERLAY_HPP

--- a/apps/player/main.cpp
+++ b/apps/player/main.cpp
@@ -22,6 +22,8 @@ namespace {
                 << "  --seconds=N    stop each episode after N simulated seconds. With both,\n"
                 << "                 whichever comes first wins. Neither, windowed, means play\n"
                 << "                 until the window is closed\n"
+                << "  --vulkan       use the Vulkan backend (OpenGL is the default). In a build\n"
+                << "                 without Vulkan support this warns and uses OpenGL\n"
                 << "  --headless     no visible window. The GL context is still created (the\n"
                 << "                 window is just not shown) so depth and lidar sensors still\n"
                 << "                 scan. Steps at a fixed 1/60 s and, with no --frames or\n"
@@ -55,6 +57,8 @@ int main(int argc, char** argv) {
             options.frames = std::atoi(argument + 9);
         } else if (std::strncmp(argument, "--seconds=", 10) == 0) {
             options.seconds = static_cast<float>(std::atof(argument + 10));
+        } else if (std::strcmp(argument, "--vulkan") == 0) {
+            options.vulkan = true;
         } else if (std::strcmp(argument, "--headless") == 0) {
             options.headless = true;
         } else if (std::strncmp(argument, "--dt=", 5) == 0) {

--- a/apps/player/main.cpp
+++ b/apps/player/main.cpp
@@ -1,0 +1,100 @@
+
+#include "PlayerApp.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <string>
+
+namespace {
+
+    void usage() {
+
+        std::cout
+                << "threepp player - plays a scene the editor authored\n"
+                << "  usage: threepp_player scene.json [options]\n"
+                << "\n"
+                << "  --episodes=N   play the document N times back to back. Each episode is a\n"
+                << "                 full play/stop cycle, and stop restores the snapshot, so\n"
+                << "                 episodes are independent (default 1)\n"
+                << "  --frames=N     stop each episode after N frames\n"
+                << "  --seconds=N    stop each episode after N simulated seconds. With both,\n"
+                << "                 whichever comes first wins. Neither, windowed, means play\n"
+                << "                 until the window is closed\n"
+                << "  --headless     no visible window. The GL context is still created (the\n"
+                << "                 window is just not shown) so depth and lidar sensors still\n"
+                << "                 scan. Steps at a fixed 1/60 s and, with no --frames or\n"
+                << "                 --seconds, runs 10 simulated seconds per episode\n"
+                << "  --dt=SECONDS   force a fixed simulation step instead of the wall clock\n"
+                << "  --record=DIR   write the sensor CSVs under DIR. With --episodes>1 each\n"
+                << "                 episode gets DIR/episode_NNN, because the sensor files are\n"
+                << "                 named for the sensor and truncated on open\n"
+                << "  --size=WxH     window size (default 1280x720)\n"
+                << "\n"
+                << "  Exit code 0 when every episode played clean, 1 when the document would\n"
+                << "  not load or play, when an episode failed to stop, or when any script\n"
+                << "  raised. 2 is a usage error.\n";
+    }
+
+}// namespace
+
+int main(int argc, char** argv) {
+
+    threepp::player::PlayerOptions options;
+
+    for (int i = 1; i < argc; ++i) {
+        const char* argument = argv[i];
+
+        if (std::strcmp(argument, "--help") == 0 || std::strcmp(argument, "-h") == 0) {
+            usage();
+            return 0;
+        } else if (std::strncmp(argument, "--episodes=", 11) == 0) {
+            options.episodes = std::atoi(argument + 11);
+        } else if (std::strncmp(argument, "--frames=", 9) == 0) {
+            options.frames = std::atoi(argument + 9);
+        } else if (std::strncmp(argument, "--seconds=", 10) == 0) {
+            options.seconds = static_cast<float>(std::atof(argument + 10));
+        } else if (std::strcmp(argument, "--headless") == 0) {
+            options.headless = true;
+        } else if (std::strncmp(argument, "--dt=", 5) == 0) {
+            options.dt = static_cast<float>(std::atof(argument + 5));
+        } else if (std::strncmp(argument, "--record=", 9) == 0) {
+            options.record = argument + 9;
+        } else if (std::strncmp(argument, "--size=", 7) == 0) {
+            const std::string value = argument + 7;
+            const auto x = value.find('x');
+            if (x == std::string::npos) {
+                std::cerr << "threepp player: cannot read " << argument << " (want --size=WxH)"
+                          << std::endl;
+                return 2;
+            }
+            options.width = std::atoi(value.substr(0, x).c_str());
+            options.height = std::atoi(value.substr(x + 1).c_str());
+        } else if (argument[0] == '-') {
+            std::cerr << "threepp player: unknown option " << argument << std::endl;
+            usage();
+            return 2;
+        } else {
+            options.scene = argument;
+        }
+    }
+
+    if (options.scene.empty()) {
+        std::cerr << "threepp player: no scene given" << std::endl;
+        usage();
+        return 2;
+    }
+    if (options.episodes < 1) {
+        std::cerr << "threepp player: --episodes must be at least 1" << std::endl;
+        return 2;
+    }
+
+    try {
+        threepp::player::PlayerApp app(std::move(options));
+        return app.run();
+    } catch (const std::exception& e) {
+        std::cerr << "threepp player: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/doc/editor.md
+++ b/doc/editor.md
@@ -40,7 +40,9 @@ Two layers, deliberately separated:
 
 **`threepp/extras/editor/*` — the reusable core.** Part of the threepp library,
 with no ImGui, no window and no GL/Vulkan dependency. It is what a different
-front end (a Qt tool, a Python binding, a batch script) would build on:
+front end (a Qt tool, a Python binding, a batch script) would build on — and
+what [`threepp_player`](player.md), the second front end that ships, is built
+on:
 
 | type | responsibility |
 | --- | --- |
@@ -2225,6 +2227,24 @@ Three sessions ship, and they start in this order: physics, then the animation
 player, then scripts. Scripts run last on purpose — a script's transform edits
 are the final word for the frame, after the simulation and the mixer have had
 their say.
+
+---
+
+## Playing a document without the editor
+
+[`threepp_player`](player.md) is the second front end over this same core: it
+loads a `scene.json` and plays it with none of the editing machinery, for policy
+validation and data generation.
+
+```
+threepp_player arena.json --headless --episodes=100 --seconds=20 --record=runs
+```
+
+It registers the same four sessions in the same order, runs each episode as a
+full play/stop cycle (so episodes are independent), records what the sensors
+measured, and exits nonzero if any script raised or the document would not play
+— which is what makes a scene something CI can gate on. See
+[doc/player.md](player.md).
 
 ---
 

--- a/doc/player.md
+++ b/doc/player.md
@@ -30,6 +30,7 @@ hundreds of parallel environments are `GpuSim`'s job; there is deliberately no
 | `--episodes=N` | Play the document N times back to back (default 1). |
 | `--frames=N` | Stop each episode after N frames. |
 | `--seconds=N` | Stop each episode after N simulated seconds. |
+| `--vulkan` | Use the Vulkan backend (OpenGL is the default). A build without Vulkan warns and uses OpenGL. |
 | `--headless` | No visible window. |
 | `--dt=SECONDS` | Force a fixed simulation step instead of the wall clock. |
 | `--record=DIR` | Write the sensor CSVs under `DIR`. |

--- a/doc/player.md
+++ b/doc/player.md
@@ -47,6 +47,14 @@ object for the camera to chase. Without a view, the player frames the scene's
 bounds. `RenderConfig` on the scene root is applied, so a document looks the way
 it was saved.
 
+**Keyboard input works.** A windowed run answers a script's
+`threepp.editor.is_key_down` from the window's own key state (one name→key
+mapping, shared with `Canvas.is_key_down` — `threepp/input/KeyFromName.hpp`),
+so a scene authored to be *driven* — the hover arena's W/A/S/D drone — is
+drivable in the player too. Headless installs no provider and the calls answer
+`False`: a script that steers still runs, just uncommanded, which is what an
+unattended evaluation wants and what keeps episode recordings reproducible.
+
 ## Exit code
 
 | code | meaning |

--- a/doc/player.md
+++ b/doc/player.md
@@ -1,0 +1,146 @@
+# threepp player
+
+`threepp_player` plays a scene the [editor](editor.md) authored. It is the same
+play runtime — physics, articulations, sensors, Python scripts — with the
+editing machinery taken off: no ImGui, no panels, no undo, no gizmos, no
+selection. A window, a camera and the four play sessions, or not even the
+window.
+
+It exists to be a **gate**. Point it at a scene whose script drives a trained
+policy, give it an episode count and a budget, let the sensors write their CSVs,
+and read the exit code. That is something CI can hold, which the editor — an
+interactive application whose success condition is "somebody looked at it" — is
+not.
+
+```
+threepp_player scene.json [options]
+```
+
+## What it is not
+
+An **evaluation** vehicle, not a trainer. It runs the document as written, one
+instance at a time, at the fidelity the editor would. Batched rollouts across
+hundreds of parallel environments are `GpuSim`'s job; there is deliberately no
+`scene.json` → `GpuSim` loader here.
+
+## Options
+
+| flag | meaning |
+| --- | --- |
+| `--episodes=N` | Play the document N times back to back (default 1). |
+| `--frames=N` | Stop each episode after N frames. |
+| `--seconds=N` | Stop each episode after N simulated seconds. |
+| `--headless` | No visible window. |
+| `--dt=SECONDS` | Force a fixed simulation step instead of the wall clock. |
+| `--record=DIR` | Write the sensor CSVs under `DIR`. |
+| `--size=WxH` | Window size (default 1280x720). |
+| `--help` | Print all of this. |
+
+The budgets are **per episode**, and they compose: with both, whichever is
+reached first ends the episode. Neither, windowed, means play until the window
+is closed. `Esc` or closing the window ends the run.
+
+A document that carries `userData["editorView"]` opens at that vantage, in the
+same `px,py,pz@tx,ty,tz` spelling the editor's `--shot` takes (the parse is
+shared — `extras/editor/ViewSpec.hpp`); `userData["editorFollow"]` names an
+object for the camera to chase. Without a view, the player frames the scene's
+bounds. `RenderConfig` on the scene root is applied, so a document looks the way
+it was saved.
+
+## Exit code
+
+| code | meaning |
+| --- | --- |
+| 0 | Every episode played clean. |
+| 1 | The document would not load or play, an episode failed to stop, or **any script raised**. |
+| 2 | Usage error. |
+
+A script that raises is logged once by `ScriptPlaySession`, disabled for the
+rest of the episode, and the scene keeps playing — the player does not confuse
+"ran" with "worked", and turns that into a nonzero exit.
+
+Nothing running at all is also `1`. A gate that goes green because the scene
+never loaded is worse than no gate.
+
+## Episodes
+
+Each episode is a full `PlayController` play → step → stop cycle. Stop restores
+the snapshot taken at play, so **episodes are independent by construction** —
+not by anybody remembering to reset something. A body that fell in episode 0
+starts episode 1 back where it was authored, and the seeded sensor streams
+replay identically:
+
+```
+$ threepp_player arena.json --headless --episodes=3 --seconds=3 --record=rec
+episode 0: 181 frames, 3.01666 s sim, 7 script(s), 0 error(s), 35 bodies, 2 sensor(s), 212 row(s) recorded
+episode 1: 181 frames, 3.01666 s sim, 7 script(s), 0 error(s), 35 bodies, 2 sensor(s), 212 row(s) recorded
+episode 2: 181 frames, 3.01666 s sim, 7 script(s), 0 error(s), 35 bodies, 2 sensor(s), 212 row(s) recorded
+threepp player: 3 episode(s), 0 failed, 0 script error(s)
+```
+
+The three `Drone_*.csv` files above are byte-identical, noise included.
+
+Script errors do not leak between episodes: `ScriptPlaySession::start()` clears
+the map, so each episode reports its own count and the run fails if any of them
+is nonzero.
+
+## Headless
+
+`--headless` does **not** mean "no graphics". The window is created and simply
+not shown (`GLFW_VISIBLE` false), so there is still a live GL context and the
+vision sensors still scan — a `--headless --record` run of a scene with a lidar
+produces its point clouds exactly as a windowed one does. If the context cannot
+be created at all, the run continues with no renderer: `SensorPlaySession`
+already tolerates that, so the vision sensors are built, say so once and never
+scan, while every proprioceptive sensor (IMU, encoders, contact, force/torque)
+records unchanged.
+
+Headless also steps at a **fixed** 1/60 s rather than the wall clock, because a
+reproducible run is the whole point, and — given neither `--frames` nor
+`--seconds` — defaults to 10 simulated seconds per episode rather than hanging a
+CI job forever.
+
+## Recording
+
+`--record=DIR` arms `SensorPlaySession`'s CSV recording and points it at `DIR`.
+One file per sensor, named for the sensor's label and the first 8 characters of
+its uuid, plus a `_cloud.csv` for the point clouds.
+
+Those names are **stable across episodes** — that is what episode independence
+means — and the files are opened with `trunc`. So with `--episodes>1` each
+episode gets its own `DIR/episode_NNN/`, or a hundred-episode run would leave
+exactly one episode's data behind. A single-episode run writes straight into
+`DIR`.
+
+## Script debug draw
+
+`threepp.editor.draw_line` and friends push world-space segments into
+`scripting::debugDraw()`. `ScriptPlaySession` switches that list on and nothing
+switches it off, so **somebody has to drain it every frame** or a long run ends
+at the 100000-segment cap.
+
+The windowed player drains it by drawing it: one `LineSegments` under the
+player's overlay group, attributes rewritten in place, vertex colours, depth
+test off. Headless, the core simply clears the list — the scripts still *run*
+their draw calls, because a draw must not behave differently just because nobody
+is looking; the segments just go nowhere.
+
+The overlay group is registered with the document as editor-only, so it never
+enters a snapshot or an export, and it is handed to the sensor session as
+hidden-during-scan, so a lidar cannot range against somebody's debug arrow.
+
+## Layout
+
+| path | what |
+| --- | --- |
+| `apps/player/PlayerCore.{hpp,cpp}` | the player minus the window: document, sessions, episodes, exit code. Built as `threepp_player_core` so `tests/extras/PlayerCore_test.cpp` drives the code the binary runs |
+| `apps/player/PlayerApp.{hpp,cpp}` | canvas, renderer, camera, follow, the episode loop |
+| `apps/player/DebugDrawOverlay.{hpp,cpp}` | the drawn lines |
+| `apps/player/main.cpp` | the CLI |
+
+The player links the play core in `threepp` and the `threepp_editor_scripting`
+static library, and **no part of the editor application**. Its optional halves
+are gated exactly as the editor's are: no PhysX means a document plays without
+physics, no `THREEPP_EDITOR_WITH_PYTHON` means its scripts are loaded and not
+run. It follows `THREEPP_BUILD_EDITOR`, because that is where the scripting
+library is declared.

--- a/include/threepp/extras/editor/ViewSpec.hpp
+++ b/include/threepp/extras/editor/ViewSpec.hpp
@@ -1,0 +1,63 @@
+// "px,py,pz@tx,ty,tz" — a camera placement, in the one spelling the editor,
+// the player and the shell all agree on.
+//
+// A document can say how it wants to be looked at (scene.userData["editorView"],
+// see EditorApp::applyDocumentView), and the same text is what --shot takes on a
+// command line. That is deliberate: a vantage can be copied out of a scene into
+// a shell and back. Which is exactly why the parse lives here and not in one
+// front end — a second parser is how the two spellings drift apart.
+//
+// Header-only, and free of everything but Vector3: the editor app, the player
+// and any tool that wants to place a camera from a string can include it without
+// taking on a translation unit or a link dependency.
+
+#ifndef THREEPP_EDITOR_VIEWSPEC_HPP
+#define THREEPP_EDITOR_VIEWSPEC_HPP
+
+#include "threepp/math/Vector3.hpp"
+
+#include <exception>
+#include <sstream>
+#include <string>
+
+namespace threepp::editor {
+
+    // Fills `position` and `target` from "px,py,pz@tx,ty,tz". Both outputs are
+    // left untouched when the text does not parse, so a caller can seed them
+    // with a default and ignore the result.
+    inline bool parseViewSpec(const std::string& text, Vector3& position, Vector3& target) {
+
+        const auto at = text.find('@');
+        if (at == std::string::npos) return false;
+
+        const auto triple = [](const std::string& part, Vector3& out) {
+            std::istringstream stream(part);
+            std::string field;
+            float values[3];
+            for (float& value : values) {
+                if (!std::getline(stream, field, ',')) return false;
+                try {
+                    value = std::stof(field);
+                } catch (const std::exception&) {
+                    return false;
+                }
+            }
+            // Everything after the third number is a typo, not a fourth axis.
+            if (std::getline(stream, field, ',')) return false;
+            out.set(values[0], values[1], values[2]);
+            return true;
+        };
+
+        Vector3 wantPosition;
+        Vector3 wantTarget;
+        if (!triple(text.substr(0, at), wantPosition)) return false;
+        if (!triple(text.substr(at + 1), wantTarget)) return false;
+
+        position.copy(wantPosition);
+        target.copy(wantTarget);
+        return true;
+    }
+
+}// namespace threepp::editor
+
+#endif//THREEPP_EDITOR_VIEWSPEC_HPP

--- a/include/threepp/input/KeyFromName.hpp
+++ b/include/threepp/input/KeyFromName.hpp
@@ -1,0 +1,54 @@
+// A friendly key NAME ('W', 'a', 'SPACE', 'UP', 'KP8') to threepp's Key enum.
+//
+// One mapping, one place. The names are a little contract that now crosses
+// three surfaces — Canvas.is_key_down in the Python wheel, the editor's
+// threepp.editor.is_key_down (answered from ImGui state, but documented as
+// taking "the same names Canvas.is_key_down takes"), and the player's keyboard
+// provider — so the spelling a script was written against must mean the same
+// key everywhere. This header is where it means it.
+//
+// Unknown names map to Key::UNKNOWN, which no keyboard ever reports as held:
+// a script polling a misspelled name reads False rather than raising, the same
+// contract is_key_down keeps for a missing window.
+
+#ifndef THREEPP_KEYFROMNAME_HPP
+#define THREEPP_KEYFROMNAME_HPP
+
+#include "threepp/input/KeyListener.hpp"
+
+#include <cctype>
+#include <string>
+
+namespace threepp {
+
+    inline Key keyFromName(std::string n) {
+
+        for (auto& ch : n) ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+        // Letters/digits exploit the enum's contiguous A-Z and NUM_0-NUM_9 ranges.
+        if (n.size() == 1 && n[0] >= 'A' && n[0] <= 'Z')
+            return static_cast<Key>(static_cast<int>(Key::A) + (n[0] - 'A'));
+        if (n.size() == 1 && n[0] >= '0' && n[0] <= '9')
+            return static_cast<Key>(static_cast<int>(Key::NUM_0) + (n[0] - '0'));
+        // Numpad keys: "KP8" / "NUM8" / "NUMPAD8" -> Key::KP_8 (distinct from the
+        // top-row digit "8" -> Key::NUM_8).
+        for (const std::string& pre : {std::string("KP"), std::string("NUMPAD"), std::string("NUM")}) {
+            if (n.size() == pre.size() + 1 && n.compare(0, pre.size(), pre) == 0 &&
+                n.back() >= '0' && n.back() <= '9')
+                return static_cast<Key>(static_cast<int>(Key::KP_0) + (n.back() - '0'));
+        }
+        if (n == "SPACE") return Key::SPACE;
+        if (n == "UP") return Key::UP;
+        if (n == "DOWN") return Key::DOWN;
+        if (n == "LEFT") return Key::LEFT;
+        if (n == "RIGHT") return Key::RIGHT;
+        if (n == "ESCAPE" || n == "ESC") return Key::ESCAPE;
+        if (n == "ENTER") return Key::ENTER;
+        if (n == "TAB") return Key::TAB;
+        if (n == "SHIFT") return Key::LEFT_SHIFT;
+        if (n == "CTRL" || n == "CONTROL") return Key::LEFT_CONTROL;
+        return Key::UNKNOWN;
+    }
+
+}// namespace threepp
+
+#endif//THREEPP_KEYFROMNAME_HPP

--- a/python/src/bind_render.cpp
+++ b/python/src/bind_render.cpp
@@ -13,6 +13,7 @@
 #include "threepp/controls/TransformControls.hpp"
 #include "threepp/core/Object3D.hpp"
 #include "threepp/helpers/DepthSensor.hpp"
+#include "threepp/input/KeyFromName.hpp"
 #include "threepp/helpers/LidarModel.hpp"
 #include "threepp/helpers/LidarTypes.hpp"
 #include "threepp/input/KeyListener.hpp"
@@ -38,33 +39,9 @@ namespace threepp_py {
         return h.cast<GLRenderer&>();
     }
 
-    // Map a friendly key name ('W', 'a', 'SPACE', 'UP', ...) to threepp's Key enum.
-    // Letters/digits exploit the enum's contiguous A-Z and NUM_0-NUM_9 ranges.
-    static Key keyFromName(std::string n) {
-        for (auto& ch : n) ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
-        if (n.size() == 1 && n[0] >= 'A' && n[0] <= 'Z')
-            return static_cast<Key>(static_cast<int>(Key::A) + (n[0] - 'A'));
-        if (n.size() == 1 && n[0] >= '0' && n[0] <= '9')
-            return static_cast<Key>(static_cast<int>(Key::NUM_0) + (n[0] - '0'));
-        // Numpad keys: "KP8" / "NUM8" / "NUMPAD8" -> Key::KP_8 (distinct from the
-        // top-row digit "8" -> Key::NUM_8).
-        for (const std::string& pre : {std::string("KP"), std::string("NUMPAD"), std::string("NUM")}) {
-            if (n.size() == pre.size() + 1 && n.compare(0, pre.size(), pre) == 0 &&
-                n.back() >= '0' && n.back() <= '9')
-                return static_cast<Key>(static_cast<int>(Key::KP_0) + (n.back() - '0'));
-        }
-        if (n == "SPACE") return Key::SPACE;
-        if (n == "UP") return Key::UP;
-        if (n == "DOWN") return Key::DOWN;
-        if (n == "LEFT") return Key::LEFT;
-        if (n == "RIGHT") return Key::RIGHT;
-        if (n == "ESCAPE" || n == "ESC") return Key::ESCAPE;
-        if (n == "ENTER") return Key::ENTER;
-        if (n == "TAB") return Key::TAB;
-        if (n == "SHIFT") return Key::LEFT_SHIFT;
-        if (n == "CTRL" || n == "CONTROL") return Key::LEFT_CONTROL;
-        return Key::UNKNOWN;
-    }
+    // keyFromName lives in the library (threepp/input/KeyFromName.hpp) - one
+    // mapping shared with the player's keyboard provider, so the names a script
+    // was written against mean the same key on every surface.
 
     void init_render(py::module_& m) {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(publicHeaders
         "threepp/extras/editor/Selection.hpp"
         "threepp/extras/editor/SensorConfig.hpp"
         "threepp/extras/editor/SplineConfig.hpp"
+        "threepp/extras/editor/ViewSpec.hpp"
         "threepp/extras/imgui/ImguiContext.hpp"
 
         "threepp/input/KeyListener.hpp"

--- a/tests/extras/CMakeLists.txt
+++ b/tests/extras/CMakeLists.txt
@@ -99,3 +99,14 @@ if (TARGET threepp_editor_scripting)
 else ()
     message(STATUS "editor scripting not built, skipping EditorScriptPlay_test..")
 endif ()
+
+# threepp_player's core — the play runtime with no window on it. Its own library
+# for exactly this reason (apps/player/CMakeLists.txt), so the test drives the
+# code the binary runs. Linking it carries the PhysX and Python gates it was
+# built with, so this one test covers whichever halves the build actually has.
+if (TARGET threepp_player_core)
+    add_test_executable(PlayerCore_test)
+    target_link_libraries(PlayerCore_test PRIVATE threepp_player_core)
+else ()
+    message(STATUS "threepp_player not built, skipping PlayerCore_test..")
+endif ()

--- a/tests/extras/PlayerCore_test.cpp
+++ b/tests/extras/PlayerCore_test.cpp
@@ -1,0 +1,361 @@
+// threepp_player, minus the window.
+//
+// The binary's CLI is verified by running it. What is asserted here is the
+// contract underneath it, which is the part a CI job actually leans on:
+//
+//   * a document with a body, a sensor and a script plays, and the player can
+//     say what happened;
+//   * EPISODES ARE INDEPENDENT. Each one is a play/stop cycle over the same
+//     snapshot, so a body that fell in episode 0 starts episode 1 back where it
+//     was authored, and every episode ends in the same place. This is the
+//     property that makes "run it a hundred times with a hundred seeds" mean
+//     anything, and it is not the player's own code — it is PlayController's
+//     snapshot/restore, which is exactly why it needs a test that would notice
+//     if the player ever grew a shortcut around it;
+//   * THE EXIT CODE. Nonzero when a script raised, nonzero when nothing ran,
+//     zero only when every episode was clean. A gate that goes green because
+//     the scene never loaded is worse than no gate;
+//   * the script debug-draw list is DRAINED. Nothing else empties it, and
+//     ScriptPlaySession switches it on, so a front end that neither draws nor
+//     clears it runs into the cap and stays there.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "PlayerCore.hpp"
+
+#include "threepp/extras/editor/PhysicsConfig.hpp"
+#include "threepp/extras/editor/SceneDocument.hpp"
+#include "threepp/extras/editor/ScriptConfig.hpp"
+#include "threepp/extras/editor/SensorConfig.hpp"
+
+#include "threepp/geometries/BoxGeometry.hpp"
+#include "threepp/materials/MeshStandardMaterial.hpp"
+#include "threepp/objects/Mesh.hpp"
+#include "threepp/scenes/Scene.hpp"
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+#include "Scripting.hpp"
+#endif
+
+#include <cmath>
+#include <string>
+
+using namespace threepp;
+using namespace threepp::editor;
+using namespace threepp::player;
+
+namespace {
+
+    constexpr float kFrame = 1.f / 60.f;// exactly one default substep
+    constexpr float kSpawnY = 3.f;
+
+    // A script that does the three things a MonoBehaviour does and nothing else.
+    // It records into the object's own transform so a C++ test can read what a
+    // Python script decided without reaching into the interpreter.
+    constexpr const char* kCounter = R"(
+class Counter:
+    ticks = 0
+
+    def start(self, obj):
+        self.obj = obj
+        self.n = 0
+
+    def update(self, dt):
+        self.n += 1
+        self.obj.rotation.y = self.n * 0.01
+
+    def stop(self):
+        pass
+)";
+
+    // Raises on the first update. ScriptPlaySession logs it once, disables the
+    // instance and keeps playing — which is exactly the failure the player has
+    // to turn into a nonzero exit code rather than swallow.
+    constexpr const char* kBroken = R"(
+class Broken:
+    def start(self, obj):
+        self.obj = obj
+
+    def update(self, dt):
+        raise RuntimeError("this policy is not ready")
+
+    def stop(self):
+        pass
+)";
+
+    // Draws one line per update, forever. The cap is 100000 segments, so a run
+    // long enough would hit it if nobody drained the list.
+    constexpr const char* kDrawer = R"(
+import threepp
+from threepp import Vector3
+
+class Drawer:
+    def start(self, obj):
+        self.obj = obj
+
+    def update(self, dt):
+        threepp.editor.draw_line(Vector3(0, 0, 0), Vector3(0, 1, 0))
+
+    def stop(self):
+        pass
+)";
+
+    // A dynamic box with an IMU and a script — the smallest document that
+    // exercises all three runtimes at once. Returned as JSON, so the test loads
+    // it through the same parse a file would take.
+    std::string documentJson(const char* script) {
+
+        SceneDocument authoring;
+        auto& scene = authoring.scene();
+
+        auto floor = Mesh::create(BoxGeometry::create(20.f, 1.f, 20.f),
+                                  MeshStandardMaterial::create());
+        floor->name = "Floor";
+        floor->position.set(0.f, -0.5f, 0.f);
+        PhysicsConfig ground;
+        ground.enabled = true;
+        ground.body = PhysicsConfig::Body::Static;
+        ground.shape = PhysicsConfig::Shape::Box;
+        ground.write(*floor);
+        scene.add(floor);
+
+        auto box = Mesh::create(BoxGeometry::create(), MeshStandardMaterial::create());
+        box->name = "Subject";
+        box->position.set(0.f, kSpawnY, 0.f);
+
+        PhysicsConfig physics;
+        physics.enabled = true;
+        physics.body = PhysicsConfig::Body::Dynamic;
+        physics.shape = PhysicsConfig::Shape::Box;
+        physics.mass = 1.f;
+        physics.write(*box);
+
+        SensorConfig imu;
+        imu.enabled = true;
+        imu.type = SensorConfig::Type::Imu;
+        imu.rateHz = 0.f;// every substep
+        imu.write(*box);
+
+        if (script) {
+            ScriptConfig config;
+            config.source = script;
+            config.write(*box);
+        }
+        scene.add(box);
+
+        std::string error;
+        auto json = authoring.toJson(false, &error);
+        REQUIRE(error.empty());
+        return json;
+    }
+
+    float subjectY(PlayerCore& core) {
+
+        auto* subject = core.scene().getObjectByName("Subject");
+        REQUIRE(subject != nullptr);
+        return subject->position.y;
+    }
+
+}// namespace
+
+
+TEST_CASE("the player opens a document and plays it", "[player]") {
+
+    PlayerCore core;
+    std::string error;
+    REQUIRE(core.openJson(documentJson(kCounter), &error));
+    CHECK(error.empty());
+
+    // Authored, before anything has played it.
+    CHECK(subjectY(core) == kSpawnY);
+
+    const auto result = core.runEpisode(0, 120, kFrame);
+
+    CHECK(result.started);
+    CHECK(result.error.empty());
+    CHECK(result.frames == 120);
+    CHECK(result.scriptErrors == 0);
+    CHECK(result.ok());
+    CHECK(core.exitCode() == 0);
+    CHECK(core.results().size() == 1);
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+    CHECK(result.scriptInstances == 1);
+#endif
+#ifdef THREEPP_EDITOR_WITH_PHYSX
+    // The floor and the box.
+    CHECK(result.bodyCount == 2);
+#endif
+    CHECK(result.sensorCount == 1);
+}
+
+TEST_CASE("a stopped episode leaves the document exactly as it was", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(kCounter)));
+
+    REQUIRE(core.beginEpisode(0));
+    for (int i = 0; i < 90; ++i) core.step(kFrame);
+
+#ifdef THREEPP_EDITOR_WITH_PHYSX
+    // It really did fall — otherwise the restore below proves nothing.
+    const float fallen = subjectY(core);
+    INFO("fell from " << kSpawnY << " to " << fallen);
+    CHECK(fallen < kSpawnY - 0.5f);
+#endif
+
+    core.endEpisode();
+
+    // Restored from the snapshot PlayController took at play().
+    CHECK(subjectY(core) == kSpawnY);
+    CHECK_FALSE(core.playing());
+}
+
+TEST_CASE("episodes are independent", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(kCounter)));
+
+    float endOfEpisode[3];
+    for (int episode = 0; episode < 3; ++episode) {
+        // Every episode starts from the authored pose, not from where the last
+        // one left off.
+        REQUIRE(subjectY(core) == kSpawnY);
+
+        REQUIRE(core.beginEpisode(episode));
+        for (int i = 0; i < 90; ++i) core.step(kFrame);
+        endOfEpisode[episode] = subjectY(core);
+        core.endEpisode();
+    }
+
+    INFO("episode ends: " << endOfEpisode[0] << ", " << endOfEpisode[1] << ", "
+                          << endOfEpisode[2]);
+    // Same document, same step, same number of steps: the same trajectory. A
+    // tolerance rather than equality because a fresh PhysX scene per episode is
+    // not obliged to be bit-identical, but it is obliged to be the same fall.
+    CHECK(std::abs(endOfEpisode[1] - endOfEpisode[0]) < 1e-3f);
+    CHECK(std::abs(endOfEpisode[2] - endOfEpisode[0]) < 1e-3f);
+
+    CHECK(core.results().size() == 3);
+    CHECK(core.failedEpisodes() == 0);
+    CHECK(core.exitCode() == 0);
+}
+
+#ifdef THREEPP_EDITOR_WITH_PYTHON
+
+TEST_CASE("a script that raises fails the episode and the run", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(kBroken)));
+
+    const auto result = core.runEpisode(0, 30, kFrame);
+
+    // It played — the point is that the player does not confuse "ran" with
+    // "worked". The scene kept simulating, one script was disabled, and the
+    // process must still report failure.
+    CHECK(result.started);
+    CHECK(result.scriptErrors == 1);
+    CHECK_FALSE(result.ok());
+
+    CHECK(core.failedEpisodes() == 1);
+    CHECK(core.exitCode() == 1);
+}
+
+TEST_CASE("one bad episode fails a run of good ones", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(kBroken)));
+
+    for (int episode = 0; episode < 3; ++episode) {
+        core.runEpisode(episode, 10, kFrame);
+    }
+
+    CHECK(core.results().size() == 3);
+    // Errors do not leak between episodes: start() clears the map, so each
+    // episode reports its own one rather than a running total.
+    for (const auto& result : core.results()) {
+        CHECK(result.scriptErrors == 1);
+    }
+    CHECK(core.failedEpisodes() == 3);
+    CHECK(core.exitCode() == 1);
+}
+
+TEST_CASE("the debug-draw list is drained every step", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(kDrawer)));
+
+    // No drain set: this is the headless path, where the core empties the list
+    // itself. The scripts still RUN their draw calls — a draw must not behave
+    // differently because nobody is looking — the segments just go nowhere.
+    REQUIRE(core.beginEpisode(0));
+    for (int i = 0; i < 400; ++i) {
+        core.step(kFrame);
+        // Never more than the one segment this frame's update() pushed.
+        REQUIRE(scripting::debugDraw().segments.size() <= 1);
+    }
+    const auto result = core.endEpisode();
+
+    CHECK(result.scriptErrors == 0);
+    CHECK(scripting::debugDraw().dropped == 0);
+    // The session is down, and nothing is left behind for the next episode.
+    CHECK(scripting::debugDraw().segments.empty());
+}
+
+TEST_CASE("a front end that draws the lines is the one that drains them", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(kDrawer)));
+
+    // What the windowed player does: the overlay consumes the segments by
+    // building geometry from them, so drawing and draining are the same act.
+    // Stood in for here, because a real overlay needs a GL context.
+    int drains = 0;
+    std::size_t sawSegments = 0;
+    core.setDebugDrawDrain([&] {
+        ++drains;
+        sawSegments += scripting::debugDraw().segments.size();
+        scripting::debugDraw().clear();
+    });
+
+    REQUIRE(core.beginEpisode(0));
+    for (int i = 0; i < 50; ++i) core.step(kFrame);
+    core.endEpisode();
+
+    CHECK(drains == 50);
+    // The drain SAW what the script drew, rather than being handed an already
+    // emptied list.
+    CHECK(sawSegments == 50);
+}
+
+#endif// THREEPP_EDITOR_WITH_PYTHON
+
+TEST_CASE("a document that will not load is a failed run", "[player]") {
+
+    PlayerCore core;
+    std::string error;
+    CHECK_FALSE(core.openJson("{ this is not a scene }", &error));
+    CHECK_FALSE(error.empty());
+
+    // Nothing ran. That is a failure to do the job, not a vacuous success — a
+    // gate that passes because the scene never loaded is the exact bug this
+    // program exists to not have.
+    CHECK(core.results().empty());
+    CHECK(core.exitCode() == 1);
+}
+
+TEST_CASE("an episode cannot be started twice", "[player]") {
+
+    PlayerCore core;
+    REQUIRE(core.openJson(documentJson(nullptr)));
+
+    REQUIRE(core.beginEpisode(0));
+    std::string error;
+    CHECK_FALSE(core.beginEpisode(1, &error));
+    CHECK(error == "an episode is already playing");
+    // The refusal is not recorded as an episode: nothing was played.
+    CHECK(core.results().empty());
+
+    core.endEpisode();
+    CHECK(core.results().size() == 1);
+}


### PR DESCRIPTION
A second front end over the editor's play runtime: `threepp_player scene.json`
loads a document the editor authored and plays it — physics, articulations,
seeded sensors, Python scripts — with none of the editing machinery. No ImGui,
no panels, no undo; just the extras/editor play core + the scripting library.

It exists to be a **gate**: run a policy-driven scene for N episodes, record the
sensor CSVs, read the exit code (0 clean, 1 on load failure or any script error,
2 usage). Episodes are full play→stop cycles over the snapshot/restore, so they
are independent by construction — three headless episodes produce byte-identical
IMU traces, seeded noise included.

**CLI:** `--episodes/--frames/--seconds/--headless/--vulkan/--dt/--record/--size`.
Headless uses a hidden window, so vision sensors (lidar/depth) still scan.

**Windowed extras:** orbit + authored `editorView`/`editorFollow`, keyboard input
reaching `threepp.editor.is_key_down` (a drivable scene is drivable here too),
script debug draw, and the sensor point cloud — verified on both GL and Vulkan.

**Library touches:** `parseViewSpec` extracted to `extras/editor/ViewSpec.hpp`
and the key-name mapping to `input/KeyFromName.hpp` (one format/one mapping,
now shared by editor, wheel and player — bindings forward, no behavior change).

Docs in `doc/player.md`